### PR TITLE
change plugin version to 0.7.5-RC1 in documentation 

### DIFF
--- a/src/sphinx/GettingStartedApplications/MyFirstProject.rst
+++ b/src/sphinx/GettingStartedApplications/MyFirstProject.rst
@@ -11,7 +11,7 @@ and documents to users which version of sbt you require for the build.
 
 Next, let's add the native packager to our build by created a ``project/plugins.sbt`` file with the following contents ::
 
-    addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.1")
+    addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "0.7.5-RC1")
 
 Now, the build needs to be configured for packaging.  Let's define the ``build.sbt`` file as follows
 


### PR DESCRIPTION
The README on github shows 0.7.5-RC1. Later in the documentation, the debianJDebPackaging plugin for cross platform debian builds is mentioned, which only seems to work on 0.7.5-RC1.
