### PR TITLE
Making SystemV start script LSB and Debian compliant

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-template
@@ -2,10 +2,10 @@
 
 ### BEGIN INIT INFO
 # Provides:	${{app_name}}
-# Required-Start: $syslog
-# Required-Stop: $syslog
+# Required-Start: $remote_fs $syslog
+# Required-Stop: $remote_fs $syslog
 # Default-Start: 2 3 4 5
-# Default-Stop:
+# Default-Stop: 0 1 6
 # Short-Description: ${{descr}}
 ### END INIT INFO
 
@@ -57,7 +57,7 @@ case "$1" in
     stop_daemon
     exit $?
 	  ;;
-  restart)
+  restart|force-reload)
     stop_daemon
     start_daemon
     exit $?


### PR DESCRIPTION
- Stops the dervice when the system is shutting down
- Makes sure all file systems including remotes are mounted before starting. `/usr` could be on a remote files system.
- Lintian complains if the user can't "force-reload" the service
