### PR TITLE
fix too long classpaths in script(bat/bash).

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
@@ -59,17 +59,7 @@ object JavaAppPackaging extends AutoPlugin with JavaAppStartScript {
     scriptClasspathOrdering <++= (Keys.dependencyClasspath in Runtime, projectDependencyArtifacts) map universalDepMappings,
     scriptClasspathOrdering <<= (scriptClasspathOrdering) map { _.distinct },
     mappings in Universal <++= scriptClasspathOrdering,
-    scriptClasspath := {
-      val allClasspath = makeRelativeClasspathNames(scriptClasspathOrdering.value)
-      val manifest = new java.util.jar.Manifest()
-      manifest.getMainAttributes().putValue("Class-Path", allClasspath.mkString(" "))
-      val jarFile = (target in Universal).value / "lib" / "manifest.jar"
-      IO.jar(Seq.empty, jarFile, manifest)
-      Seq((Keys.projectID, Keys.artifact in Compile in Keys.packageBin).map(makeManifestJarName).value)
-    },
-    mappings in Universal += {
-      ((target in Universal).value / "lib" / "manifest.jar") -> ("lib/"+(Keys.projectID, Keys.artifact in Compile in Keys.packageBin).map(makeManifestJarName).value)
-    },
+    scriptClasspath <<= scriptClasspathOrdering map makeRelativeClasspathNames,
     bashScriptExtraDefines := Nil,
     bashScriptConfigLocation <<= bashScriptConfigLocation ?? None,
     bashScriptDefines <<= (Keys.mainClass in Compile, scriptClasspath, bashScriptExtraDefines, bashScriptConfigLocation) map { (mainClass, cp, extras, config) =>
@@ -116,9 +106,6 @@ object JavaAppPackaging extends AutoPlugin with JavaAppStartScript {
       if (name startsWith "lib/") name drop 4
       else "../" + name
     }
-
-  private def makeManifestJarName(id:ModuleID, art:Artifact): String =
-    makeJarName(id.organization, id.name, id.revision, art.name, art.classifier).replaceFirst("\\.jar$","-manifest.jar")
 
   // Constructs a jar name from components...(ModuleID/Artifact)
   private def makeJarName(org: String, name: String, revision: String, artifactName: String, artifactClassifier: Option[String]): String =

--- a/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
@@ -1,0 +1,46 @@
+package com.typesafe.sbt.packager
+package archetypes.jar
+
+import sbt._
+import sbt.Keys.{ mappings, target, name, mainClass, sourceDirectory }
+import com.typesafe.sbt.packager.Keys.{ scriptClasspath }
+import com.typesafe.sbt.SbtNativePackager.{ Universal }
+
+object ClasspathJarPlugin extends AutoPlugin {
+
+  object autoImport {
+    val classspathJarName = TaskKey[String]("classpath-jar-name", "classpath-jar name")
+  }
+  import autoImport._
+
+  override def requires = archetypes.JavaAppPackaging
+
+  override lazy val projectSettings = Seq[Setting[_]](
+    classspathJarName <<= (Keys.packageBin in Compile, Keys.projectID, Keys.artifact in Compile in Keys.packageBin) map { (jar, id, art) =>
+      makeJarName(id.organization, id.name, id.revision, art.name, art.classifier)
+    },
+    mappings in Universal += {
+      ((target in Universal).value / "lib" / classspathJarName.value) -> ("lib/" + classspathJarName.value)
+    },
+    scriptClasspath := {
+      writeJar((target in Universal).value / "lib" / classspathJarName.value, scriptClasspath.value)
+      Seq(classspathJarName.value)
+    }
+  )
+
+  // Constructs a jar name from components...(ModuleID/Artifact)
+  private def makeJarName(org: String, name: String, revision: String, artifactName: String, artifactClassifier: Option[String]): String =
+    (org + "." +
+      name + "-" +
+      Option(artifactName.replace(name, "")).filterNot(_.isEmpty).map(_ + "-").getOrElse("") +
+      revision +
+      artifactClassifier.filterNot(_.isEmpty).map("-" + _).getOrElse("") +
+      "-classpath.jar")
+
+  /** write jar file */
+  private def writeJar(jarFile: File, allClasspath: Seq[String]) = {
+    val manifest = new java.util.jar.Manifest()
+    manifest.getMainAttributes().putValue("Class-Path", allClasspath.mkString(" "))
+    IO.jar(Seq.empty, jarFile, manifest)
+  }
+}

--- a/src/sbt-test/jar/classpath-jar/build.sbt
+++ b/src/sbt-test/jar/classpath-jar/build.sbt
@@ -1,0 +1,29 @@
+enablePlugins(ClasspathJarPlugin)
+
+name := "classpath-jar-test"
+
+version := "0.1.0"
+
+// test dependencies sample
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-kernel" % "2.3.4"
+)
+
+TaskKey[Unit]("check-classspath") := { 
+  val dir = (stagingDirectory in Universal).value
+  val bat = IO.read(dir / "bin" / "classpath-jar-test.bat")
+  assert(bat contains "set \"APP_CLASSPATH=%APP_LIB_DIR%\\classpath-jar-test.classpath-jar-test-0.1.0-classpath.jar\"")
+  val jar = new java.util.jar.JarFile(dir / "lib" / "classpath-jar-test.classpath-jar-test-0.1.0-classpath.jar")
+  assert(jar.getManifest().getMainAttributes().getValue("Class-Path").toString() contains "com.typesafe.akka.akka-actor")
+  jar close
+}
+
+TaskKey[Unit]("run-check") := { 
+  val dir = (stagingDirectory in Universal).value
+  val cmd = if(System.getProperty("os.name").contains("Windows")){
+    Seq("cmd", "/c", (dir / "bin" / "classpath-jar-test.bat").getAbsolutePath)
+  }else{
+    Seq((dir / "bin" / "classpath-jar-test").getAbsolutePath)
+  }
+  assert(Process(cmd).!! contains "SUCCESS!")
+}

--- a/src/sbt-test/jar/classpath-jar/project/plugins.sbt
+++ b/src/sbt-test/jar/classpath-jar/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/jar/classpath-jar/src/main/scala/test/Test.scala
+++ b/src/sbt-test/jar/classpath-jar/src/main/scala/test/Test.scala
@@ -1,0 +1,19 @@
+package test
+
+// use dependency library
+
+import akka.actor._
+import akka.routing.RoundRobinRouter
+
+class PrintActor extends Actor{
+  def receive = {
+    case msg => println(msg)
+  }
+}
+
+object Test extends App {
+  val system = ActorSystem("testSystem")
+  val router = system.actorOf(Props[PrintActor])
+  router ! "SUCCESS!!"
+  system.shutdown
+}

--- a/src/sbt-test/jar/classpath-jar/src/templates/bat-template
+++ b/src/sbt-test/jar/classpath-jar/src/templates/bat-template
@@ -1,0 +1,21 @@
+@echo off
+rem this template is minimal for test independent
+
+@setlocal enabledelayedexpansion
+@echo off
+
+set "@@APP_ENV_NAME@@_HOME=%~dp0\\.."
+
+set "APP_LIB_DIR=%@@APP_ENV_NAME@@_HOME%\lib\"
+
+set _JAVACMD=%JAVACMD%
+
+if "%_JAVACMD%"=="" (
+  if not "%JAVA_HOME%"=="" (
+    if exist "%JAVA_HOME%\bin\java.exe" set "_JAVACMD=%JAVA_HOME%\bin\java.exe"
+  )
+)
+
+@@APP_DEFINES@@
+
+"%_JAVACMD%" -cp "%APP_CLASSPATH%" %APP_MAIN_CLASS% %*

--- a/src/sbt-test/jar/classpath-jar/test
+++ b/src/sbt-test/jar/classpath-jar/test
@@ -1,0 +1,5 @@
+# Run the staging and check the script.
+> stage
+$ exists target/universal/stage/lib/classpath-jar-test.classpath-jar-test-0.1.0-classpath.jar
+> check-classspath
+> run-check


### PR DESCRIPTION
the maximum length of the string that you can use at the command prompt is 8191 characters. http://support.microsoft.com/kb/830473/en-us

Create manifest.jar it contains Class-Path manifest.
java classpath option need only a manifest.jar.

```
java -Xjvmopt1 -Xjvmopt2 -cp org.name-version-artifactClassifier.jar:scala-liblary.jar:aaaaaa.jar:bbbbbb:jar:cccc.jar:......:xxxxxx.jar mainClass arg1 arg2
```

↓

```
java -Xjvmopt1 -Xjvmopt2 -cp org.name-version-artifactClassifier-manifest.jar mainClass arg1 arg2
```

This patch affects both the batch script and bash script.

fix #72
