### PR TITLE
Fixing update-latest to work with docker 1.3 and greater

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -214,7 +214,7 @@ object DockerPlugin extends AutoPlugin {
 
     if (latest) {
       val name = tag.substring(0, tag.lastIndexOf(":")) + ":latest"
-      val latestCmd = Seq("docker", "tag", tag, name)
+      val latestCmd = Seq("docker", "tag", "-f", tag, name)
       Process(latestCmd).! match {
         case 0 => log.info("Update Latest from image" + tag)
         case n => sys.error("Failed to run docker tag")


### PR DESCRIPTION
Docker `1.3` and greater don't override a preexisting tag without the `-f` option.
This may create stale images:

```bash
> sbt docker:publishLocal
> docker images
docker-test         0.1.0               f2e7a5bb081e        About a minute ago   720 MB
docker-test         latest              f2e7a5bb081e        About a minute ago   720 MB
dockerfile/java     latest              e5b3ce7f0b79        4 days ago           705.7 MB

> sbt docker:publishLocal
> docker images
docker-test         0.1.0               49299e1e9e14        2 seconds ago        720 MB
docker-test         latest              49299e1e9e14        2 seconds ago        720 MB
<none>              <none>              f2e7a5bb081e        About a minute ago   720 MB
dockerfile/java     latest              e5b3ce7f0b79        4 days ago           705.7 MB
```