### PR TITLE
Fix java 8 version check

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -167,7 +167,7 @@ get_mem_opts () {
      [[ "${java_args[@]}" == *-XX:ReservedCodeCacheSize* ]];
   then
     echo ""
-  elif [[ !$no_java_version_check ]] && [[ "$java_version" > "1.8" ]]; then
+  elif [[ !$no_version_check ]] && [[ "$java_version" > "1.8" ]]; then
     echo "-Xms${mem}m -Xmx${mem}m -XX:ReservedCodeCacheSize=${codecache}m"
   else 
     echo "-Xms${mem}m -Xmx${mem}m -XX:MaxPermSize=${perm}m -XX:ReservedCodeCacheSize=${codecache}m"
@@ -284,7 +284,7 @@ loadConfigFile() {
 # Now check to see if it's a good enough version
 # TODO - Check to see if we have a configured default java version, otherwise use 1.6
 java_version_check() { 
-  declare -r java_version=$("$java_cmd" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+  readonly java_version=$("$java_cmd" -version 2>&1 | awk -F '"' '/version/ {print $2}')
   if [[ "$java_version" == "" ]]; then
     echo
     echo No java installations was detected.


### PR DESCRIPTION
The Java 8 version check in the bash-template does not currently work. There are two issues:
- Typo in the guard name: `no_java_version_check` instead of `no_version_check`
- Assumes `$java_version` is a global variable but that is not currently exported by `java_version_check`, at least when running under bash 3.2.51(1)-release on OS X Mavericks
