### PR TITLE
Fix #195 Adding rpmBrpJavaRepackJars setting 

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
+++ b/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
@@ -1,0 +1,6 @@
+%define __os_install_post \
+/usr/lib/rpm/brp-compress \
+%{!?__debug_package:/usr/lib/rpm/brp-strip %{__strip}} \
+/usr/lib/rpm/brp-strip-static-archive %{__strip} \
+/usr/lib/rpm/brp-strip-comment-note %{__strip} %{__objdump} \
+%{nil}

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
@@ -46,6 +46,8 @@ trait RpmKeys {
   val rpmPosttrans = SettingKey[Option[String]]("rpm-posttrans", "%posttrans scriptlet")
   val rpmPreun = SettingKey[Option[String]]("rpm-preun", "%preun scriptlet")
   val rpmPostun = SettingKey[Option[String]]("rpm-postun", "%postun scriptlet")
+  val rpmBrpJavaRepackJars = SettingKey[Boolean]("brp-java-repack-jars", """Overrides the __os_post_install scriplet
+      http://swaeku.github.io/blog/2013/08/05/how-to-disable-brp-java-repack-jars-during-rpm-build/ for details""")
 
   // Building
   val rpmLint = TaskKey[Unit]("rpm-lint", "Runs rpmlint program against the genreated RPM, if available.")


### PR DESCRIPTION
When activated with

``` scala
rpmBrpJavaRepackJars := false
```

A  the `__os_install_post` macro will be added to the `rpmPre in Rpm` setting and jar repacking is disabled.

http://swaeku.github.io/blog/2013/08/05/how-to-disable-brp-java-repack-jars-during-rpm-build/

@timperrett can you verify this?
