### PR TITLE
Add Docker tests execution on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: scala
 os:
   - linux
 script:
-  - sbt ++$TRAVIS_SCALA_VERSION "scripted rpm/* debian/* universal/*"
+  - sbt ++$TRAVIS_SCALA_VERSION "scripted rpm/* debian/* universal/* docker/*"
 scala:
   - 2.10.3
 jdk:

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -110,7 +110,7 @@ trait DockerPlugin extends Plugin with UniversalPlugin {
       val name = tag.substring(0, tag.lastIndexOf(":")) + ":latest"
       val latestCmd = Seq("docker", "tag", tag, name)
       Process(latestCmd).! match {
-        case 0 => log.info("Update Latest from image" + tag)
+        case 0 => log.info("Update latest from image " + tag)
         case n => sys.error("Failed to run docker tag")
       }
     }


### PR DESCRIPTION
Automated testing of Docker capabilities isn't currently checked on Travis CI.

May need to install Docker before on Travis CI (in the `install` step).

There is a working example that can be found on Github: https://github.com/lukecyca/travis-docker-example

For the record Docker tests are passing locally on my OS X laptop:
```
...
Running docker / simple-docker
Running docker / staging
Running docker / test-executableScriptName
Running docker / test-packageName
Running docker / test-packageName-universal
Running docker / update-latest
Running docker / volumes
[success] Total time: 114 s, completed Sep 17, 2014 2:54:33 PM
```