### PR TITLE
Fixed two bugs

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/GenericPackageSettings.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/GenericPackageSettings.scala
@@ -113,7 +113,7 @@ trait GenericPackageSettings
       } yield ComponentFile(name, editable = (name startsWith "conf"))
     val corePackage =
       WindowsFeature(
-        id=WixHelper.cleanStringForId(name+"_core"),
+        id=WixHelper.cleanStringForId(name + "_core").takeRight(38),  // Must be no longer
         title=name,
         desc="All core files.",
         absent="disallow",


### PR DESCRIPTION
Hey,

I was searching and reverse-engineering quite a while to find these two bugs is stumbled across when trying to bundle ja Java Runtime Environment with an app.

The directory tree in the .wix file was broken when having intermediate folders with just subfolders and no files. groupBy just didn't generate the missing link, so some folders got "orphaned". I think there might be a more elegant solution than my brute-force attack... but hey.

File ID collisions in .wix file, e.g. when two files are present: flup+1.a and flub-1.a. I appended a file name hash to the end of every ID, making it (a lot mor) unique.

Cheers!
Peter
