### PR TITLE
implemented `die` function in bash-template

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -4,6 +4,11 @@
 ###  Helper methods for BASH scripts ###
 ###  ------------------------------- ###
 
+die() {
+  echo "$@" 1>&2
+  exit 1
+}
+
 realpath () {
 (
   TARGET_FILE="$1"


### PR DESCRIPTION
This pull request is related to #259 (`die` command not found in bash script)

(thanks to https://github.com/sbt/sbt-native-packager/issues/259#issuecomment-45880827)
