### PR TITLE
Added bare-minimum support for creating apple's DMG files.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
@@ -7,6 +7,7 @@ import sbt._
 trait UniversalKeys {
   val packageZipTarball = TaskKey[File]("package-zip-tarball", "Creates a tgz package.")
   val packageXzTarball = TaskKey[File]("package-xz-tarball", "Creates a txz package.")
+  val packageOsxDmg = TaskKey[File]("package-osx-dmg", "Creates a dmg package for OSX (only on osx).")
 }
 
 object Keys extends UniversalKeys {

--- a/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
@@ -21,6 +21,7 @@ trait UniversalPlugin extends Plugin {
   /** Creates all package types for a given configuration */
   private[this] def makePackageSettingsForConfig(config: Configuration): Seq[Setting[_]] =
     makePackageSettings(packageBin, config)(makeZip) ++
+    makePackageSettings(packageOsxDmg, config)(makeDmg) ++
     makePackageSettings(packageZipTarball, config)(makeTgz) ++
     makePackageSettings(packageXzTarball, config)(makeTxz) ++
     inConfig(config)(Seq(


### PR DESCRIPTION
- Added method to take a mappings and generate a DMG file.
- added package-osx-dmg method to universal (only works on mac).

Note on dmg:  It's just a generic way to create disks and mount applications.
I'm not positive it makes sense to do so outside of app bundles, but we'll at least
provide the hook, so OSX users can figure out what they want.

Hoping a MacOSX user may review this.
