### PR TITLE
Make start script more portable by using /usr/bin/env as shebang.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ###  ------------------------------- ###
 ###  Helper methods for BASH scripts ###


### PR DESCRIPTION
This is needed for a few *NIX OSes, like FreeBSD, where bash is installed by package system into /usr/local/bin.
