### PR TITLE
debian:package-bin throws a FileNotFoundException for missing postrm

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -51,7 +51,7 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin {
 
 
   private[this] def appendAndFixPerms(script: File, lines: Seq[String], perms: LinuxFileMetaData): File = {
-    IO.writeLines(script, lines)
+    IO.writeLines(script, lines, append = true)
     chmod(script, perms.permissions)
     script
   }


### PR DESCRIPTION
If no `src/debian/DEBIAN/postrm` file exists and `daemonUser` is not the root user then a FileNotFoundException is thrown for `sbt debian:package-bin`. The error is caused by the script for removing the `daemonUser` user account from the installation being prepended to the `postrm` file that does not exist
