### PR TITLE
Fixed user deletion issue in rpm postuninstall scriptlet.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/rpm/postuninstall
+++ b/src/main/resources/com/typesafe/sbt/packager/rpm/postuninstall
@@ -1,6 +1,6 @@
 # Removing system user/group : ${{daemon_user}} and ${{daemon_group}}
 
-# Scriplet syntax: http://fedoraproject.org/wiki/Packaging:ScriptletSnippets#Syntax
+# Scriptlet syntax: http://fedoraproject.org/wiki/Packaging:ScriptletSnippets#Syntax
 # $1 == 1 is upgrade and $1 == 0 is uninstall
 if [[ $1 == 0 ]]
 then


### PR DESCRIPTION
Default rpm postuninstall scriptlet unconditionally deletes user / group.
This is a problem when someone tries to upgrade a package in one step (using rpm -U package-name).
Currently this ends up with upgraded package artifacts and removed package user.

The fix adds a check which tests number of packages which will be left in the system after the action completes:
http://fedoraproject.org/wiki/Packaging:ScriptletSnippets#Syntax
