### PR TITLE
Made -agentlib options before the classpath in the bash script.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -222,7 +222,7 @@ process_args () {
 
      -java-home) require_arg path "$1" "$2" && java_cmd="$2/bin/java" && shift 2 ;;
 
-            -D*) addJava "$1" && shift ;;
+ -D*|-agentlib*) addJava "$1" && shift ;;
             -J*) addJava "${1:2}" && shift ;;
               *) addResidual "$1" && shift ;;
     esac


### PR DESCRIPTION
If someone wants to add remote debugging options for their project, he will add something like 

```
-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005
```

in src/universal/conf/jvmopts

However, the auto generated bash only treat arguments starting with -D as JVM arguments. The option we just added will be appended at the end of the java command as "residual arguments", which will not work.

This commit fixes it.
