### PR TITLE
Fix plugin organization in _Getting Started_ documentation.

### DIFF
--- a/src/sphinx/gettingstarted.rst
+++ b/src/sphinx/gettingstarted.rst
@@ -7,7 +7,7 @@ The sbt-native-packager is a plugin.   To use it, first create a ``project/plugi
 
   resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))(Resolver.ivyStylePatterns)
   
-  addSbtPlugin("com.jsuereth" % "sbt-native-packager" % "0.1.0")
+  addSbtPlugin("com.typesafe" % "sbt-native-packager" % "0.1.0")
 
 
 Also, each operating system requires its own tools for download.


### PR DESCRIPTION
Was "com.jsureth", should be  "com.typesafe".

See: http://scalasbt.artifactoryonline.com/scalasbt/webapp/browserepo.html?pathId=sbt-plugin-releases:com.typesafe/sbt-native-packager
