### PR TITLE
Handles OpenJDK version output on Windows

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bat-template
@@ -42,7 +42,8 @@ if "%_JAVACMD%"=="" set _JAVACMD=java
 
 rem Detect if this java is ok to use.
 for /F %%j in ('"%_JAVACMD%" -version  2^>^&1') do (
-  if %%~j==Java set JAVAINSTALLED=1
+  if %%~j==java set JAVAINSTALLED=1
+  if %%~j==openjdk set JAVAINSTALLED=1
 )
 
 rem BAT has no logical or, so we do it OLD SCHOOL! Oppan Redmond Style


### PR DESCRIPTION
OpenJDK on Windows does not output `java` when `java -version` is issued but instead prints `openjdk` and then the version information. The script expected `java` to work before this fix.
