### PR TITLE
Removing `normalizedKey` in packagerSettings. #188

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/GenericPackageSettings.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/GenericPackageSettings.scala
@@ -3,7 +3,7 @@ package packager
 
 import Keys._
 import sbt._
-import sbt.Keys.{ name, mappings, sourceDirectory }
+import sbt.Keys.{ name, mappings, sourceDirectory, normalizedName }
 import linux.LinuxSymlink
 import linux.LinuxPackageMapping
 

--- a/src/main/scala/com/typesafe/sbt/packager/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Keys.scala
@@ -9,9 +9,6 @@ object Keys extends linux.Keys
   with windows.WindowsKeys
   with universal.UniversalKeys {
 
-  // TODO - Do these keys belong here?
-  def normalizedName = sbt.Keys.normalizedName
-
   // These keys are used by the JavaApp/JavaServer archetypes.
   val makeBashScript = TaskKey[Option[File]]("makeBashScript", "Creates or discovers the bash script used by this project.")
   val bashScriptDefines = TaskKey[Seq[String]]("bashScriptDefines", "A list of definitions that should be written to the bash file template.")


### PR DESCRIPTION
To answer this TODO `Do these keys belong here?`: IMHO not.
