### PR TITLE
Better upstart script

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/upstart-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/upstart-template
@@ -11,6 +11,9 @@ author "${{author}}"
 # When to start the service
 start on runlevel [2345]
 
+# When to stop the service
+stop on runlevel [016]
+
 # Automatically restart process if crashed. Tries ${{retries}} times every ${{retryTimeout}} seconds
 respawn
 respawn limit ${{retries}} ${{retryTimeout}}


### PR DESCRIPTION
Add a stop stanzas (http://upstart.ubuntu.com/cookbook/#job-with-start-on-but-no-stop-on) and use start-stop-daemon as recommended in the upstart cookbook (http://upstart.ubuntu.com/cookbook/#changing-user)

Some server applications (like those builded with play framework) will not launch after a reboot/shutdown without a proper stop because they create a pid file and don't boot if this file exists. For those applications, a stop before system's shutdown is mandatory.

Also, for those applications, we can improve the script by adding a "pre start" Stanzas that will delete the pid file if it exist and if there haven't a running process with the corresponding id. That's why I think the feature #118 will be useful. Playframework will provide his upstart script.
