### PR TITLE
start template clean up to be used with new /etc/default

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-template
@@ -9,7 +9,6 @@
 # Short-Description: ${{descr}}
 ### END INIT INFO
 
-test -e /etc/default/${{app_name}} && source /etc/default/${{app_name}}
 source /lib/init/vars.sh
 source /lib/lsb/init-functions
 


### PR DESCRIPTION
Since bash script will read /etc/default/app_name we don't need it any more in start template
