### PR TITLE
Fix RPM System User Deletion on Upgrade

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemd/postun-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemd/postun-rpm-template
@@ -1,12 +1,18 @@
 # Removing system user/group : ${{daemon_user}} and ${{daemon_group}}
-echo "Try deleting system user and group [${{daemon_user}}:${{daemon_group}}]"
-if getent passwd | grep -q "^${{daemon_user}}:"; 
+
+# Scriptlet syntax: http://fedoraproject.org/wiki/Packaging:ScriptletSnippets#Syntax
+# $1 == 1 is upgrade and $1 == 0 is uninstall
+if [[ $1 == 0 ]]
 then
-    echo "Deleting system user: ${{daemon_user}}"
-    userdel ${{daemon_user}}
-fi
-if getent group | grep -q "^${{daemon_group}}:" ;
-then
-    echo "Deleting system group: ${{daemon_group}}"
-    groupdel ${{daemon_group}}
+    echo "Try deleting system user and group [${{daemon_user}}:${{daemon_group}}]"
+    if getent passwd | grep -q "^${{daemon_user}}:";
+    then
+        echo "Deleting system user: ${{daemon_user}}"
+        userdel ${{daemon_user}}
+    fi
+    if getent group | grep -q "^${{daemon_group}}:" ;
+    then
+        echo "Deleting system group: ${{daemon_group}}"
+        groupdel ${{daemon_group}}
+    fi
 fi

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/postun-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemv/postun-rpm-template
@@ -1,12 +1,18 @@
 # Removing system user/group : ${{daemon_user}} and ${{daemon_group}}
-echo "Try deleting system user and group [${{daemon_user}}:${{daemon_group}}]"
-if getent passwd | grep -q "^${{daemon_user}}:"; 
+
+# Scriptlet syntax: http://fedoraproject.org/wiki/Packaging:ScriptletSnippets#Syntax
+# $1 == 1 is upgrade and $1 == 0 is uninstall
+if [[ $1 == 0 ]]
 then
-    echo "Deleting system user: ${{daemon_user}}"
-    userdel ${{daemon_user}}
-fi
-if getent group | grep -q "^${{daemon_group}}:" ;
-then
-    echo "Deleting system group: ${{daemon_group}}"
-    groupdel ${{daemon_group}}
+    echo "Try deleting system user and group [${{daemon_user}}:${{daemon_group}}]"
+    if getent passwd | grep -q "^${{daemon_user}}:";
+    then
+        echo "Deleting system user: ${{daemon_user}}"
+        userdel ${{daemon_user}}
+    fi
+    if getent group | grep -q "^${{daemon_group}}:" ;
+    then
+        echo "Deleting system group: ${{daemon_group}}"
+        groupdel ${{daemon_group}}
+    fi
 fi


### PR DESCRIPTION
This is an extension to this [commit](https://github.com/sbt/sbt-native-packager/commit/f0ead4a032399f8f04dcf49bc5fa2e6331d0f18c) to fix the RPM upgrade problem.

I've been having problems with my system user being deleted on an RPM upgrade. So I dug deeper and i found this problem:

``` bash
$ rpm -qp --scripts  myrpm.noarch.rpm
... (stripped out unrelated stuff) ...
postuninstall scriptlet (using /bin/sh):
# Removing system user/group : XXX and XXX
echo "Try deleting system user and group [XXX:XXX]"
if getent passwd | grep -q "^XXX:"; 
then
    echo "Deleting system user: XXX"
    userdel XXX
fi
if getent group | grep -q "^XXX:" ;
then
    echo "Deleting system group: XXX"
    groupdel XXX
fi
```

So I copied the [postuninstall](https://github.com/sbt/sbt-native-packager/blob/8c0877d03cb42a1bcc38e2a89ec2dc6c3344fcd3/src/main/resources/com/typesafe/sbt/packager/rpm/postuninstall) into my project's /src/rpm/scriptlets/postun-rpm and the problem resolved itself.

It feels strange that there's multiple copies of the same script; I'm guessing some clean up will need to be done. Anyhow, here's a pull request that should fix the problem for the time being.

Thanks!
