### PR TITLE
Relocated the scope for common docker settings

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -63,6 +63,8 @@ object DockerPlugin extends AutoPlugin {
 
   override lazy val projectSettings = Seq(
     dockerBaseImage := "dockerfile/java:latest",
+    dockerExposedPorts := Seq(),
+    dockerExposedVolumes := Seq(),
     name in Docker <<= name,
     packageName in Docker <<= packageName,
     executableScriptName in Docker <<= executableScriptName,
@@ -74,8 +76,6 @@ object DockerPlugin extends AutoPlugin {
   ) ++ mapGenericFilesToDocker ++ inConfig(Docker)(Seq(
       daemonUser := "daemon",
       defaultLinuxInstallLocation := "/opt/docker",
-      dockerExposedPorts := Seq(),
-      dockerExposedVolumes := Seq(),
       dockerPackageMappings <<= (sourceDirectory) map { dir =>
         MappingsHelper contentOf dir
       },

--- a/src/sbt-test/docker/ports/build.sbt
+++ b/src/sbt-test/docker/ports/build.sbt
@@ -1,0 +1,7 @@
+enablePlugins(SbtNativePackager)
+
+name := "simple-test"
+
+version := "0.1.0"
+
+dockerExposedPorts := Seq(9000)

--- a/src/sbt-test/docker/ports/project/plugins.sbt
+++ b/src/sbt-test/docker/ports/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/ports/test
+++ b/src/sbt-test/docker/ports/test
@@ -1,0 +1,3 @@
+# Stage the distribution and ensure files show up.
+> docker:stage
+$ exec grep -q -F 'EXPOSE 9000' target/docker/Dockerfile


### PR DESCRIPTION
I found myself forgetting the configuration in `dockerExposedPorts in Docker` and so I thought that the `dockerExposedPorts` and `dockerExposedVolumes` shouldn't need the configuration provided. The other commonly used keys do not e.g. `dockerBaseImage`.

In addition I've provided a scripted test for checking the `EXPOSE` value.
