### PR TITLE
Added support for -javaagent parameters.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -214,6 +214,7 @@ process_args () {
 
      -java-home) require_arg path "$1" "$2" && java_cmd="$2/bin/java" && shift 2 ;;
 
+    -javaagent*) addJava "$1" && shift ;;
             -D*) addJava "$1" && shift ;;
             -J*) addJava "${1:2}" && shift ;;
               *) addResidual "$1" && shift ;;


### PR DESCRIPTION
This change ensures that "-javaagent:" parameters get passed to the JVM correctly. Previously they ended up as arguments to the main class rather than the JVM and consequently did not work.
