### PR TITLE
Setting maintainer for Docker images can be optional.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,8 @@ Any help on testing and improving this feature is appreciated so feel free to re
 
 Native packager now provides experimental `Docker` images.
 To enable this feature follow [My First Packaged Server Project guide](http://www.scala-sbt.org/sbt-native-packager/GettingStartedServers/MyFirstProject.html) and use one of the provided Docker tasks for generating images.
-The only essential extra setting for creating a local image for testing is:
 
-    maintainer in Docker := "John Smith <john.smith@example.com>"
-
-To publish the image, ``dockerRepository`` should also be set.
+To publish the image, ``dockerRepository`` should be set.
 
 As with the `systemd` support, help with testing and improvements is appreciated.
 

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -108,10 +108,14 @@ object DockerPlugin extends AutoPlugin {
     ))
 
   private[this] final def makeDockerContent(dockerBaseImage: String, dockerBaseDirectory: String, maintainer: String, daemonUser: String, execScript: String, exposedPorts: Seq[Int], exposedVolumes: Seq[String]) = {
-    val headerCommands = Seq(
-      Cmd("FROM", dockerBaseImage),
-      Cmd("MAINTAINER", maintainer)
-    )
+    val fromCommand = Cmd("FROM", dockerBaseImage)
+
+    val maintainerCommand: Option[Cmd] = {
+      if (maintainer.isEmpty)
+        None
+      else
+        Some(Cmd("MAINTAINER", maintainer))
+    }
 
     val dockerCommands = Seq(
       Cmd("ADD", "files /"),
@@ -144,7 +148,10 @@ object DockerPlugin extends AutoPlugin {
         )
     }
 
-    Dockerfile(headerCommands ++ volumeCommands ++ exposeCommand ++ dockerCommands: _*).makeContent
+    val commands =
+      Seq(fromCommand) ++ maintainerCommand ++ volumeCommands ++ exposeCommand ++ dockerCommands
+
+    Dockerfile(commands: _*).makeContent
   }
 
   private[this] final def generateDockerConfig(


### PR DESCRIPTION
The maintainer line is optional in the Dockerfile. While the initial commit
assumed that it was required, it appears that this is not the case. We
can therefore skip adding the line if the maintainer is not set.
