### PR TITLE
Add support for package maintainer scripts.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -16,6 +16,7 @@ trait DebianKeys {
   val debianPackageMetadata = SettingKey[PackageMetaData]("debian-package-metadata", "Meta data used when constructing a debian package.")
   // Package building
   val debianControlFile = TaskKey[File]("debian-control-file", "Makes the debian package control file.")
+  val debianMaintainerScripts = TaskKey[Seq[(File, String)]]("debian-maintainer-scripts", "Makes the debian maintainer scripts.")
   val debianConffilesFile = TaskKey[File]("debian-conffiles-file", "Makes the debian package conffiles file.")
   val debianMD5sumsFile = TaskKey[File]("debian-md5sums-file", "Makes the debian package md5sums file.")
   val debianZippedMappings = TaskKey[Seq[LinuxPackageMapping]]("debian-zipped-mappings", "Files that need to be gzipped when they hit debian.")


### PR DESCRIPTION
Debian allows packages to have {pre|post} install and {pre|post} removal
scripts. They are used to manage and configure the system in ways that files
alone cannot (e.g. add user) This change allows users of the sbt native
packager to include these files (optionally) in their generated debs.
