### PR TITLE
Fix Windows msi installer PATH entry

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/windows/WixHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/windows/WixHelper.scala
@@ -93,7 +93,7 @@ object WixHelper {
         val homeEnvVar = archetypes.JavaAppBatScript.makeEnvFriendlyName(name) +"_HOME"
         val pathAddition = 
           if(dir.isEmpty) "%"+homeEnvVar+"%"
-          else "[INSTALLDIR]\\"+dir.replaceAll("\\/", "\\\\")
+          else "[INSTALLDIR]"+dir.replaceAll("\\/", "\\\\")
         val id = cleanStringForId(dir).takeRight(65) + "PathC"
         val guid = makeGUID
         val xml =


### PR DESCRIPTION
During sbt installation on Windows7 x64 with the msi, SBT_HOME (from [INSTALLDIR]), was set to `C:\Program Files (x86)\sbt\`, PATH was then updated with `C:\Program Files (x86)\sbt\\bin` so sbt could not be run from the command line due to the double back slash.

I could not run `windows:package-msi` to test my change, but using [SuperOrca](http://www.pantaray.com/msi_super_orca.html) to change the msi PATH from `[~];[INSTALLDIR]\bin` to `[~];[INSTALLDIR]bin` and reinstalling sbt with the updated msi fixed the problem.

Running `windows:package-msi` with the latest source errored out with:
`[error] Not a valid key: package-msi (similar: package-site, package-bin, package-src)`
