### PR TITLE
Permissions for /var/log/$app_name fixed

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/GenericPackageSettings.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/GenericPackageSettings.scala
@@ -63,6 +63,7 @@ trait GenericPackageSettings
 
     // Default place to install code.
     defaultLinuxInstallLocation := "/usr/share",
+    defaultLinuxLogsLocation := "/var/log",
 
     // First we look at the src/linux files
     linuxPackageMappings <++= (sourceDirectory in Linux) map { dir =>

--- a/src/main/scala/com/typesafe/sbt/packager/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Keys.scala
@@ -29,4 +29,5 @@ object Keys extends linux.Keys
          |  APP_DEFINES - the defines to go into the app
          |  """.stripMargin)
   val defaultLinuxInstallLocation = SettingKey[String]("defaultLinuxInstallLocation", "The location where we will install generic linux packages.")
+  val defaultLinuxLogsLocation = SettingKey[String]("defaultLinuxLogsLocation", "The location where all application logs will be stored.")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -163,8 +163,8 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin {
 
               // remove key, flatten it and then go through each file
               pathList.map(_._2).flatten foreach {
-                case (_, target) =>
-                  val pathReplacements = replacements :+ ("path" -> target.toString)
+                case (file, name) =>
+                  val pathReplacements = replacements :+ ("path" -> (file / name).getAbsolutePath)
                   IO.append(postinst, TemplateWriter.generateScript(DebianPlugin.postinstChownTemplateSource, pathReplacements))
               }
 


### PR DESCRIPTION
There was symlink $app_home/logs -> /var/log/$app_name, but this directory was owned by root. If we start it as a daemon, daemonUser unable to write logs.
