### PR TITLE
More relative path checks for the bash script's realpath processing

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -21,6 +21,13 @@ realpath () {
       COUNT=$(($COUNT + 1))
   done
 
+  if [ "$TARGET_FILE" == "." -o "$TARGET_FILE" == ".." ]; then
+    cd "$TARGET_FILE"
+    TARGET_FILEPATH=
+  else
+    TARGET_FILEPATH=/$TARGET_FILE
+  fi
+
   # make sure we grab the actual windows path, instead of cygwin's path.
   if [[ "x$CHECK_CYGWIN" == "x" ]]; then
     echo "$(pwd -P)/$TARGET_FILE"


### PR DESCRIPTION
Specifically checks for base names of "." and ".." after symlink processing. This enables relative paths to be passed in that are terminated with such strings e.g. "/users/huntc/.." will correctly evaluate to "/users".

This issue relates to https://github.com/playframework/playframework/pull/1577
