### PR TITLE
Back to specific directory for ADD command

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -115,11 +115,12 @@ object DockerPlugin extends AutoPlugin {
         Some(Cmd("MAINTAINER", maintainer))
     }
 
+    val files = dockerBaseDirectory.split(java.io.File.separator)(1)
+
     val dockerCommands = Seq(
-      Cmd("ADD", "* /"),
+      Cmd("ADD", s"$files /$files"),
       Cmd("WORKDIR", "%s" format dockerBaseDirectory),
       ExecCmd("RUN", "chown", "-R", daemonUser, "."),
-      ExecCmd("RUN", "rm", "/Dockerfile"),
       Cmd("USER", daemonUser),
       ExecCmd("ENTRYPOINT", entrypoint: _*),
       ExecCmd("CMD")
@@ -200,12 +201,11 @@ object DockerPlugin extends AutoPlugin {
 
   def publishLocalDocker(context: File, tag: String, latest: Boolean, log: Logger): Unit = {
     val cmd = Seq("docker", "build", "--force-rm", "-t", tag, ".")
-    val cwd = context.getParentFile
 
     log.debug("Executing " + cmd.mkString(" "))
-    log.debug("Working directory " + cwd.toString)
+    log.debug("Working directory " + context.toString)
 
-    val ret = Process(cmd, cwd) ! publishLocalLogger(log)
+    val ret = Process(cmd, context) ! publishLocalLogger(log)
 
     if (ret != 0)
       throw new RuntimeException("Nonzero exit value: " + ret)


### PR DESCRIPTION
PR https://github.com/sbt/sbt-native-packager/pull/424 moved to a ADD wildcard approach, and then removed the Dockerfile. There were two problems with this:

* ADD seems to behave weirdly regarding recursion. /opt/docker and /docker were both added to the output.
* I had incorrectly set the current working directory to the parent of the context directory, where it really should be the context directory itself. This only worked because there was a Dockerfile in the parent also.