### PR TITLE
Docker mappings - incomplete?

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -9,7 +9,6 @@ import sbt._
  */
 trait DockerKeys {
   val dockerGenerateConfig = TaskKey[File]("docker-generate-config", "Generates configuration file for Docker.")
-  val dockerGenerateContext = TaskKey[File]("docker-generate-context", "Generates context directory for Docker.")
   val dockerPackageMappings = TaskKey[Seq[(File, String)]]("docker-package-mappings", "Generates location mappings for Docker build.")
   val dockerTarget = TaskKey[String]("docker-target", "Defines target used when building and publishing Docker image")
 

--- a/src/sbt-test/docker/staging/test
+++ b/src/sbt-test/docker/staging/test
@@ -1,4 +1,4 @@
 # Stage the distribution and ensure files show up.
 > docker:stage
-$ exists target/docker/Dockerfile
-$ exists target/docker/files
+$ exists target/docker/stage/Dockerfile
+$ exists target/docker/stage/opt

--- a/src/sbt-test/docker/test-executableScriptName/test
+++ b/src/sbt-test/docker/test-executableScriptName/test
@@ -1,6 +1,6 @@
 # Generate the Docker image locally
 > docker:publishLocal
-$ exists target/docker/Dockerfile
-$ exists target/docker/files/opt/docker/bin/docker-exec
+$ exists target/docker/stage/Dockerfile
+$ exists target/docker/stage/opt/docker/bin/docker-exec
 > check-dockerfile
 $ exec bash -c 'docker run docker-package:0.1.0 | grep -q "Hello world"'

--- a/src/sbt-test/docker/test-packageName-universal/test
+++ b/src/sbt-test/docker/test-packageName-universal/test
@@ -1,6 +1,6 @@
 # Generate the Docker image locally
 > docker:publishLocal
-$ exists target/docker/Dockerfile
-$ exists target/docker/files/opt/docker/bin/docker-test
+$ exists target/docker/stage/Dockerfile
+$ exists target/docker/stage/opt/docker/bin/docker-test
 > check-dockerfile
 $ exec bash -c 'docker run docker-package:0.1.0 | grep -q "Hello world"'

--- a/src/sbt-test/docker/test-packageName/test
+++ b/src/sbt-test/docker/test-packageName/test
@@ -1,6 +1,6 @@
 # Generate the Docker image locally
 > docker:publishLocal
-$ exists target/docker/Dockerfile
-$ exists target/docker/files/opt/docker/bin/docker-test
+$ exists target/docker/stage/Dockerfile
+$ exists target/docker/stage/opt/docker/bin/docker-test
 > check-dockerfile
 $ exec bash -c 'docker run docker-package:0.1.0 | grep -q "Hello world"'

--- a/test-project-docker/build.sbt
+++ b/test-project-docker/build.sbt
@@ -1,0 +1,7 @@
+enablePlugins(JavaAppPackaging)
+
+name := "docker-test"
+
+version := "0.1.0"
+
+maintainer := "Gary Coady <gary@lyranthe.org>"

--- a/test-project-docker/project/build.properties
+++ b/test-project-docker/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7

--- a/test-project-docker/project/plugins.sbt
+++ b/test-project-docker/project/plugins.sbt
@@ -1,0 +1,3 @@
+lazy val root = Project("plugins", file(".")).dependsOn(plugin)
+
+lazy val plugin = file("../").getCanonicalFile.toURI

--- a/test-project-docker/src/main/scala/Main.scala
+++ b/test-project-docker/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}


### PR DESCRIPTION
I've just noticed that `docker:mappings` does not include the `DockerFile` that is produced. The `sbt-bundle` plugin uses `docker:mappings` as a general approach to including files when staging or producing a dist (it actually doesn't know anothing about the 'docker' config as this a setting to it). Should `docker:mappings` also include the `DockerFile` itself? I'm thinking so...

As an alternative the `File` result of `stage` could be used... only again it does not include the `DockerFile` as it points to `/files`. I'd prefer to use mappings though anyhow given that it retains the relative path.

What are your thoughts? `mappings` appears to be inclusive of the entire package with the other configurations doesn't it? /cc @jsuereth 
