### PR TITLE
change parameter ordering for rpmbuild, fixes ignoring arch on OSX

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -75,10 +75,10 @@ object RpmHelper {
     val args: Seq[String] = Seq(
         "rpmbuild",
         "-bb",
+        "--target", spec.meta.arch + '-' + spec.meta.vendor + '-' + spec.meta.os,
         "--buildroot", buildRoot.getAbsolutePath,
-        "--define", "_topdir " + workArea.getAbsolutePath,
-        "--target", spec.meta.arch + '-' + spec.meta.vendor + '-' + spec.meta.os
-     ) ++ ( 
+        "--define", "_topdir " + workArea.getAbsolutePath
+     ) ++ (
        if(gpg) Seq("--define", "_gpg_name " + "<insert keyname>", "--sign") 
        else Seq.empty 
      ) ++ Seq(spec.meta.name + ".spec")


### PR DESCRIPTION
On OSX strict parameter ordering is required for rpmbuild. This results in x86_64 rpms when noarch is specified in the build, for example. We recently noted this issue in the similar maven packager with fix here https://github.com/rickard-von-essen/rpm-maven-plugin/commit/673e61e432aeef1229bcb040b6db9cf8f9239b38 and SO post noting it here http://stackoverflow.com/questions/8051744/macosx-rpmbuild-target-noarch-doesnt-work
