### PR TITLE
Fix non Java 8 MaxPermSize configuration

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -167,7 +167,7 @@ get_mem_opts () {
      [[ "${java_args[@]}" == *-XX:ReservedCodeCacheSize* ]];
   then
     echo ""
-  elif [[ !$no_java_version_check ]] && [[ java_version > "1.8" ]]; then
+  elif [[ !$no_java_version_check ]] && [[ "$java_version" > "1.8" ]]; then
     echo "-Xms${mem}m -Xmx${mem}m -XX:ReservedCodeCacheSize=${codecache}m"
   else 
     echo "-Xms${mem}m -Xmx${mem}m -XX:MaxPermSize=${perm}m -XX:ReservedCodeCacheSize=${codecache}m"


### PR DESCRIPTION
The check for Java 8 was always evaluating to true, so MaxPermSize was never being set on Java 6/7 VMs.
