### PR TITLE
Fix permissions and group for /var/run/${{app_name}} folder in SystemV init script

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -19,13 +19,17 @@ if [ -z "$DAEMON_USER" ]; then
     DAEMON_USER=${{daemon_user}}
 fi
 
+if [ -z "$DAEMON_GROUP" ]; then
+    DAEMON_GROUP=${{daemon_group}}
+fi
+
 
 RUN_CMD="${{chdir}}/bin/${{exec}}"
 
 
 start_daemon() {
     log_daemon_msg "Starting" "${{app_name}}"
-    [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -m750 "/var/run/${{app_name}}"
+    [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -g "$DAEMON_GROUP" -m755 "/var/run/${{app_name}}"
     start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --exec "$RUN_CMD" --start -- $RUN_OPTS
     log_end_msg $?
 }

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -38,6 +38,10 @@ if [ -z "$DAEMON_USER" ]; then
     DAEMON_USER=${{daemon_user}}
 fi
 
+if [ -z "$DAEMON_GROUP" ]; then
+    DAEMON_GROUP=${{daemon_group}}
+fi
+
 
 # smb could define some additional options in $RUN_OPTS
 RUN_CMD="${{chdir}}/bin/${{app_name}}"
@@ -64,7 +68,7 @@ start() {
     [ $retval -eq 0 ] && touch ${lockfile} && success || failure
 
     # Insert pid into pid file for CentOS killproc function
-    [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -m750 "/var/run/${{app_name}}"
+    [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -g "$DAEMON_GROUP" -m755 "/var/run/${{app_name}}"
     echo
     echo $PID > ${PIDFILE}
     return $retval


### PR DESCRIPTION
Fix for issue #381. Tested with Precise32 and Fedora18. 
