### PR TITLE
Replace bash image with java’s in akka-bash-template

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/akka-bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/akka-bash-template
@@ -11,4 +11,4 @@ ${{template_declares}}
 # we will use akka_classpath instead the app_classpath
 [ -n "$akka_classpath" ] || akka_classpath="$AKKA_HOME/lib/*:$AKKA_HOME/conf"
 
-java $JAVA_OPTS -cp "$akka_classpath" -Dakka.home="$AKKA_HOME" -Dakka.kernel.quiet=false akka.kernel.Main $app_mainclass
+exec java $JAVA_OPTS -cp "$akka_classpath" -Dakka.home="$AKKA_HOME" -Dakka.kernel.quiet=false akka.kernel.Main $app_mainclass


### PR DESCRIPTION
There’s no need to keep the bash process running. Also, bash does not forward `SIGTERM` etc. to its child processes, so killing bash did not kill the java process.
