### PR TITLE
Fix rpmbuild syntax in RpmHelper

### DIFF
--- a/src/main/scala/com/typesafe/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/packager/rpm/RpmHelper.scala
@@ -24,9 +24,11 @@ object RpmHelper {
     // TODO - special treatment of icon...
     val buildroot = workArea / "tmp-buildroot"
     
-    def copyWithZip(from: File, to: File, zipped: Boolean): Unit =
+    def copyWithZip(from: File, to: File, zipped: Boolean): Unit = {
+      log.debug("Copying %s to %s".format(from, to))
       if(zipped) IO.gzip(from, to)
       else IO.copyFile(from, to, true)
+    }
     // We don't have to do any permission modifications since that's in the
     // the .spec file.
     for { 
@@ -58,13 +60,14 @@ object RpmHelper {
     val args: Seq[String] = Seq(
         "rpmbuild",
         "-bb",
-        "--buildroot=" + buildRoot.getAbsolutePath,
+        "--buildroot", buildRoot.getAbsolutePath,
         "--define", "_topdir " + workArea.getAbsolutePath,
         "--target", spec.meta.arch + '-' + spec.meta.vendor + '-' + spec.meta.os
      ) ++ ( 
        if(gpg) Seq("--define", "_gpg_name " + "<insert keyname>", "--sign") 
        else Seq.empty 
      ) ++ Seq(spec.meta.name + ".spec")
+     log.debug("Executing rpmbuild with: " + args.mkString(" "))
      (Process(args, Some(specsDir)) ! log) match {
         case 0 => ()
         case 1 => sys.error("Unable to run rpmbuild, check output for details.")


### PR DESCRIPTION
Got another one for you, Josh...

I tried using the `rpm:package-bin` task and got this error:

```
[error] rpmbuild: --buildroot=/Users/mtye/webapplications/hellolift/target/rpm/buildroot: unknown option
```

According to the man doc for the version of rpmbuild I'm using (5.0.0, Mac OS X Snow Leopard), the syntax for the `buildroot` option is `--buildroot DIRECTORY`, not `--buildroot=DIRECTORY`.

I've been told (by colleagues more knowledgeable than I) that there are unfortunate behavioral inconsistencies between various versions of RPM - notably 4.9 vs. 5.0. However, they all seem to share the same option syntax.

So, my question is: Does the existing `RpmHelper.buildPackage` code work for you, and if so, on what platform/RPM version?

If it _does_ work for you, then it may be necessary to add an `rpmVersion` setting to the plugin and adjust the `rpmbuild` args to accomodate the syntax differences between versions. Alternately, you could just mandate in the documentation that the plugin only works with specific version(s) of RPM.

If the existing code doesn't work for you, either, pull my patch and see if that fixes it. I also added some debug logging to help diagnose errors with the RPM packaging.
