### PR TITLE
Play backward compatibility issue

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
@@ -107,14 +107,16 @@ object JavaAppPackaging extends AutoPlugin with JavaAppStartScript {
       else "../" + name
     }
 
-  // Constructs a jar name from components...(ModuleID/Artifact)
-  private def makeJarName(org: String, name: String, revision: String, artifactName: String, artifactClassifier: Option[String]): String =
-    (org + "." +
+  /**
+   * Constructs a jar name from components...(ModuleID/Artifact)
+   */
+  def makeJarName(org: String, name: String, revision: String, artifactName: String, artifactClassifier: Option[String]): String =
+    org + "." +
       name + "-" +
       Option(artifactName.replace(name, "")).filterNot(_.isEmpty).map(_ + "-").getOrElse("") +
       revision +
       artifactClassifier.filterNot(_.isEmpty).map("-" + _).getOrElse("") +
-      ".jar")
+      ".jar"
 
   // Determines a nicer filename for an attributed jar file, using the 
   // ivy metadata if available.


### PR DESCRIPTION
I've just tried using `1.0.0-M1` with Play and unfortunately it is not possible.

The first thing I've come across is that some APIs have become private e.g.:

https://github.com/sbt/sbt-native-packager/blob/master/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala#L111

Play actually uses the `makeJarName` function (there may be others, but I've not been able to progress beyond this issue so far).

I'm just wondering if we should re-visit what was made private - how concerned are we re. backward compatibility from an API perspective?
