### PR TITLE
Debian Control File - Invalid package name

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -98,7 +98,7 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin {
     debianMaintainerScripts <++= (debianMakePostrmScript, debianControlScriptsDirectory) map scriptMapping(Names.Postrm)) ++ inConfig(Debian)(Seq(
       packageArchitecture := "all",
       debianPackageInfo <<=
-        (name, version, maintainer, packageSummary, packageDescription) apply PackageInfo,
+        (normalizedName, version, maintainer, packageSummary, packageDescription) apply PackageInfo,
       debianPackageMetadata <<=
         (debianPackageInfo,
           debianPriority, packageArchitecture, debianSection,


### PR DESCRIPTION
An invalid control file is generated, when the `name` contains special characters.
