### PR TITLE
Added support for classifiers in multiproject builds

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
@@ -189,7 +189,7 @@ object JavaAppPackaging {
           case (Some(l), Some(r)) =>
             // TODO - extra attributes and stuff for comparison?
             // seems to break stuff if we do...
-            (l.name == r.name)
+            l.name == r.name && l.classifier == r.classifier
           case _ => false
         }
       }

--- a/src/sbt-test/universal/multiproject-classifiers/project/Build.scala
+++ b/src/sbt-test/universal/multiproject-classifiers/project/Build.scala
@@ -1,0 +1,54 @@
+import sbt._
+import Keys._
+import com.typesafe.sbt.SbtNativePackager._
+
+object MutliBuild extends Build {
+  
+  val appVersion = "1.0"
+    
+  val mySettings: Seq[Setting[_]] =
+    packageArchetype.java_application ++
+    Seq(
+      organization := "org.test",
+      version := appVersion,
+      TaskKey[Unit]("show-files") <<= (name, target, streams) map { (n, t, s) =>
+        System.out.synchronized {
+          println("Files in ["+n+"]")
+          val files = (t / "universal/stage").***.get
+          files foreach println
+        }
+      }
+    )
+
+  val assets = config("assets")
+
+  lazy val sub = (
+    Project("sub", file("sub"))
+    settings(mySettings:_*)
+    settings(
+      ivyConfigurations += assets,
+      artifact in assets := artifact.value.copy(classifier = Some("assets")),
+      packagedArtifacts += {
+        val file = target.value / "assets.jar"
+        val assetsDir = baseDirectory.value / "src" / "main" / "assets"
+        val sources = assetsDir.***.filter(_.isFile) pair relativeTo(assetsDir)
+        IO.zip(sources, file)
+        (artifact in assets).value -> file
+      },
+      exportedProducts in assets := {
+        Seq(
+          Attributed.blank(baseDirectory.value / "src" / "main" / "assets")
+            .put(artifact.key, (artifact in assets).value)
+            .put(AttributeKey[ModuleID]("module-id"), projectID.value)
+        )
+      }
+    )
+  )
+ 
+  lazy val root = (
+    Project("root", file("."))
+    settings(mySettings:_*)
+  	dependsOn(sub % "compile->compile;compile->assets")
+  )
+
+}

--- a/src/sbt-test/universal/multiproject-classifiers/project/plugins.sbt
+++ b/src/sbt-test/universal/multiproject-classifiers/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/universal/multiproject-classifiers/sub/src/main/assets/foo.css
+++ b/src/sbt-test/universal/multiproject-classifiers/sub/src/main/assets/foo.css
@@ -1,0 +1,1 @@
+h1 { color: blue; }

--- a/src/sbt-test/universal/multiproject-classifiers/test
+++ b/src/sbt-test/universal/multiproject-classifiers/test
@@ -1,0 +1,5 @@
+# Run the staging and check the script.
+> stage
+> show-files
+$ exists target/universal/stage/lib/org.test.sub-1.0.jar
+$ exists target/universal/stage/lib/org.test.sub-1.0-assets.jar


### PR DESCRIPTION
If one project has two dependencies on another project for different classifiers in that project, this ensures that both dependencies are included.
