### PR TITLE
Using `--startas` instead of `--exec` now in order to make start script idempotent.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -30,7 +30,7 @@ RUN_CMD="${{chdir}}/bin/${{exec}}"
 start_daemon() {
     log_daemon_msg "Starting" "${{app_name}}"
     [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -g "$DAEMON_GROUP" -m755 "/var/run/${{app_name}}"
-    start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --exec "$RUN_CMD" --start -- $RUN_OPTS
+    start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS
     log_end_msg $?
 }
 


### PR DESCRIPTION
 This will only use PID file to check whether application is started or not. `--exec` in contrast is also checks the `/proc/[PID]/exe` file which links to the java executable and not original start script (see [this article](https://chris-lamb.co.uk/posts/start-stop-daemon-exec-vs-startas)). 

For more detail please see the discussion on #451

I tried to use another solution (`exec -a "appName"`), but unfortunately it does not work as I expected. So as far as i can tell `--startas` is the only option.

