### PR TITLE
brpJavaRepackJar template fixed

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
+++ b/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
@@ -1,6 +1,6 @@
 %define __os_install_post \
-/usr/lib/rpm/brp-compress \
-%{!?__debug_package:/usr/lib/rpm/brp-strip %{__strip}} \
-/usr/lib/rpm/brp-strip-static-archive %{__strip} \
-/usr/lib/rpm/brp-strip-comment-note %{__strip} %{__objdump} \
+%{_rpmconfigdir}/brp-compress \
+%{!?__debug_package:%{_rpmconfigdir}/brp-strip %{__strip}} \
+%{_rpmconfigdir}/brp-strip-static-archive %{__strip} \
+%{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump} \
 %{nil}


### PR DESCRIPTION
It fails with 
`/usr/lib/rpm/brp-compress: No such file or directory`
Actually this files located at `/usr/libexec/rmp/` on Gentoo installation.
