### PR TITLE
Use StringUtilities.normalize to allow compilation with SBT 0.12.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -158,7 +158,7 @@ trait DockerPlugin extends Plugin with UniversalPlugin {
         MappingsHelper contentOf dir
       },
       mappings <++= dockerPackageMappings,
-      normalizedName <<= name apply Project.normalizeModuleID,
+      normalizedName <<= name apply StringUtilities.normalize,
       stage <<= (dockerGenerateConfig, dockerGenerateContext) map { (configFile, contextDir) => () },
       dockerGenerateContext <<= (cacheDirectory, mappings, target) map {
         (cacheDirectory, mappings, t) =>


### PR DESCRIPTION
Project.normalizeModuleID is recommended for use with SBT 0.13, but it
doesn't exist with 0.12. This uses the deprecated call instead.
