### PR TITLE
Remove cross-build configuration from build.sbt.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,16 +2,7 @@ import scalariform.formatter.preferences._
 
 sbtPlugin := true
 
-sbtVersion in Global := {
-  scalaBinaryVersion.value match {
-    case "2.10" => "0.13.5"
-    case "2.9.2" => "0.13.5"
-  }
-}
-
 scalaVersion in Global := "2.10.2"
-
-crossScalaVersions := Seq("2.9.2", "2.10.2")
 
 name := "sbt-native-packager"
 


### PR DESCRIPTION
If sbt-native-packager only supports SBT 0.13+, then scala 2.10
is the required version for the API.

Example errors with "sbt +compile" because SBT 0.13 uses macros:

[error] error while loading package, class file needed by package is missing.
[error] reference value internal of package scala.reflect.macros refers to nonexisting symbol.
[error] error while loading package, class file needed by package is missing.
[error] reference value internal of package scala.reflect.macros refers to nonexisting symbol.
[error] error while loading ProjectExtra, class file needed by ProjectExtra is missing.
[error] reference value internal of package scala.reflect.macros refers to nonexisting symbol.
[error] error while loading ProjectExtra, class file needed by ProjectExtra is missing.
[error] reference value internal of package scala.reflect.macros refers to nonexisting symbol.
[error] error while loading Def, class file needed by Def is missing.
