### PR TITLE
wait for process to stop or timeout in systemv init script

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -39,7 +39,7 @@ stop_daemon() {
 
   log_daemon_msg "Stopping" "${{app_name}}"
 	  if start-stop-daemon --status --pidfile "$PIDFILE"; then
-		  start-stop-daemon --stop --pidfile "$PIDFILE"
+		  start-stop-daemon --stop --pidfile "$PIDFILE" --retry=TERM/${{term_timeout}}/KILL/${{kill_timeout}}
 		  log_end_msg $?
 	  else
 		  log_progress_msg "not running"

--- a/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
@@ -21,6 +21,8 @@ trait LinuxKeys {
   val linuxPackageMappings = TaskKey[Seq[LinuxPackageMapping]]("linux-package-mappings", "File to install location mappings including owner and privileges.")
   val linuxPackageSymlinks = TaskKey[Seq[LinuxSymlink]]("linux-package-symlinks", "Symlinks we should produce in the underlying package.")
   val generateManPages = TaskKey[Unit]("generate-man-pages", "Shows all the man files in the current project")
+  val termTimeout = SettingKey[Int]("term-timeout", "Timeout before sigterm on stop")
+  val killTimeout = SettingKey[Int]("kill-timeout", "Timeout before sigkill on stop (after term)")
 
   val linuxMakeStartScript = TaskKey[Option[File]]("makeStartScript", "Creates or discovers the start script used by this project")
   val linuxStartScriptTemplate = TaskKey[URL]("linuxStartScriptTemplate", "The location of the template start script file we use for debian (upstart or init.d")
@@ -42,6 +44,8 @@ trait LinuxKeys {
          |  daemonUserUid - daemon user uid
          |  daemonGroup - daemon group
          |  daemonGroupGid - daemon group gid
+         |  termTimeout - timeout before sigterm on stop
+         |  killTimeout - timeout before sigkill on stop (after term)
       """.stripMargin
   )
 

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
@@ -71,6 +71,8 @@ object LinuxPlugin extends AutoPlugin {
     stopRunlevels := None,
     requiredStartFacilities := None,
     requiredStopFacilities := None,
+    termTimeout := 60,
+    killTimeout := 30,
 
     // Default linux bashscript replacements
     linuxScriptReplacements := makeReplacements(
@@ -84,7 +86,9 @@ object LinuxPlugin extends AutoPlugin {
       daemonUserUid = (daemonUserUid in Linux).value,
       daemonGroup = (daemonGroup in Linux).value,
       daemonGroupGid = (daemonGroupGid in Linux).value,
-      daemonShell = (daemonShell in Linux).value
+      daemonShell = (daemonShell in Linux).value,
+      termTimeout = (termTimeout in Linux).value,
+      killTimeout = (killTimeout in Linux).value
     ),
     linuxScriptReplacements += controlScriptFunctionsReplacement( /* Add key for control-functions */ )
 
@@ -159,7 +163,9 @@ object LinuxPlugin extends AutoPlugin {
     daemonGroupGid: Option[String],
     daemonShell: String,
     retries: Int = 0,
-    retryTimeout: Int = 60
+    retryTimeout: Int = 60,
+    termTimeout: Int = 60,
+    killTimeout: Int = 30
   ): Seq[(String, String)] =
     Seq(
       "author" -> author,
@@ -174,7 +180,9 @@ object LinuxPlugin extends AutoPlugin {
       "daemon_user_uid" -> daemonUserUid.getOrElse(""),
       "daemon_group" -> daemonGroup,
       "daemon_group_gid" -> daemonGroupGid.getOrElse(""),
-      "daemon_shell" -> daemonShell
+      "daemon_shell" -> daemonShell,
+      "term_timeout" -> termTimeout.toString,
+      "kill_timeout" -> killTimeout.toString
     )
 
   /**

--- a/src/sbt-test/debian/sysvinit-stoptimeouts-deb/build.sbt
+++ b/src/sbt-test/debian/sysvinit-stoptimeouts-deb/build.sbt
@@ -1,0 +1,52 @@
+import com.typesafe.sbt.packager.archetypes.ServerLoader
+
+enablePlugins(JavaServerAppPackaging)
+
+serverLoading in Debian := ServerLoader.SystemV
+
+daemonUser in Debian := "root"
+
+mainClass in Compile := Some("empty")
+
+name := "debian-test"
+
+version := "0.1.0"
+
+maintainer := "Josh Suereth <joshua.suereth@typesafe.com>"
+
+packageSummary := "Test debian package"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+requiredStartFacilities := Some("$test-service")
+
+requiredStartFacilities in Debian := Some("$test-deb-service")
+
+termTimeout := 10
+
+killTimeout := 20
+
+TaskKey[Unit]("check-control-files") <<= (target, streams) map { (target, out) =>
+  val header = "#!/bin/sh"
+  val debian = target / "debian-test-0.1.0" / "DEBIAN"
+  val postinst = IO.read(debian / "postinst")
+  val postrm = IO.read(debian / "postrm")
+  Seq(postinst, postrm) foreach { script =>
+    assert(script.startsWith(header), "script doesn't start with #!/bin/sh header:\n" + script)
+    assert(header.r.findAllIn(script).length == 1, "script contains more than one header line:\n" + script)
+  }
+  out.log.success("Successfully tested systemV control files")
+  ()
+}
+
+TaskKey[Unit]("check-startup-script") <<= (target, streams) map { (target, out) =>
+  val script = IO.read(target / "debian-test-0.1.0" / "etc" / "init.d" / "debian-test")
+  assert(script.contains("# Default-Start: 2 3 4 5"), "script doesn't contain Default-Start header\n" + script)
+  assert(script.contains("# Default-Stop: 0 1 6"), "script doesn't contain Default-Stop header\n" + script)
+  assert(script.contains("# Required-Start: $test-deb-service"), "script doesn't contain Required-Start header\n" + script)
+  assert(script.contains("# Required-Stop: $remote_fs $syslog"), "script doesn't contain Required-Stop header\n" + script)
+  assert(script.contains("--retry=TERM/10/KILL/20"), "script doesn't contains stop timeouts\n" + script)
+  out.log.success("Successfully tested systemV start up script")
+  ()
+}

--- a/src/sbt-test/debian/sysvinit-stoptimeouts-deb/project/plugins.sbt
+++ b/src/sbt-test/debian/sysvinit-stoptimeouts-deb/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/debian/sysvinit-stoptimeouts-deb/test
+++ b/src/sbt-test/debian/sysvinit-stoptimeouts-deb/test
@@ -1,0 +1,10 @@
+# Run the debian packaging.
+> debian:package-bin
+$ exists target/debian-test_0.1.0_all.deb
+
+$ exists target/debian-test-0.1.0/etc
+$ exists target/debian-test-0.1.0/etc/default/debian-test
+$ exists target/debian-test-0.1.0/etc/init.d/debian-test
+
+> check-control-files
+> check-startup-script


### PR DESCRIPTION
start-stop-dameons does not wait for service to stop before returning.
This may results in error on upgrade of the package trying to start the service while old version is still shutting down.