### PR TITLE
Trying travis-ci container architecture for faster builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,13 @@ jdk:
 notifications:
   email:
     - qbranch@typesafe.com
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq rpm
+#before_install:
+# - sudo apt-get update -qq
+# - sudo apt-get install -qq rpm
+ 
+sudo: false
+cache: 
+ apt: true
+ directories:
+ - $HOME/.sbt
+ - $HOME/.ivy2

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,10 @@ jdk:
 notifications:
   email:
     - qbranch@typesafe.com
-#before_install:
-# - sudo apt-get update -qq
-# - sudo apt-get install -qq rpm
+addons:
+  apt:
+    packages:
+    - rpm
  
 sudo: false
 cache: 


### PR DESCRIPTION
Enable container architecture and caching

> The features described here are currently only available for private repositories on travis-ci.com and our new container-based infrastructure. These features are also still experimental, please contact us with any questions, issues and feedback.

## Links

- http://docs.travis-ci.com/user/caching/
- [Arbitrary Directories](http://docs.travis-ci.com/user/caching/#Arbitrary-directories)
- [Ubuntu Packages](http://docs.travis-ci.com/user/caching/#Caching-Ubuntu-packages)