### PR TITLE
Support EXPOSE [port] ... for Docker

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -10,6 +10,7 @@ trait DockerKeys {
   val dockerPackageMappings = TaskKey[Seq[(File, String)]]("docker-package-mappings", "Generates location mappings for Docker build.")
 
   val dockerBaseImage = SettingKey[String]("dockerBaseImage", "Base image for Dockerfile.")
+  val dockerExposedPorts = SettingKey[Seq[Int]]("dockerExposedPorts", "Ports exposed by Docker image")
 }
 
 object Keys extends DockerKeys {


### PR DESCRIPTION
Docker allows the ability to share ports between containers, if the ports
are listed in the configuration for the Docker image. This commit adds a
dockerExposedPorts setting which adds the appropriate line.
