### PR TITLE
change parameter ordering for rpmbuild, fixes ignoring arch on OSX

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -74,9 +74,9 @@ object RpmHelper {
     val args: Seq[String] = Seq(
       "rpmbuild",
       "-bb",
+      "--target", spec.meta.arch + '-' + spec.meta.vendor + '-' + spec.meta.os,
       "--buildroot", buildRoot.getAbsolutePath,
-      "--define", "_topdir " + workArea.getAbsolutePath,
-      "--target", spec.meta.arch + '-' + spec.meta.vendor + '-' + spec.meta.os
+      "--define", "_topdir " + workArea.getAbsolutePath
     ) ++ (
         if (gpg) Seq("--define", "_gpg_name " + "<insert keyname>", "--sign")
         else Seq.empty


### PR DESCRIPTION
Rebase for  #185
