### PR TITLE
windows bat exit code fix

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bat-template
@@ -10,7 +10,6 @@
 @echo off
 
 if "%@@APP_ENV_NAME@@_HOME%"=="" set "@@APP_ENV_NAME@@_HOME=%~dp0\\.."
-set ERROR_CODE=0
 
 set "APP_LIB_DIR=%@@APP_ENV_NAME@@_HOME%\lib\"
 
@@ -130,12 +129,7 @@ rem Call the application and pass all arguments unchanged.
 
 @endlocal
 
-if ERRORLEVEL 1 goto error
-goto end
-
-:error
-set ERROR_CODE=1
 
 :end
 
-exit /B %ERROR_CODE%
+exit /B %ERRORLEVEL%

--- a/src/sbt-test/windows/test-bat-template/build.sbt
+++ b/src/sbt-test/windows/test-bat-template/build.sbt
@@ -98,6 +98,8 @@ TaskKey[Unit]("check-script") <<= (stagingDirectory in Universal, name, streams)
   // include space and double-quote is failed...
   // can't success include double-quote. arguments pass from Process(Seq("-Da=xx\"yy", "aa\"bb")) is parsed (%1="-Da", %2="xx\"yy aa\"bb") by cmd.exe ...
   //checkOutput(0, "arg #0 is [xx\"yy]\nproperty(test.hoge) is [aa\"bb]\nvmarg #0 is [-Dtest.hoge=aa\"bb]\nSUCCESS!", "-Dtest.hoge=aa\"bb", "xx\"yy")
-  checkOutputEnv(Map("return-code-1"->"true"), 1, "arg #0 is [RC1]\nFAILURE!", "RC1")
+  checkOutputEnv(Map("return-code"->"1"), 1, "arg #0 is [RC1]\nFAILURE!", "RC1")
+  checkOutputEnv(Map("return-code"->"2"), 2, "arg #0 is [RC2]\nFAILURE!", "RC2")
+  checkOutputEnv(Map("return-code"->"-1"), -1, "arg #0 is [RC-1]\nFAILURE!", "RC-1")
   assert(fails.toString == "", fails.toString)
 }

--- a/src/sbt-test/windows/test-bat-template/src/main/scala/test/Test.scala
+++ b/src/sbt-test/windows/test-bat-template/src/main/scala/test/Test.scala
@@ -11,9 +11,9 @@ object Test extends App {
         println("vmarg #" + i + " is [" + x + "]")
       }
     }
-    if(System.getenv("return-code-1") == "true"){
+    if(System.getenv("return-code") != null){
       println("FAILURE!")
-      System.exit(1)
+      System.exit(System.getenv("return-code").toInt)
     } else {
       println("SUCCESS!")
       System.exit(0)


### PR DESCRIPTION
Return exit code 1 in windows bat script if java application exits with
a return code greater than 0.  Update windows bat regression tests to
check the returned code.
