### PR TITLE
Ensure /var/run/app_name/ exists when starting

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-debian-template
@@ -25,6 +25,7 @@ RUN_CMD="${{chdir}}/bin/${{app_name}}"
 
 start_daemon() {
     log_daemon_msg "Starting" "${{app_name}}"
+    [ -e "/var/run/${{app_name}}" ] || install -d -o"$DAEMON_USER" -m750 "/var/run/${{app_name}}"
     start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --exec "$RUN_CMD" --start -- $RUN_OPTS
     log_end_msg $?
 }


### PR DESCRIPTION
On Debian, /var/run is a symbolic link to /run which is [actually a tmpfs](https://wiki.debian.org/ReleaseGoals/RunDirectory#Overview). So after system reboot, the /var/run/app_name directory doesn't exist anymore, leading to the following error:

```
start-stop-daemon: unable to open pidfile '/var/run/app_name/running.pid' for writing (No such file or directory)
```
