### PR TITLE
Fix addApp function to append to app_commands

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -128,7 +128,7 @@ addJava () {
 }
 addApp () {
   dlog "[addApp] arg = '$1'"
-  sbt_commands=( "${app_commands[@]}" "$1" )
+  app_commands=( "${app_commands[@]}" "$1" )
 }
 addResidual () {
   dlog "[residual] arg = '$1'"


### PR DESCRIPTION
I'm guessing this is what it was supposed to be, sbt_commands is not referenced anywhere else in the file.
