### PR TITLE
FIX #217 Introduced executableScriptName setting

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemd/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemd/start-debian-template
@@ -5,7 +5,7 @@ Requires=${{start_facilities}}
 [Service]
 Type=simple
 WorkingDirectory=${{chdir}}
-ExecStart=${{chdir}}/bin/${{app_name}}
+ExecStart=${{chdir}}/bin/${{exec}}
 Restart=always
 RestartSec=${{retryTimeout}}
 

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemd/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemd/start-rpm-template
@@ -5,7 +5,7 @@ Requires=${{start_facilities}}
 [Service]
 Type=simple
 WorkingDirectory=${{chdir}}
-ExecStart=${{chdir}}/bin/${{app_name}}
+ExecStart=${{chdir}}/bin/${{exec}}
 Restart=always
 RestartSec=${{retryTimeout}}
 

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-debian-template
@@ -20,7 +20,7 @@ if [ -z "$DAEMON_USER" ]; then
 fi
 
 
-RUN_CMD="${{chdir}}/bin/${{app_name}}"
+RUN_CMD="${{chdir}}/bin/${{exec}}"
 
 
 start_daemon() {

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/start-rpm-template
@@ -28,7 +28,7 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-prog="${{app_name}}"
+prog="${{exec}}"
 
 # FIXME The pid file should be handled by the executed script
 # The pid can be filled in in this script

--- a/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala
@@ -30,7 +30,8 @@ object SbtNativePackager extends Plugin
       NativePackagerKeys.maintainer := "",
       NativePackagerKeys.packageDescription := "",
       NativePackagerKeys.packageSummary := "",
-      packageName <<= normalizedName
+      NativePackagerKeys.packageName <<= normalizedName,
+      NativePackagerKeys.executableScriptName <<= NativePackagerKeys.packageName
     )
 
   import SettingsHelper._

--- a/src/main/scala/com/typesafe/sbt/packager/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Keys.scala
@@ -12,6 +12,7 @@ object Keys extends linux.Keys
 
   // These keys are used by the JavaApp/JavaServer archetypes.
   val packageName = SettingKey[String]("packageName", "Name of the created output package. Used for dirs/scripts.")
+  val executableScriptName = SettingKey[String]("executableScriptName", "Name of the executing script.")
   val makeBashScript = TaskKey[Option[File]]("makeBashScript", "Creates or discovers the bash script used by this project.")
   val bashScriptDefines = TaskKey[Seq[String]]("bashScriptDefines", "A list of definitions that should be written to the bash file template.")
   val bashScriptExtraDefines = TaskKey[Seq[String]]("bashScriptExtraDefines", "A list of extra definitions that should be written to the bash file template.")

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -4,7 +4,7 @@ package debian
 
 import Keys._
 import sbt._
-import sbt.Keys.{ target, name, normalizedName, TaskStreams }
+import sbt.Keys.{ target, name, TaskStreams }
 import linux.{ LinuxFileMetaData, LinuxPackageMapping, LinuxSymlink }
 import linux.Keys.{ linuxScriptReplacements, daemonShell }
 import com.typesafe.sbt.packager.Hashing
@@ -28,6 +28,7 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin with NativePackaging wi
     target in Debian <<= (target, name in Debian, version in Debian) apply ((t, n, v) => t / (n + "-" + v)),
     name in Debian <<= (name in Linux),
     packageName in Debian <<= (packageName in Linux),
+    executableScriptName in Debian <<= (executableScriptName in Linux),
     version in Debian <<= (version in Linux),
     linuxPackageMappings in Debian <<= linuxPackageMappings,
     packageDescription in Debian <<= packageDescription in Linux,

