### PR TITLE
Correct key to "Docker" so the example works out of the box

### DIFF
--- a/GettingStartedServers/MyFirstProject.html
+++ b/GettingStartedServers/MyFirstProject.html
@@ -250,7 +250,7 @@ ends with <em>success</em> you are fine.</p>
 <div class="section" id="docker">
 <h2>Docker<a class="headerlink" href="#docker" title="Permalink to this headline">¶</a></h2>
 <p>A basic <tt class="docutils literal"><span class="pre">build.sbt</span></tt> for Docker requires the <tt class="docutils literal"><span class="pre">linux.Keys.maintainer</span></tt> setting:</p>
-<div class="highlight-scala"><div class="highlight"><pre><span class="n">maintainer</span> <span class="n">in</span> <span class="nc">Linux</span> <span class="o">:=</span> <span class="s">&quot;John Smith &lt;john.smith@example.com&gt;&quot;</span>
+<div class="highlight-scala"><div class="highlight"><pre><span class="n">maintainer</span> <span class="n">in</span> <span class="nc">Docker</span> <span class="o">:=</span> <span class="s">&quot;John Smith &lt;john.smith@example.com&gt;&quot;</span>
 </pre></div>
 </div>
 <p>There are a number of other available settings:</p>


### PR DESCRIPTION
If this example, "Maintainer" in the Dockerfile will be empty and the image will fail to build.
