### PR TITLE
Added Template Directories for Debian package #54

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -3,7 +3,7 @@ package packager
 package debian
 
 import sbt._
-import linux.LinuxPackageMapping
+import linux.{ LinuxPackageMapping, LinuxPackageTemplateMapping }
 
 /** DEB packaging specifc build targets. */
 trait DebianKeys {
@@ -35,6 +35,9 @@ trait DebianKeys {
   val debianMakePrermScript = TaskKey[Option[File]]("makePrermScript", "Creates or discovers the prerm script used by this project")
   val debianMakePostinstScript = TaskKey[Option[File]]("makePostInstScript", "Creates or discovers the postinst script used by this project")
   val debianMakePostrmScript = TaskKey[Option[File]]("makePostrmScript", "Creates or discovers the postrm script used by this project")
+
+  // Debian template directories
+  val debianMakeTemplateDirectories = TaskKey[Seq[LinuxPackageTemplateMapping]]("debianMakeTemplateDirectories", "Creates empty directories put into the .deb file")
 
   // Debian upstart scripts
   val debianControlScriptsReplacements = SettingKey[DebianControlScriptReplacements]("debianControlScriptsReplacements",

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPackageMapping.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPackageMapping.scala
@@ -10,11 +10,11 @@ case class LinuxFileMetaData(
   permissions: String = "755",
   config: String = "false",
   docs: Boolean = false) {
-  
+
   def withUser(u: String) = copy(user = u)
   def withGroup(g: String) = copy(group = g)
   def withPerms(p: String) = copy(permissions = p)
-  def withConfig(value:String = "true") = copy(config = value)
+  def withConfig(value: String = "true") = copy(config = value)
   def asDocs() = copy(docs = true)
 }
 
@@ -22,29 +22,44 @@ case class LinuxPackageMapping(
   mappings: Traversable[(File, String)],
   fileData: LinuxFileMetaData = LinuxFileMetaData(),
   zipped: Boolean = false) {
-  
+
   def withUser(user: String) = copy(fileData = fileData withUser user)
   def withGroup(group: String) = copy(fileData = fileData withGroup group)
   def withPerms(perms: String) = copy(fileData = fileData withPerms perms)
   def withConfig(c: String = "true") = copy(fileData = fileData withConfig c)
   def asDocs() = copy(fileData = fileData asDocs ())
-  
-  /** Modifies the current package mapping to have gzipped data. */ 
+
+  /** Modifies the current package mapping to have gzipped data. */
   def gzipped = copy(zipped = true)
+}
+
+/**
+ * Creates empty directories (template directories)
+ * with the specified LinuxFileMetaData
+ */
+case class LinuxPackageTemplateMapping(
+  mappings: Traversable[String],
+  fileData: LinuxFileMetaData = LinuxFileMetaData()) {
+
+  def withUser(user: String) = copy(fileData = fileData withUser user)
+  def withGroup(group: String) = copy(fileData = fileData withGroup group)
+  def withPerms(perms: String) = copy(fileData = fileData withPerms perms)
+  def withConfig(c: String = "true") = copy(fileData = fileData withConfig c)
+  def asDocs() = copy(fileData = fileData asDocs ())
 }
 
 // TODO - Maybe this can support globbing symlinks?
 // Maybe it should share an ancestor with LinuxPackageMapping so we can configure symlinks the same time as normal files?
 case class LinuxSymlink(link: String, destination: String)
 object LinuxSymlink {
-  
+
   def makeRelative(from: String, to: String): String = {
     val partsFrom: Seq[String] = from split "/" filterNot (_.isEmpty)
     val partsTo: Seq[String] = to split "/" filterNot (_.isEmpty)
-          
+
     val prefixAndOne = (1 to partsFrom.length).map(partsFrom.take).dropWhile(seq => partsTo.startsWith(seq)).headOption getOrElse sys.error("Cannot symlink to yourself!")
-    val prefix = prefixAndOne dropRight 1      
-    if(prefix.length > 0) {
+    val prefix = prefixAndOne dropRight 1
+    if (prefix.length > 0) {
       val escapeCount = (partsTo.length - 1) - prefix.length
       val escapes = (0 until escapeCount) map (i => "..")
       val remainder = partsFrom drop prefix.length
@@ -53,28 +68,28 @@ object LinuxSymlink {
   }
   // TODO - Does this belong here?
   def makeSymLinks(symlinks: Seq[LinuxSymlink], pkgDir: File, relativeLinks: Boolean = true): Unit = {
-      for(link <- symlinks) {
-        // TODO - drop preceeding '/'
-        def dropFirstSlash(n: String): String =
-          if(n startsWith "/") n drop 1
-          else n
-        def addFirstSlash(n: String): String =
-          if(n startsWith "/") n
-          else "/" + n
-        val to = pkgDir / dropFirstSlash(link.link)
-        val linkDir = to.getParentFile
-        if(!linkDir.isDirectory) IO.createDirectory(linkDir)
-        val name = IO.relativize(linkDir, to).getOrElse {
-          sys.error("Could not relativize names ("+to+") ("+linkDir+")!!! *(logic error)*")
-        }
-        val linkFinal = 
-          if(relativeLinks) makeRelative(link.destination, link.link)
-          else addFirstSlash(link.destination)
-        // TODO - if it already exists, delete it, or check accuracy...
-        if(!to.exists) Process(Seq("ln", "-s", linkFinal, name), linkDir).! match {
-          case 0 => ()
-          case n => sys.error("Failed to symlink " + link.destination + " to " + to)
-        }
+    for (link <- symlinks) {
+      // TODO - drop preceeding '/'
+      def dropFirstSlash(n: String): String =
+        if (n startsWith "/") n drop 1
+        else n
+      def addFirstSlash(n: String): String =
+        if (n startsWith "/") n
+        else "/" + n
+      val to = pkgDir / dropFirstSlash(link.link)
+      val linkDir = to.getParentFile
+      if (!linkDir.isDirectory) IO.createDirectory(linkDir)
+      val name = IO.relativize(linkDir, to).getOrElse {
+        sys.error("Could not relativize names (" + to + ") (" + linkDir + ")!!! *(logic error)*")
       }
+      val linkFinal =
+        if (relativeLinks) makeRelative(link.destination, link.link)
+        else addFirstSlash(link.destination)
+      // TODO - if it already exists, delete it, or check accuracy...
+      if (!to.exists) Process(Seq("ln", "-s", linkFinal, name), linkDir).! match {
+        case 0 => ()
+        case n => sys.error("Failed to symlink " + link.destination + " to " + to)
+      }
+    }
   }
 }

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
@@ -5,34 +5,36 @@ package linux
 import Keys._
 import sbt._
 
-/** Plugin trait containing all the generic values used for
+/**
+ * Plugin trait containing all the generic values used for
  * packaging linux software.
  */
 trait LinuxPlugin extends Plugin {
   // TODO - is this needed
   val Linux = config("linux")
-  
+
   def linuxSettings: Seq[Setting[_]] = Seq(
     linuxPackageMappings := Seq.empty,
     linuxPackageSymlinks := Seq.empty,
     sourceDirectory in Linux <<= sourceDirectory apply (_ / "linux"),
     generateManPages <<= (sourceDirectory in Linux, sbt.Keys.streams) map { (dir, s) =>
-      for( file <- (dir / "usr/share/man/man1" ** "*.1").get ) {
+      for (file <- (dir / "usr/share/man/man1" ** "*.1").get) {
         val man = makeMan(file)
         s.log.info("Generated man page for[" + file + "] =")
         s.log.info(man)
-      }  
+      }
     },
     packageSummary in Linux <<= packageSummary,
-    packageDescription in Linux <<= packageDescription
-  )
-  
+    packageDescription in Linux <<= packageDescription)
+
   /** DSL for packaging files into .deb */
   def packageMapping(files: (File, String)*) = LinuxPackageMapping(files)
-  
+
+  def packageTemplateMapping(files: String*) = LinuxPackageTemplateMapping(files)
+
   // TODO - we'd like a set of conventions to take universal mappings and create linux package mappings.
 
-  /** Create a ascii friendly string for a man page. */  
-  final def makeMan(file: File): String = 
+  /** Create a ascii friendly string for a man page. */
+  final def makeMan(file: File): String =
     Process("groff -man -Tascii " + file.getAbsolutePath).!!
 }

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -27,6 +27,15 @@ debianPackageRecommends in Debian += "git"
 
 //debianMakePrermScript := Some(sourceDirectory.value / "deb" / "control" / "prerm") //change defaults
 
+// adding template directories
+//debianMakeTemplateDirectories in Debian += packageTemplateMapping(
+//    "/var/log/" + name.value,
+//    "/etc/" + name.value
+//)
+
+//debianMakeTemplateDirectories in Debian += (packageTemplateMapping(
+//    "/var/log/private"
+//) withPerms "0644" )
 
 TaskKey[Unit]("check-script") <<= (NativePackagerKeys.stagingDirectory in Universal, target in Debian, name, version, maintainer in Debian, streams) map {
  (dir, debTarget, name, version, author, streams) =>


### PR DESCRIPTION
Template directories can now be created via

``` scala
debianMakeTemplateDirectories in Debian += packageTemplateMapping(
    "/var/log/" + name.value,
    "/etc/" + name.value
)
```

Sorry for some changes, the IDE formatting kicked in :/
