### PR TITLE
Allow name in Docker to be modified.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -56,6 +56,7 @@ trait DockerPlugin extends Plugin with UniversalPlugin {
 
   def dockerSettings: Seq[Setting[_]] = Seq(
     dockerBaseImage := "dockerfile/java",
+    name in Docker <<= name,
     sourceDirectory in Docker <<= sourceDirectory apply (_ / "docker"),
     target in Docker <<= target apply (_ / "docker")
   ) ++ mapGenericFilesToDocker ++ inConfig(Docker)(Seq(
@@ -67,6 +68,7 @@ trait DockerPlugin extends Plugin with UniversalPlugin {
         MappingsHelper contentOf dir
       },
       mappings <++= dockerPackageMappings,
+      normalizedName <<= name apply Project.normalizeModuleID,
       stage <<= (dockerGenerateConfig, dockerGenerateContext) map { (configFile, contextDir) => () },
       dockerGenerateContext <<= (cacheDirectory, mappings, target) map {
         (cacheDirectory, mappings, t) =>

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -16,6 +16,7 @@ trait DockerKeys {
 object Keys extends DockerKeys {
   def cacheDirectory = sbt.Keys.cacheDirectory
   def mappings = sbt.Keys.mappings
+  def name = sbt.Keys.name
   def publishArtifact = sbt.Keys.publishArtifact
   def sourceDirectory = sbt.Keys.sourceDirectory
   def target = sbt.Keys.target


### PR DESCRIPTION
`name in Docker := "..."` didn't do anything useful. This change follows the pattern followed by https://github.com/sbt/sbt-native-packager/pull/250 to allow the feature.
