### PR TITLE
Do not try to setup missing deployment settings for Docker.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala
@@ -37,7 +37,6 @@ object SbtNativePackager extends Plugin
   def deploymentSettings = makeDeploymentSettings(Debian, packageBin in Debian, "deb") ++
     makeDeploymentSettings(Rpm, packageBin in Rpm, "rpm") ++
     makeDeploymentSettings(Windows, packageBin in Windows, "msi") ++
-    makeDeploymentSettings(Docker, packageBin in Docker, "tgz") ++
     makeDeploymentSettings(Universal, packageBin in Universal, "zip") ++
     addPackage(Universal, packageZipTarball in Universal, "tgz") ++
     makeDeploymentSettings(UniversalDocs, packageBin in UniversalDocs, "zip") ++


### PR DESCRIPTION
Docker has no tasks for packageBin/etc. It should not be mentioned
in the deploymentSettings definition. Otherwise, adding
deploymentSettings to your build results in:
Reference to undefined setting:

  docker:packageBin from docker:$local (build.sbt:3)
