### PR TITLE
FIX #211 and #232. Checking $java_args[@] for memory settings, too.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -166,6 +166,7 @@ get_mem_opts () {
      [[ "${java_args[@]}" == *-XX:MaxPermSize* ]] || 
      [[ "${java_args[@]}" == *-XX:ReservedCodeCacheSize* ]];
   then
+    echo ""
   elif [[ !$no_java_version_check ]] && [[ java_version > "1.8" ]]; then
     echo "-Xms${mem}m -Xmx${mem}m -XX:ReservedCodeCacheSize=${codecache}m"
   else 


### PR DESCRIPTION
Finally. This was a bit tricky, but should be fixed now. @jsuereth you may want to add this to the `sbt-launcher-package` project, too.

@kardapoltsev can you review/test please? I just checked with Ubuntu 14.04 and play.
