### PR TITLE
Include configurations when locating real dependency

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
@@ -189,7 +189,7 @@ object JavaAppPackaging {
           case (Some(l), Some(r)) =>
             // TODO - extra attributes and stuff for comparison?
             // seems to break stuff if we do...
-            (l.name == r.name)
+            (l.name == r.name && l.configurations == r.configurations)
           case _ => false
         }
       }


### PR DESCRIPTION
This adds an extra field to compare when resolving the real dependency from the project artifacts.

Whilst converting a project to use sbt-native-packager I found that a sub-project dependency projectB was picking up projectB-tests.jar instead of projectB.jar. This then caused the app to fail as the sub-project was missing. This change fixes it for me by ensuring that when it is looking for the compile artifact it doesn't inadvertantly pick up the test artifact by virtue of it being first in the list of project artifacts during this search.

This may not be the correct solution - I note that there is a comment that adding extra attributes `seems to break stuff` - but it works for me like this and I'd very much like this or an equivalent fix merged. Alternatively, please advise if you believe my build is somehow broken and it is that which causes the test jars to be included in the project artifacts.

Thanks!