--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -48,6 +48,7 @@ object Keys extends DebianKeys {
   // Metadata keys
   def name = sbt.Keys.name
   def packageName = linux.Keys.packageName
+  def executableScriptName = linux.Keys.executableScriptName
   def version = sbt.Keys.version
   def maintainer = linux.Keys.maintainer
   def packageArchitecture = linux.Keys.packageArchitecture

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -21,7 +21,7 @@ object Keys extends DockerKeys {
   def mappings = sbt.Keys.mappings
   def name = sbt.Keys.name
   def packageName = universal.Keys.packageName
-  def normalizedName = universal.Keys.normalizedName
+  def executableScriptName = universal.Keys.executableScriptName
   def stage = universal.Keys.stage
   def publish = sbt.Keys.publish
   def publishArtifact = sbt.Keys.publishArtifact

--- a/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
@@ -49,6 +49,6 @@ trait Keys {
 object Keys extends Keys {
   def name = sbt.Keys.name
   def packageName = packager.Keys.packageName
-  def normalizedName = sbt.Keys.normalizedName
+  def executableScriptName = packager.Keys.executableScriptName
   def sourceDirectory = sbt.Keys.sourceDirectory
 }

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
@@ -36,8 +36,8 @@ trait LinuxPlugin extends Plugin {
     packageDescription in Linux <<= packageDescription,
     name in Linux <<= name,
     packageName in Linux <<= packageName,
-    normalizedName in Linux <<= (name in Linux) apply Project.normalizeModuleID,
-    daemonUser in Linux <<= normalizedName in Linux,
+    executableScriptName in Linux <<= executableScriptName,
+    daemonUser in Linux <<= packageName in Linux,
     daemonGroup in Linux <<= daemonUser in Linux,
     daemonShell in Linux := "/bin/false",
     defaultLinuxInstallLocation := "/usr/share",
@@ -47,16 +47,17 @@ trait LinuxPlugin extends Plugin {
     linuxJavaAppStartScriptBuilder := JavaAppStartScript.Debian,
     // This one is begging for sbt 0.13 syntax...
     linuxScriptReplacements <<= (
-      maintainer in Linux, packageSummary in Linux, daemonUser in Linux, daemonGroup in Linux, daemonShell in Linux, normalizedName in Linux,
+      maintainer in Linux, packageSummary in Linux, daemonUser in Linux, daemonGroup in Linux, daemonShell in Linux,
+      packageName in Linux, executableScriptName in Linux,
       sbt.Keys.version, defaultLinuxInstallLocation, linuxJavaAppStartScriptBuilder)
-      apply { (author, descr, daemonUser, daemonGroup, daemonShell, name, version, installLocation, builder) =>
+      apply { (author, descr, daemonUser, daemonGroup, daemonShell, name, execScript, version, installLocation, builder) =>
         val appDir = installLocation + "/" + name
 
         // TODO Making replacements should be done somewhere else. Maybe TemplateWriter
         builder.makeReplacements(
           author = author,
           description = descr,
-          execScript = name,
+          execScript = execScript,
           chdir = appDir,
           appName = name,
           daemonUser = daemonUser,

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
@@ -62,7 +62,7 @@ object Keys extends RpmKeys {
   // METADATA keys.
   def name = sbt.Keys.name
   def packageName = packager.Keys.packageName
-  def normalizedName = sbt.Keys.normalizedName
+  def executableScriptName = linux.Keys.executableScriptName
   def version = sbt.Keys.version
   def maintainer = linux.Keys.maintainer
   def packageArchitecture = linux.Keys.packageArchitecture

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -46,9 +46,9 @@ trait RpmPlugin extends Plugin with LinuxPlugin {
     packageDescription in Rpm <<= packageDescription in Linux,
     target in Rpm <<= target(_ / "rpm"),
     name in Rpm <<= name in Linux,
-    packageName in Rpm <<= packageName in Linux
+    packageName in Rpm <<= packageName in Linux,
+    executableScriptName in Rpm <<= executableScriptName in Linux
   ) ++ inConfig(Rpm)(Seq(
-      normalizedName <<= name apply Project.normalizeModuleID,
       packageArchitecture := "noarch",
       rpmMetadata <<=
         (packageName, version, rpmRelease, rpmPrefix, packageArchitecture, rpmVendor, rpmOs, packageSummary, packageDescription, rpmAutoprov, rpmAutoreq) apply RpmMetadata,

--- a/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
@@ -20,7 +20,7 @@ object Keys extends UniversalKeys {
   def packageDoc = sbt.Keys.packageDoc
   def name = sbt.Keys.name
   def packageName = packager.Keys.packageName
-  def normalizedName = sbt.Keys.normalizedName
+  def executableScriptName = packager.Keys.executableScriptName
   def target = sbt.Keys.target
   def sourceDirectory = sbt.Keys.sourceDirectory
   def streams = sbt.Keys.streams

--- a/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
@@ -25,7 +25,8 @@ trait UniversalPlugin extends Plugin {
       name in Universal <<= name,
       name in UniversalDocs <<= name in Universal,
       name in UniversalSrc <<= name in Universal,
-      packageName in Universal <<= packageName
+      packageName in Universal <<= packageName,
+      executableScriptName in Universal <<= executableScriptName
     ) ++
       makePackageSettingsForConfig(Universal) ++
       makePackageSettingsForConfig(UniversalDocs) ++
@@ -38,7 +39,6 @@ trait UniversalPlugin extends Plugin {
       makePackageSettings(packageZipTarball, config)(makeTgz) ++
       makePackageSettings(packageXzTarball, config)(makeTxz) ++
       inConfig(config)(Seq(
-        normalizedName <<= name apply Project.normalizeModuleID,
         packageName <<= (packageName, version) apply (_ + "-" + _),
         mappings <<= sourceDirectory map findSources,
         dist <<= (packageBin, streams) map printDist,

--- a/src/main/scala/com/typesafe/sbt/packager/windows/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/windows/Keys.scala
@@ -14,7 +14,7 @@ trait WindowsKeys {
   val wixProductConfig = TaskKey[xml.Node]("wix-product-xml", "The WIX XML configuration for a product (nested in Wix/Product elements).")
   val wixConfig = TaskKey[xml.Node]("wix-xml", "The WIX XML configuration for this package.")
   val wixFile = TaskKey[File]("wix-file", "The WIX XML file to package with.")
-  @deprecated("use packageBin instead!")
+  @deprecated("use packageBin instead!", "0.7.0")
   val packageMsi = TaskKey[File]("package-msi", "creates a new windows CAB file containing everything for the installation.")
   val candleOptions = SettingKey[Seq[String]]("candle-options", "Options to pass to the candle.exe program.")
   val lightOptions = SettingKey[Seq[String]]("light-options", "Options to pass to the light.exe program.")
@@ -25,11 +25,12 @@ object Keys extends WindowsKeys {
   def target = sbt.Keys.target
   def mappings = sbt.Keys.mappings
   def name = sbt.Keys.name
+  def packageName = packager.Keys.packageName
+  def executableScriptName = packager.Keys.executableScriptName
   def streams = sbt.Keys.streams
   def sourceDirectory = sbt.Keys.sourceDirectory
   def packageBin = sbt.Keys.packageBin
-  // TODO - move this somewhere generic.
-  def maintainer = linux.Keys.maintainer
-  def packageSummary = linux.Keys.packageSummary
-  def packageDescription = linux.Keys.packageDescription
+  def maintainer = packager.Keys.maintainer
+  def packageSummary = packager.Keys.packageSummary
+  def packageDescription = packager.Keys.packageDescription
 }

--- a/src/main/scala/com/typesafe/sbt/packager/windows/WindowsPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/windows/WindowsPlugin.scala
@@ -4,6 +4,7 @@ package windows
 
 import Keys._
 import sbt._
+import sbt.Keys.{ normalizedName }
 
 trait WindowsPlugin extends Plugin {
   val Windows = config("windows")
@@ -13,6 +14,7 @@ trait WindowsPlugin extends Plugin {
     target in Windows <<= target apply (_ / "windows"),
     // TODO - Should this use normalized name like the linux guys?
     name in Windows <<= name,
+    packageName in Windows <<= normalizedName,
     // Defaults so that our simplified building works
     candleOptions := Seq("-ext", "WixUtilExtension"),
     lightOptions := Seq("-ext", "WixUIExtension",

--- a/src/sbt-test/debian/test-executableScriptName/build.sbt
+++ b/src/sbt-test/debian/test-executableScriptName/build.sbt
@@ -1,0 +1,29 @@
+import NativePackagerKeys._
+
+packagerSettings
+
+packageArchetype.java_server
+
+name := "debian-test"
+
+executableScriptName := "debian-exec"
+
+version := "0.1.0"
+
+maintainer := "Josh Suereth <joshua.suereth@typesafe.com>"
+
+packageSummary := "Test debian package"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+debianPackageDependencies in Debian ++= Seq("java2-runtime", "bash (>= 2.05a-11)")
+
+debianPackageRecommends in Debian += "git"
+
+TaskKey[Unit]("check-upstart-script") <<= (target, streams) map { (target, out) =>
+  val script = IO.read(target / "debian-test-0.1.0" / "etc" / "init" / "debian-test.conf")
+  assert(script.contains("exec ./bin/debian-exec"), "wrong exec call\n" + script)
+  out.log.success("Successfully tested control script")
+  ()
+}

--- a/src/sbt-test/debian/test-executableScriptName/project/plugins.sbt
+++ b/src/sbt-test/debian/test-executableScriptName/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/debian/test-executableScriptName/src/main/scala/test/Main.scala
+++ b/src/sbt-test/debian/test-executableScriptName/src/main/scala/test/Main.scala
@@ -1,0 +1,10 @@
+package test
+
+object Main {
+  def main (args: Array[String]) {
+    //server app imitation
+    while (true){
+      Thread.sleep(1000L)
+    }
+  }
+}

--- a/src/sbt-test/debian/test-executableScriptName/test
+++ b/src/sbt-test/debian/test-executableScriptName/test
@@ -1,0 +1,18 @@
+# Run the debian packaging.
+> debian:package-bin
+$ exists target/debian-test_0.1.0_all.deb
+# Testing the packageName configuration
+$ exists target/debian-test-0.1.0/DEBIAN
+$ exists target/debian-test-0.1.0/DEBIAN/control
+# --------------------------------------------
+$ exists target/debian-test-0.1.0/usr/
+$ exists target/debian-test-0.1.0/usr/share/
+$ exists target/debian-test-0.1.0/usr/share/debian-test/
+$ exists target/debian-test-0.1.0/usr/share/debian-test/bin/
+$ exists target/debian-test-0.1.0/usr/share/debian-test/bin/debian-exec
+$ exists target/debian-test-0.1.0/var/log/debian-test/
+$ exists target/debian-test-0.1.0/var/run/debian-test/
+$ exists target/debian-test-0.1.0/etc/default/debian-test/
+# --------------------------------------------
+$ exists target/debian-test-0.1.0/etc/init/debian-test.conf
+> check-upstart-script

--- a/src/sbt-test/docker/test-executableScriptName/build.sbt
+++ b/src/sbt-test/docker/test-executableScriptName/build.sbt
@@ -1,0 +1,21 @@
+import com.typesafe.sbt.SbtNativePackager._
+import NativePackagerKeys._
+
+packageArchetype.java_application
+
+name := "docker-test"
+
+packageName in Docker := "docker-package"
+
+executableScriptName := "docker-exec"
+
+version := "0.1.0"
+
+maintainer := "Gary Coady <gary@lyranthe.org>"
+
+TaskKey[Unit]("check-dockerfile") <<= (target, streams) map { (target, out) =>
+  val dockerfile = IO.read(target / "docker" / "Dockerfile")
+  assert(dockerfile.contains("ENTRYPOINT [\"bin/docker-exec\"]\n"), "dockerfile doesn't contain ENTRYPOINT [\"docker-exec\"]\n" + dockerfile)
+  out.log.success("Successfully tested control script")
+  ()
+}

--- a/src/sbt-test/docker/test-executableScriptName/project/plugins.sbt
+++ b/src/sbt-test/docker/test-executableScriptName/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/test-executableScriptName/src/main/scala/Main.scala
+++ b/src/sbt-test/docker/test-executableScriptName/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}

--- a/src/sbt-test/docker/test-executableScriptName/test
+++ b/src/sbt-test/docker/test-executableScriptName/test
@@ -1,0 +1,6 @@
+# Generate the Docker image locally
+> docker:publishLocal
+$ exists target/docker/Dockerfile
+$ exists target/docker/files/opt/docker/bin/docker-exec
+> check-dockerfile
+$ exec bash -c 'docker run docker-package:0.1.0 | grep -q "Hello world"'

--- a/src/sbt-test/rpm/test-executableScriptName/build.sbt
+++ b/src/sbt-test/rpm/test-executableScriptName/build.sbt
@@ -1,0 +1,49 @@
+import NativePackagerKeys._
+
+packageArchetype.java_server
+
+name := "rpm-test"
+
+version := "0.1.0"
+
+maintainer := "Josh Suereth <joshua.suereth@typesafe.com>"
+
+packageSummary := "Test rpm package"
+
+executableScriptName := "rpm-exec"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+rpmRelease := "1"
+
+rpmVendor := "typesafe"
+
+rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
+
+rpmLicense := Some("BSD")
+
+TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
+  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
+  out.log.success(spec)
+  assert(spec contains "%attr(0644,root,root) /usr/share/rpm-test/lib/rpm-test.rpm-test-0.1.0.jar", "Wrong installation path\n" + spec)
+  assert(spec contains "%config %attr(0755,root,root) /etc/init.d/rpm-test", "Wrong /etc/init.d/\n" + spec)
+  assert(spec contains "%config %attr(755,root,root) /etc/default/rpm-test", "Wrong etc default file\n" + spec)
+  assert(spec contains "%dir %attr(755,rpm-test,rpm-test) /var/log/rpm-test", "Wrong logging dir path\n" + spec)
+  assert(spec contains "%dir %attr(755,rpm-test,rpm-test) /var/run/rpm-test", "Wrong /var/run dir path\n" + spec)
+  out.log.success("Successfully tested rpm-test file")
+  ()
+}
+
+TaskKey[Unit]("unzip") <<= (packageBin in Rpm, streams) map { (rpmFile, streams) =>
+  val rpmPath = Seq(rpmFile.getAbsolutePath)
+  Process("rpm2cpio" , rpmPath) #| Process("cpio -i --make-directories") ! streams.log
+  ()
+}
+
+TaskKey[Unit]("checkStartupScript") <<= (target, streams) map { (target, out) =>
+  val script = IO.read(file("etc/init.d/rpm-test"))
+  assert(script contains "rpm-exec", "SystemV script didn't contain correct executable filename 'rpm-exec' \n" + script)
+  out.log.success("Successfully tested startup script start up script")
+  ()
+}

--- a/src/sbt-test/rpm/test-executableScriptName/project/plugins.sbt
+++ b/src/sbt-test/rpm/test-executableScriptName/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/test-executableScriptName/src/main/scala/test/Main.scala
+++ b/src/sbt-test/rpm/test-executableScriptName/src/main/scala/test/Main.scala
@@ -1,0 +1,10 @@
+package test
+
+object Main {
+  def main (args: Array[String]) {
+    //server app imitation
+    while (true){
+      Thread.sleep(1000L)
+    }
+  }
+}

--- a/src/sbt-test/rpm/test-executableScriptName/test
+++ b/src/sbt-test/rpm/test-executableScriptName/test
@@ -1,0 +1,14 @@
+# Run the debian packaging.
+> rpm:package-bin
+$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+$ exists target/rpm/SPECS/rpm-test.spec
+
+# Check files for defaults
+> check-spec-file
+
+> unzip
+# Bootscript != executable Script
+$ exists etc/init.d/rpm-test
+# $ exists usr/share/rpm-test/bin/rpm-exec
+
+> checkStartupScript

--- a/src/sbt-test/rpm/test-packageName/build.sbt
+++ b/src/sbt-test/rpm/test-packageName/build.sbt
@@ -27,12 +27,11 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
   val spec = IO.read(target / "rpm" / "SPECS" / "rpm-package.spec")
   out.log.success(spec)
   assert(spec contains "%attr(0644,root,root) /usr/share/rpm-package/lib/rpm-test.rpm-test-0.1.0.jar", "Wrong installation path\n" + spec)
-  assert(spec contains "%config %attr(0755,root,root) /etc/init.d/rpm-package", "Wrong etc path path\n" + spec)
-  assert(spec contains "%config %attr(755,root,root) /etc/default/rpm-package", "Wrong etc default file\n" + spec)
-  assert(spec contains "%config %attr(0755,root,root) /etc/init.d/rpm-package", "Wrong etc path\n" + spec)
-  assert(spec contains "%dir %attr(755,rpm-test,rpm-test) /var/log/rpm-package", "Wrong logging dir path\n" + spec)
-  assert(spec contains "%dir %attr(755,rpm-test,rpm-test) /var/run/rpm-package", "Wrong /var/run dir path\n" + spec)
-  out.log.success("Successfully tested rpm test file")
+  assert(spec contains "%config %attr(0755,root,root) /etc/init.d/rpm-package", "Wrong /etc/init.d path\n" + spec)
+  assert(spec contains "%config %attr(755,root,root) /etc/default/rpm-package", "Wrong /etc default file\n" + spec)
+  assert(spec contains "%dir %attr(755,rpm-package,rpm-package) /var/log/rpm-package", "Wrong logging dir path\n" + spec)
+  assert(spec contains "%dir %attr(755,rpm-package,rpm-package) /var/run/rpm-package", "Wrong /var/run dir path\n" + spec)
+  out.log.success("Successfully tested rpm-package file")
   ()
 }
 

--- a/src/sbt-test/universal/test-executableScriptName/build.sbt
+++ b/src/sbt-test/universal/test-executableScriptName/build.sbt
@@ -1,0 +1,14 @@
+import NativePackagerKeys._
+
+packageArchetype.java_application
+
+name := "simple-test"
+
+executableScriptName := "simple-exec"
+
+version := "0.1.0"
+
+TaskKey[Unit]("unzip") <<= (packageBin in Universal, streams) map { (zipFile, streams) =>
+    val args = Seq(zipFile.getAbsolutePath)
+    Process("unzip", args) !  streams.log
+}

--- a/src/sbt-test/universal/test-executableScriptName/project/plugins.sbt
+++ b/src/sbt-test/universal/test-executableScriptName/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/universal/test-executableScriptName/src/main/scala/Main.scala
+++ b/src/sbt-test/universal/test-executableScriptName/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}

--- a/src/sbt-test/universal/test-executableScriptName/test
+++ b/src/sbt-test/universal/test-executableScriptName/test
@@ -1,0 +1,6 @@
+# Run the zip packaging.
+> show universal:package-bin
+$ exists target/universal/simple-test-0.1.0.zip
+> unzip
+$ exists simple-test-0.1.0/bin/
+$ exists simple-test-0.1.0/bin/simple-exec

--- a/test-project/build.sbt
+++ b/test-project/build.sbt
@@ -25,6 +25,10 @@ debianPackageDependencies in Debian ++= Seq("java2-runtime", "bash (>= 2.05a-11)
 
 debianPackageRecommends in Debian += "git"
 
+rpmVendor := "typesafe"
+
+rpmLicense := Some("BSD")
+
 //debianMakePrermScript := Some(sourceDirectory.value / "deb" / "control" / "prerm") //change defaults
 
 


### PR DESCRIPTION
Adding `executableScriptName` to customize the executable script file.
This setting is not scope in any way and only affects the file under `bin/<exec>`.
