### PR TITLE
Default values for packageArchetype.java_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ Here's what to add to your `build.sbt`:
 
     packageArchetype.java_server
 
+For debian packaging there are a few things generated for you
+
+* A template folder `/var/log/<app-name>`
+* A symlink `/installdir/<app-name>/logs` to `/var/log/<app-name` (Installdir is by default `/usr/share`)
+* Default `serverLoading` is `Upstart` (you can choose SystemV with `com.typesafe.sbt.packager.archetypes.ServerLoader.SystemV` )
+* Default `daemonUser` is _root_ (only relevant for SystemV)
+* If you choose different permissions than the default ones for your packages, _add-user_ and _remove-user_ statements will be added to
+the `postrm` and `postinst` control files
 
 ### By-hand packaging ###
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
@@ -25,11 +25,12 @@ object JavaServerAppPackaging {
 
   def debianSettings: Seq[Setting[_]] =
     Seq(
+      serverLoading := Upstart,
+      daemonUser := "root",
       debianStartScriptReplacements <<= (
         maintainer in Debian, packageSummary in Debian, serverLoading in Debian, daemonUser in Debian, normalizedName,
         sbt.Keys.version, defaultLinuxInstallLocation, mainClass in Compile, scriptClasspath)
         map { (author, descr, loader, daemonUser, name, version, installLocation, mainClass, cp) =>
-          // TODO name-version is copied from UniversalPlugin. This should be consolidated into a setting (install location...)
           val appDir = installLocation + "/" + name
           val appClasspath = cp.map(appDir + "/lib/" + _).mkString(":")
 


### PR DESCRIPTION
Setting `Upstart` as `serverLoading` and `root` for `daemonUser` as default values for `packageArchetype.java_server`.

This can be changed with this

``` scala
serverLoading in Debian := com.typesafe.sbt.packager.archetypes.ServerLoader.Upstart

daemonUser in Debian := "root"
```
