### PR TITLE
fix order of docker commands

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -9,9 +9,12 @@ trait DockerPlugin extends Plugin with UniversalPlugin {
   val Docker = config("docker") extend Universal
 
   private[this] final def makeDockerContent(dockerBaseImage: String, dockerBaseDirectory: String, maintainer: String, daemonUser: String, name: String, exposedPorts: Seq[Int], exposedVolumes: Seq[String]) = {
-    val dockerCommands = Seq(
+    val headerCommands = Seq(
       Cmd("FROM", dockerBaseImage),
-      Cmd("MAINTAINER", maintainer),
+      Cmd("MAINTAINER", maintainer)
+    )
+
+    val dockerCommands = Seq(
       Cmd("ADD", "files /"),
       Cmd("WORKDIR", "%s" format dockerBaseDirectory),
       ExecCmd("RUN", "chown", "-R", daemonUser, "."),
@@ -42,7 +45,7 @@ trait DockerPlugin extends Plugin with UniversalPlugin {
         )
     }
 
-    Dockerfile(volumeCommands ++ exposeCommand ++ dockerCommands: _*).makeContent
+    Dockerfile(headerCommands ++ volumeCommands ++ exposeCommand ++ dockerCommands: _*).makeContent
   }
 
   private[this] final def generateDockerConfig(


### PR DESCRIPTION
In Dockerfile the FROM commad should be alway the first 
but when add dockerExposedPorts or dockerExposedVolumes those are the first line in the file.

```
[info] Step 0 : EXPOSE 9000
[error] 2014/07/14 12:46:23 Please provide a source image with `from` prior to commit
[trace] Stack trace suppressed: run last docker:publishLocal for the full output.
[error] (docker:publishLocal) Nonzero exit value: 1
```
