### PR TITLE
fix two typos in code examples in the doc.

### DIFF
--- a/src/sphinx/archetypes.rst
+++ b/src/sphinx/archetypes.rst
@@ -25,7 +25,7 @@ custom start scripts, or services.  It is just a bash/bat script that starts up 
 this archetype in your build, do the following in your ``build.sbt``:
 
 
-    archetypes.java_application
+    packageArchetype.java_application
 
     name := "A-package-friendly-name"
     

--- a/src/sphinx/universal.rst
+++ b/src/sphinx/universal.rst
@@ -136,7 +136,7 @@ use the task-scope feature of sbt:
 
 .. code-block:: scala
 
-    mappings in Universal in package-zip-tarball += file("README") -> "README
+    mappings in Universal in package-zip-tarball += file("README") -> "README"
     
 Besides ``mappings``, the ``name``, ``sourceDirectory`` and ``target`` configurations are all respected by universal packaging.
 


### PR DESCRIPTION
I just stumbled upon two typos in the generated documentation.
