### PR TITLE
Fix wrong String.replaceAll in JavaAppBatScript.makeWindowsRelativeClasspathDefine

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppBatScript.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppBatScript.scala
@@ -10,7 +10,7 @@ object JavaAppBatScript {
     name.toUpperCase.replaceAll("\\W", "_")   
   
   def makeWindowsRelativeClasspathDefine(cp: Seq[String]): String = {
-    def cleanPath(path: String): String = path.replaceAll("/", "\\")
+    def cleanPath(path: String): String = path.replaceAll("/", "\\\\")
     def makeRelativePath(path: String): String =
       "%APP_LIB_DIR%\\" + cleanPath(path)
     "set \"APP_CLASSPATH=" + (cp map makeRelativePath mkString ";") + "\""


### PR DESCRIPTION
When adding a setting such as `scriptClasspath += "../conf"`, the execution of `universal:packageBin` whould fail in `path.replaceAll` with a `StringIndexOutOfBoundsException`, because for some reason `\` needs to be escaped twice.
