### PR TITLE
FIX #112 Adding BuildArch to the spec file

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmMetadata.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmMetadata.scala
@@ -189,7 +189,8 @@ case class RpmSpec(meta: RpmMetadata,
     sb append ("autoprov: %s\n" format meta.autoprov)
     sb append ("autoreq: %s\n" format meta.autoreq)
     
-    sb append ("BuildRoot: %s\n\n" format rpmRoot.getAbsolutePath)
+    sb append ("BuildRoot: %s\n" format rpmRoot.getAbsolutePath)
+    sb append ("BuildArch: %s\n\n" format meta.arch)
     
     sb append "%description\n"
     sb append meta.description


### PR DESCRIPTION
Adding the `BuildArch` to the spec file. Tests run fine. 
