### PR TITLE
Append newline after template_declares substitution

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppBashScript.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppBashScript.scala
@@ -40,6 +40,7 @@ object JavaAppBashScript {
      for(line <- sbt.IO.readLinesURL(bashTemplateSource, charset)) {
        if(line contains """${{template_declares}}""") {
          sb append (defines mkString "\n")
+         sb append "\n"
        } else {
          sb append line
          sb append "\n"


### PR DESCRIPTION
If I define an extra declares setting in the build file, but don't end it with a newline character, it ends up being on the same line as the next statement, and that makes me sad.
