### PR TITLE
First refactoring to provide multiple debian packaging strategies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ scalacOptions in Compile += "-deprecation"
 
 libraryDependencies ++= Seq(
     "org.apache.commons" % "commons-compress" % "1.4.1",
-    "org.vafer" % "jdeb" % "1.2"
+    "org.vafer" % "jdeb" % "1.2" artifacts (Artifact("jdeb", "jar", "jar"))
 )
 
 site.settings

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -19,6 +19,7 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin with NativePackaging wi
   import linux.LinuxPlugin.Users
 
   def debianSettings: Seq[Setting[_]] = Seq(
+    /* ==== Debian default settings ==== */
     debianPriority := "optional",
     debianSection := "java",
     debianPackageDependencies := Seq.empty,
@@ -32,6 +33,7 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin with NativePackaging wi
     packageSummary in Debian <<= packageSummary in Linux,
     maintainer in Debian <<= maintainer in Linux,
 
+    /* ==== Debian configuration settings ==== */
     debianControlScriptsDirectory <<= (sourceDirectory) apply (_ / "debian" / Names.Debian),
     debianMaintainerScripts := Seq.empty,
     debianMakePreinstScript := None,
@@ -40,74 +42,206 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin with NativePackaging wi
     debianMakePostrmScript := None,
     debianChangelog := None,
 
+    /* ==== Debian maintainer scripts ==== */
     debianMaintainerScripts <++= (debianMakePrermScript, debianControlScriptsDirectory) map scriptMapping(Names.Prerm),
     debianMaintainerScripts <++= (debianMakePreinstScript, debianControlScriptsDirectory) map scriptMapping(Names.Preinst),
     debianMaintainerScripts <++= (debianMakePostinstScript, debianControlScriptsDirectory) map scriptMapping(Names.Postinst),
-    debianMaintainerScripts <++= (debianMakePostrmScript, debianControlScriptsDirectory) map scriptMapping(Names.Postrm)) ++
-    inConfig(Debian)(Seq(
-      packageArchitecture := "all",
-      debianPackageInfo <<=
-        (normalizedName, version, maintainer, packageSummary, packageDescription) apply PackageInfo,
-      debianPackageMetadata <<=
-        (debianPackageInfo,
-          debianPriority, packageArchitecture, debianSection,
-          debianPackageDependencies, debianPackageRecommends) apply PackageMetaData,
-      debianPackageInstallSize <<= linuxPackageMappings map { mappings =>
-        (for {
-          LinuxPackageMapping(files, _, zipped) <- mappings
-          (file, _) <- files
-          if !file.isDirectory && file.exists
-          // TODO - If zipped, heuristically figure out a reduction factor.
-        } yield file.length).sum / 1024
-      },
-      debianControlFile <<= (debianPackageMetadata, debianPackageInstallSize, target) map {
-        (data, size, dir) =>
-          if (data.info.description == null || data.info.description.isEmpty) {
-            sys.error(
-              """packageDescription in Debian cannot be empty. Use
+    debianMaintainerScripts <++= (debianMakePostrmScript, debianControlScriptsDirectory) map scriptMapping(Names.Postrm)) ++ inConfig(Debian)(
+      /* ==== Debian scoped settings ==== */
+      Seq(
+        packageArchitecture := "all",
+        debianPackageInfo <<=
+          (normalizedName, version, maintainer, packageSummary, packageDescription) apply PackageInfo,
+        debianPackageMetadata <<=
+          (debianPackageInfo,
+            debianPriority, packageArchitecture, debianSection,
+            debianPackageDependencies, debianPackageRecommends) apply PackageMetaData,
+        debianPackageInstallSize <<= linuxPackageMappings map { mappings =>
+          (for {
+            LinuxPackageMapping(files, _, zipped) <- mappings
+            (file, _) <- files
+            if !file.isDirectory && file.exists
+            // TODO - If zipped, heuristically figure out a reduction factor.
+          } yield file.length).sum / 1024
+        },
+        debianControlFile <<= (debianPackageMetadata, debianPackageInstallSize, target) map {
+          (data, size, dir) =>
+            if (data.info.description == null || data.info.description.isEmpty) {
+              sys.error(
+                """packageDescription in Debian cannot be empty. Use
                  packageDescription in Debian := "My package Description"""")
-          }
-          val cfile = dir / Names.Debian / Names.Control
-          IO.write(cfile, data.makeContent(size), java.nio.charset.Charset.defaultCharset)
-          chmod(cfile, "0644")
-          cfile
-      },
-      debianConffilesFile <<= (linuxPackageMappings, target) map {
-        (mappings, dir) =>
-          val cfile = dir / Names.Debian / Names.Conffiles
-          val conffiles = for {
-            LinuxPackageMapping(files, meta, _) <- mappings
-            if meta.config != "false"
-            (file, name) <- files
-            if file.isFile
-          } yield name
-          IO.writeLines(cfile, conffiles)
-          chmod(cfile, "0644")
-          cfile
-      },
-      debianMD5sumsFile <<= (debianExplodedPackage, target) map {
-        (mappings, dir) =>
-          val md5file = dir / Names.Debian / "md5sums"
-          val md5sums = for {
-            (file, name) <- (dir.*** --- dir x relativeTo(dir))
-            if file.isFile
-            if !(name startsWith Names.Debian)
-            if !(name contains "debian-binary")
-            // TODO - detect symlinks with Java7 (when we can) rather than hackery...
-            if file.getCanonicalPath == file.getAbsolutePath
-            fixedName = if (name startsWith "/") name drop 1 else name
-          } yield Hashing.md5Sum(file) + "  " + fixedName
-          IO.writeLines(md5file, md5sums)
-          chmod(md5file, "0644")
-          md5file
-      },
-      // Setting the packaging strategy
-      packageBin <<= Native()
-    ) ++ debianNativeSettings
+            }
+            val cfile = dir / Names.Debian / Names.Control
+            IO.write(cfile, data.makeContent(size), java.nio.charset.Charset.defaultCharset)
+            chmod(cfile, "0644")
+            cfile
+        },
+        debianConffilesFile <<= (linuxPackageMappings, target) map {
+          (mappings, dir) =>
+            val cfile = dir / Names.Debian / Names.Conffiles
+            val conffiles = for {
+              LinuxPackageMapping(files, meta, _) <- mappings
+              if meta.config != "false"
+              (file, name) <- files
+              if file.isFile
+            } yield name
+            IO.writeLines(cfile, conffiles)
+            chmod(cfile, "0644")
+            cfile
+        },
+        debianMD5sumsFile <<= (debianExplodedPackage, target) map {
+          (mappings, dir) =>
+            val md5file = dir / Names.Debian / "md5sums"
+            val md5sums = for {
+              (file, name) <- (dir.*** --- dir x relativeTo(dir))
+              if file.isFile
+              if !(name startsWith Names.Debian)
+              if !(name contains "debian-binary")
+              // TODO - detect symlinks with Java7 (when we can) rather than hackery...
+              if file.getCanonicalPath == file.getAbsolutePath
+              fixedName = if (name startsWith "/") name drop 1 else name
+            } yield Hashing.md5Sum(file) + "  " + fixedName
+            IO.writeLines(md5file, md5sums)
+            chmod(md5file, "0644")
+            md5file
+        },
+        debianExplodedPackage <<= (linuxPackageMappings, debianControlFile, debianMaintainerScripts, debianConffilesFile, debianChangelog, daemonShell in Linux, linuxScriptReplacements, linuxPackageSymlinks, target, streams)
+          map { (mappings, _, maintScripts, _, changelog, shell, replacements, symlinks, t, streams) =>
 
-    )
+            // Create files and directories
+            mappings foreach {
+              case LinuxPackageMapping(paths, perms, zipped) =>
+                val (dirs, files) = paths.partition(_._1.isDirectory)
+                dirs map {
+                  case (_, name) => t / name
+                } foreach { targetDir =>
+                  targetDir mkdirs ()
+                  chmod(targetDir, perms.permissions)
+                }
 
-  private[this] def scriptMapping(scriptName: String)(script: Option[File], controlDir: File): Seq[(File, String)] = {
+                files map {
+                  case (file, name) => (file, t / name)
+                } foreach {
+                  case (source, target) => copyAndFixPerms(source, target, perms, zipped)
+                }
+            }
+            // Now generate relative symlinks
+            LinuxSymlink.makeSymLinks(symlinks, t, false)
+
+            // Put the maintainer files in `dir / "DEBIAN"` named as specified.
+            // Valid values for the name are preinst,postinst,prerm,postrm
+            for ((file, name) <- maintScripts) {
+              val targetFile = t / Names.Debian / name
+              copyAndFixPerms(file, targetFile, LinuxFileMetaData())
+              filterAndFixPerms(targetFile, replacements, LinuxFileMetaData())
+            }
+
+            // Check for non root user/group and append to postinst / postrm
+            // filter all root mappings, map to (user,group) key, group by, append everything
+            mappings filter {
+              case LinuxPackageMapping(_, LinuxFileMetaData(Users.Root, Users.Root, _, _, _), _) => false
+              case _ => true
+            } map {
+              case LinuxPackageMapping(paths, LinuxFileMetaData(user, group, _, _, _), _) => (user, group) -> paths
+            } groupBy (_._1) foreach {
+              case ((user, group), pathList) =>
+                streams.log info ("Altering postrm/postinst files to add user " + user + " and group " + group)
+                val postinst = createFileIfRequired(t / Names.Debian / Names.Postinst, LinuxFileMetaData())
+                val postrm = createFileIfRequired(t / Names.Debian / Names.Postrm, LinuxFileMetaData())
+                val prerm = createFileIfRequired(t / Names.Debian / Names.Prerm, LinuxFileMetaData())
+                val headerScript = IO.readLinesURL(Native.headerSource)
+
+                val replacements = Seq("group" -> group, "user" -> user, "shell" -> shell)
+
+                prependAndFixPerms(prerm, headerScript, LinuxFileMetaData())
+
+                // remove key, flatten it and then go through each file
+                pathList.map(_._2).flatten foreach {
+                  case (_, target) =>
+                    val pathReplacements = replacements :+ ("path" -> target.toString)
+                    val chownAdd = Seq(TemplateWriter.generateScript(Native.postinstChownTemplateSource, pathReplacements))
+                    prependAndFixPerms(postinst, chownAdd, LinuxFileMetaData())
+                }
+
+                validateUserGroupNames(user, streams)
+                validateUserGroupNames(group, streams)
+
+                val userGroupAdd = Seq(
+                  TemplateWriter.generateScript(Native.postinstGroupaddTemplateSource, replacements),
+                  TemplateWriter.generateScript(Native.postinstUseraddTemplateSource, replacements))
+
+                prependAndFixPerms(postinst, userGroupAdd, LinuxFileMetaData())
+                prependAndFixPerms(postinst, headerScript, LinuxFileMetaData())
+
+                val purgeAdd = Seq(TemplateWriter.generateScript(Native.postrmPurgeTemplateSource, replacements))
+                appendAndFixPerms(postrm, purgeAdd, LinuxFileMetaData())
+                prependAndFixPerms(postrm, headerScript, LinuxFileMetaData())
+            }
+            t
+          },
+        // Setting the packaging strategy
+        packageBin <<= debianNativePackaging
+
+      // Adding package specific implementation settings
+      ) ++ debianNativeSettings ++ debianJDebSettings)
+
+  /* ============================================= */
+  /* ========== Debian Helper Methods ============ */
+  /* ============================================= */
+
+  private[debian] final def copyAndFixPerms(from: File, to: File, perms: LinuxFileMetaData, zipped: Boolean = false): Unit = {
+    if (zipped) {
+      IO.withTemporaryDirectory { dir =>
+        val tmp = dir / from.getName
+        IO.copyFile(from, tmp)
+        val zipped = Archives.gzip(tmp)
+        IO.copyFile(zipped, to, true)
+      }
+    } else IO.copyFile(from, to, true)
+    // If we have a directory, we need to alter the perms.
+    chmod(to, perms.permissions)
+    // TODO - Can we do anything about user/group ownership?
+  }
+
+  private[debian] final def filterAndFixPerms(script: File, replacements: Seq[(String, String)], perms: LinuxFileMetaData): File = {
+    val filtered = TemplateWriter.generateScript(script.toURI.toURL, replacements)
+    IO.delete(script)
+    IO.write(script, filtered)
+    chmod(script, perms.permissions)
+    script
+  }
+
+  private[debian] final def prependAndFixPerms(script: File, lines: Seq[String], perms: LinuxFileMetaData): File = {
+    val old = IO.readLines(script)
+    IO.writeLines(script, lines ++ old, append = false)
+    chmod(script, perms.permissions)
+    script
+  }
+
+  private[debian] final def appendAndFixPerms(script: File, lines: Seq[String], perms: LinuxFileMetaData): File = {
+    IO.writeLines(script, lines, append = true)
+    chmod(script, perms.permissions)
+    script
+  }
+
+  private[debian] final def createFileIfRequired(script: File, perms: LinuxFileMetaData): File = {
+    if (!script.exists()) {
+      script.createNewFile()
+      chmod(script, perms.permissions)
+    }
+    script
+  }
+
+  private[debian] final def validateUserGroupNames(user: String, streams: TaskStreams) {
+    if ((UserNamePattern findFirstIn user).isEmpty) {
+      streams.log.warn("The user or group '" + user + "' may contain invalid characters for Debian based distributions")
+    }
+    if (user.length > 32) {
+      streams.log.warn("The length of '" + user + "' must be not be greater than 32 characters for Debian based distributions.")
+    }
+  }
+
+  private[debian] def scriptMapping(scriptName: String)(script: Option[File], controlDir: File): Seq[(File, String)] = {
     (script, controlDir) match {
       // check if user defined script exists
       case (_, dir) if (dir / scriptName).exists =>
@@ -118,6 +252,9 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin with NativePackaging wi
   }
 }
 
+/**
+ * Contains debian specific constants
+ */
 object DebianPlugin {
   object Names {
     val DebianSource = "debian"
@@ -135,5 +272,4 @@ object DebianPlugin {
     val Changelog = "changelog"
     val Files = "files"
   }
-
 }

--- a/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
@@ -7,18 +7,98 @@ import sbt._
 import sbt.Keys.{ target, name, normalizedName, TaskStreams }
 import linux.{ LinuxFileMetaData, LinuxPackageMapping, LinuxSymlink }
 import linux.Keys.{ linuxScriptReplacements, daemonShell }
+import com.typesafe.sbt.packager.linux.LinuxPackageMapping
+import scala.collection.JavaConversions._
 
+import org.vafer.jdeb.{ DebMaker, DataProducer }
+import org.vafer.jdeb.mapping._
+import org.vafer.jdeb.producers._
+import DebianPlugin.Names
+
+/**
+ * This provides a java based debian packaging implementation based
+ * on the jdeb maven-plugin. To use this, put this into your build.sbt
+ *
+ * {{
+ *    packageBin in Debian <<= debianJDebPackaging in Debian
+ * }}
+ *
+ * @author Nepomuk Seiler
+ * @see https://github.com/tcurdt/jdeb/blob/master/src/main/java/org/vafer/jdeb/maven/DebMojo.java#L503
+ *
+ */
 trait JDebPackaging { this: DebianPlugin with linux.LinuxPlugin =>
 
-  private[debian] def debianJDebSettings: Seq[Setting[_]] = Seq.empty
+  private[debian] def debianJDebSettings: Seq[Setting[_]] = Seq(
+
+    /**
+     * Depends on the 'debianExplodedPackage' task as this creates all the files
+     * which are defined in the mappings.
+     */
+    debianJDebPackaging <<= (debianExplodedPackage, linuxPackageMappings, linuxPackageSymlinks,
+      debianControlFile, debianMaintainerScripts, debianConffilesFile,
+      normalizedName, version, target, streams) map {
+        (_, mappings, symlinks, controlfile, controlscripts, conffile,
+        name, version, target, s) =>
+          s.log.info("Building debian package with java based implementation 'jdeb'")
+          val console = new JDebConsole(s.log)
+
+          val debianFile = target.getParentFile / "%s_%s_all.deb".format(name, version)
+          val debMaker = new DebMaker(console,
+            fileAndDirectoryProducers(mappings, target) ++ linkProducers(symlinks),
+            conffileProducers()
+          )
+          debMaker setDeb debianFile
+          debMaker setControl (target / Names.Debian)
+
+          // TODO set compression, gzip is default
+          // TODO add signing with setKeyring, setKey, setPassphrase, setSignPackage, setSignMethod, setSignRole
+          debMaker validate ()
+          debMaker makeDeb ()
+          debianFile
+      })
+
+  /**
+   * Creating file and directory producers. These "produce" the
+   * files for the debian packaging
+   */
+  private[debian] def fileAndDirectoryProducers(mappings: Seq[LinuxPackageMapping], target: File): Seq[DataProducer] = mappings.map {
+    case LinuxPackageMapping(paths, perms, zipped) =>
+      // TODO implement mappers here or use the maintainerscripts logic?
+      val (dirs, files) = paths.partition(_._1.isDirectory)
+      paths map {
+        case (path, name) if path.isDirectory =>
+          new DataProducerDirectory(target / name, null, Array("**"), null)
+        case (path, name) =>
+          new DataProducerFile(target / name, name, null, null, null)
+      }
+  }.flatten
+
+  /**
+   * Creating link producers for symlinks.
+   */
+  private[debian] def linkProducers(symlinks: Seq[LinuxSymlink]): Seq[DataProducer] = symlinks map {
+    case LinuxSymlink(link, destination) =>
+      new DataProducerLink(link, destination, true, null, null, null)
+  }
+
+  /**
+   * Creating the files which should be added as conffiles.
+   * This is currently handled by the debian plugin itself.
+   */
+  private[debian] def conffileProducers(): Seq[DataProducer] = Seq.empty
+
 }
 
 /**
  * This provides the task for building a debian packaging with
  * the java-based implementation jdeb
  */
-object JDeb {
+class JDebConsole(log: Logger) extends org.vafer.jdeb.Console {
 
-  // https://github.com/tcurdt/jdeb/blob/master/src/main/java/org/vafer/jdeb/maven/DebMojo.java#L503
-  def apply(): Def.Initialize[Task[java.io.File]] = ???
+  def debug(message: String) = log debug message
+
+  def info(message: String) = log info message
+
+  def warn(message: String) = log warn message
 }

--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -16,6 +16,9 @@ trait DebianKeys {
   val debianPackageMetadata = SettingKey[PackageMetaData]("debian-package-metadata", "Meta data used when constructing a debian package.")
   val debianChangelog = SettingKey[Option[File]]("debian-changelog", "The changelog for this deb file")
   // Package building
+  val debianNativePackaging = TaskKey[File]("debian-packaging-native", "Builds the debian package with native cli tools")
+  val debianJDebPackaging = TaskKey[File]("debian-packaging-jdeb", "Builds the debian package with jdeb (java-based)")
+
   val debianControlFile = TaskKey[File]("debian-control-file", "Makes the debian package control file.")
   val debianMaintainerScripts = TaskKey[Seq[(File, String)]]("debian-maintainer-scripts", "Makes the debian maintainer scripts.")
   val debianConffilesFile = TaskKey[File]("debian-conffiles-file", "Makes the debian package conffiles file.")

--- a/src/sbt-test/debian/simple-jdeb/build.sbt
+++ b/src/sbt-test/debian/simple-jdeb/build.sbt
@@ -1,0 +1,22 @@
+import NativePackagerKeys._
+
+packagerSettings
+
+mapGenericFilesToLinux
+
+name := "debian-test"
+
+version := "0.1.0"
+
+maintainer := "Josh Suereth <joshua.suereth@typesafe.com>"
+
+packageSummary := "Test debian package"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+debianPackageDependencies in Debian ++= Seq("java2-runtime", "bash (>= 2.05a-11)")
+
+debianPackageRecommends in Debian += "git"
+
+packageBin in Debian <<= debianJDebPackaging in Debian

--- a/src/sbt-test/debian/simple-jdeb/project/plugins.sbt
+++ b/src/sbt-test/debian/simple-jdeb/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/debian/simple-jdeb/test
+++ b/src/sbt-test/debian/simple-jdeb/test
@@ -1,0 +1,3 @@
+# Run the debian packaging.
+> debian:package-bin
+$ exists target/debian-test_0.1.0_all.deb


### PR DESCRIPTION
This is the first refactoring step to provide an additional java-based debian packaging implementation.
Does this look okay from the coding side? @jsuereth , @kardapoltsev , @aparkinson ?

I basically introduced two new task `debianJDebPackaging` and `debianNativePackaging`.
You set the packaging strategy with `packageBin in Debian <<= debianJDebPackaging in Debian`.
