### PR TITLE
Add the required import.

### DIFF
--- a/src/sphinx/DetailedTopics/custom.rst
+++ b/src/sphinx/DetailedTopics/custom.rst
@@ -26,6 +26,8 @@ contains the assembled jar. This is what the final ``build.sbt`` should contain:
 
 .. code-block:: scala
 
+    import AssemblyKeys._
+
     // the assembly settings
     assemblySettings
 


### PR DESCRIPTION
I'm not sure if this is the right way to do this, but I tried to
use this chunk of the documentation without reading the rest and
was unaware this was needed, thought it might help the next person
trying to cut and paste away.
