### PR TITLE
Fixed wrong archive name in jdeb packaging

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -252,6 +252,15 @@ trait DebianPlugin extends Plugin with linux.LinuxPlugin with NativePackaging wi
       case (scr, _) => scr.toSeq.map(_ -> scriptName)
     }
   }
+
+  private[debian] def archiveFilename(appName: String, version: String, arch: String): String = {
+    appName + "_" + version + "_" + arch + ".deb"
+  }
+
+  private[debian] def changesFilename(appName: String, version: String, arch: String): String = {
+    appName + "_" + version + "_" + arch + ".changes"
+  }
+
 }
 
 /**

--- a/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
@@ -37,12 +37,13 @@ trait JDebPackaging { this: DebianPlugin with linux.LinuxPlugin =>
      */
     debianJDebPackaging <<= (debianExplodedPackage, linuxPackageMappings, linuxPackageSymlinks,
       debianControlFile, debianMaintainerScripts, debianConffilesFile,
-      normalizedName, version, target, streams) map {
+      normalizedName, version, packageArchitecture, target, streams) map {
         (_, mappings, symlinks, controlfile, controlscripts, conffile,
-        name, version, target, s) =>
+        name, version, arch, target, s) =>
           s.log.info("Building debian package with java based implementation 'jdeb'")
           val console = new JDebConsole(s.log)
-          val debianFile = target.getParentFile / "%s_%s_all.deb".format(name, version)
+          val archive = archiveFilename(name, version, arch)
+          val debianFile = target.getParentFile / archive
           val debMaker = new DebMaker(console,
             fileAndDirectoryProducers(mappings, target) ++ linkProducers(symlinks),
             conffileProducers()

--- a/src/main/scala/com/typesafe/sbt/packager/debian/NativePackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/NativePackaging.scala
@@ -70,7 +70,7 @@ trait NativePackaging { this: DebianPlugin with linux.LinuxPlugin =>
       (pkgdir, _, section, priority, name, version, arch, tdir, s) =>
         s.log.info("Building debian package with native implementation")
         // Make the package.  We put this in fakeroot, so we can build the package with root owning files.
-        val archive = name + "_" + version + "_" + arch + ".deb"
+        val archive = archiveFilename(name, version, arch)
         Process(Seq("fakeroot", "--", "dpkg-deb", "--build", pkgdir.getAbsolutePath, "../" + archive), Some(tdir)) ! s.log match {
           case 0 => ()
           case x => sys.error("Failure packaging debian file.  Exit code: " + x)


### PR DESCRIPTION
Jdeb packagind don't use packageArchitecture while generating debian archive filename.
