### PR TITLE
RPM doesn't accept filenames with whitespace

### DIFF
--- a/src/main/scala/com/typesafe/packager/rpm/RpmMetadata.scala
+++ b/src/main/scala/com/typesafe/packager/rpm/RpmMetadata.scala
@@ -69,7 +69,10 @@ case class RpmSpec(meta: RpmMetadata,
     sb append ','
     sb append meta.group
     sb append ") "
-    sb append target
+    sb append (target.contains(' ') match {
+      case true => "\"%s\"" format target
+      case false => target
+    })
     sb append '\n'
     sb.toString
   }


### PR DESCRIPTION
```
[error] error: Two files on one line: /opt/app/images/Sorting
[error] error: File must begin with "/": icons.psd
```

 See [problem explanation](http://www.mail-archive.com/rpm-users@rpm5.org/msg00309.html).
