### PR TITLE
Fixes #39 - Unable to follow symlinks.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -284,7 +284,8 @@ EOM
 declare -a residual_args
 declare -a java_args
 declare -a app_commands
-declare -r app_home="$(realpath "$(dirname "$0")")"
+declare -r real_script_path="$(realpath "$0")"
+declare -r app_home="$(realpath "$(dirname "$real_script_path")")"
 # TODO - Check whether this is ok in cygwin...
 declare -r lib_dir="$(realpath "${app_home}/../lib")"
 ${{template_declares}}


### PR DESCRIPTION
Turns out that we were naively going up a directoryon a bash script.

However, we should first find out where the bash script _really_ is located,
then go up a directory and take the real directory of that to find the installation.

This is friendlier to our debian/rpm start scripts.  Thanks to @muuki88 for diagnosing
and proposing an alternative solution.
