### PR TITLE
Adding support for rpm scriptlets

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
@@ -34,6 +34,17 @@ trait RpmKeys {
   // SPEC
   val rpmSpecConfig = TaskKey[RpmSpec]("rpm-spec-config", "All the configuration for an RPM .spec file.")
   
+ // SCRIPTS
+  val rpmScripts = SettingKey[RpmScripts]("rpm-scripts", "Configuration of pre- and post-integration scripts.")
+
+  val rpmPretrans = SettingKey[Option[String]]("rpm-pretrans", "%pretrans scriptlet")
+  val rpmPre = SettingKey[Option[String]]("rpm-pre", "%pre scriptlet")
+  val rpmVerifyscript = SettingKey[Option[String]]("rpm-verifyscipt", "%verifyscript scriptlet")
+  val rpmPost = SettingKey[Option[String]]("rpm-post", "%post scriptlet")
+  val rpmPosttrans = SettingKey[Option[String]]("rpm-posttrans", "%posttrans scriptlet")
+  val rpmPreun = SettingKey[Option[String]]("rpm-preun", "%preun scriptlet")
+  val rpmPostun = SettingKey[Option[String]]("rpm-postun", "%postun scriptlet")
+
   // Building
   val rpmLint = TaskKey[Unit]("rpm-lint", "Runs rpmlint program against the genreated RPM, if available.")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -25,6 +25,13 @@ trait RpmPlugin extends Plugin with LinuxPlugin {
     rpmPrerequisites := Seq.empty,
     rpmObsoletes := Seq.empty,
     rpmConflicts := Seq.empty,
+    rpmPretrans := None,
+    rpmPre := None,
+    rpmPost := None,
+    rpmVerifyscript := None,
+    rpmPosttrans := None,
+    rpmPreun := None,
+    rpmPostun := None,
     packageSummary in Rpm <<= packageSummary in Linux,
     packageDescription in Rpm <<= packageDescription in Linux,
     target in Rpm <<= target(_ / "rpm")
@@ -36,8 +43,10 @@ trait RpmPlugin extends Plugin with LinuxPlugin {
       (rpmLicense, rpmDistribution, rpmUrl, rpmGroup, rpmPackager, rpmIcon) apply RpmDescription,
     rpmDependencies <<=
       (rpmProvides, rpmRequirements, rpmPrerequisites, rpmObsoletes, rpmConflicts) apply RpmDependencies,
+    rpmScripts <<=
+      (rpmPretrans,rpmPre,rpmPost,rpmVerifyscript,rpmPosttrans,rpmPreun,rpmPostun) apply RpmScripts,
     rpmSpecConfig <<=
-      (rpmMetadata, rpmDescription, rpmDependencies, linuxPackageMappings) map RpmSpec,
+      (rpmMetadata, rpmDescription, rpmDependencies, rpmScripts, linuxPackageMappings) map RpmSpec,
     packageBin <<= (rpmSpecConfig, target, streams) map { (spec, dir, s) =>
         RpmHelper.buildRpm(spec, dir, s.log)
     },


### PR DESCRIPTION
Now the %pretrans, %pre, %post, %verifyscript %posttrans, %preun and %postun scriptlets are supported.

This currently does not escape percent signs in the contents of the scriptlets
