### PR TITLE
[fix #472] /etc/default/<package-name> should be shell script setting envars

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -363,8 +363,7 @@ ${{template_declares}}
 declare java_cmd=$(get_java_cmd)
 
 
-# if configuration files exist, source it and use JAVA_OPTS to prepend their contents to $@
-[[ -f "$script_conf_file" ]] && . "$script_conf_file" 
+# use JAVA_OPTS to prepend its contents to $@
 set -- "$JAVA_OPTS" "$@"
 
 run "$@"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -290,11 +290,6 @@ run() {
   exit $exit_code
 }
 
-# Loads a configuration file full of default command line options for this script.
-loadConfigFile() {
-  cat "$1" | sed '/^\#/d'
-}
-
 # Now check to see if it's a good enough version
 # TODO - Check to see if we have a configured default java version, otherwise use 1.6
 java_version_check() { 
@@ -367,7 +362,9 @@ ${{template_declares}}
 # java_cmd is overrode in process_args when -java-home is used
 declare java_cmd=$(get_java_cmd)
 
-# if configuration files exist, prepend their contents to $@ so it can be processed by this runner
-[[ -f "$script_conf_file" ]] && set -- $(loadConfigFile "$script_conf_file") "$@"
+
+# if configuration files exist, source it and use JAVA_OPTS to prepend their contents to $@
+[[ -f "$script_conf_file" ]] && . "$script_conf_file" 
+set -- "$JAVA_OPTS" "$@"
 
 run "$@"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
@@ -14,6 +14,7 @@
 # ${{daemon_user}}		daemon user
 # -------------------------------------------------
 
+# Using $JAVA_OPTS envars
 # Setting -Xmx and -Xms in Megabyte
 # -mem 1024
 
@@ -32,3 +33,7 @@
 
 # Don't run the java version check
 # -no-version-check
+
+# Example
+# JAVA_OPTS=" -Dpidfile.path=/var/run/${{app_name}}/play.pid $JAVA_OPTS"
+# JAVA_OPTS=" -mem 1024 -Dkey=val -jvm-debug $JAVA_OPTS"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -12,6 +12,10 @@
 source /lib/init/vars.sh
 source /lib/lsb/init-functions
 
+# if configuration files exist, source it and use JAVA_OPTS to prepend their contents to $@
+[[ -f /etc/default/${{app_name}} ]] && . /etc/default/${{app_name}}
+# $JAVA_OPTS used in $RUN_CMD wrapper
+export JAVA_OPTS
 
 PIDFILE=/var/run/${{app_name}}/running.pid
 

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -28,6 +28,11 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
+# if configuration files exist, source it and use JAVA_OPTS to prepend their contents to $@
+[[ -f /etc/default/${{app_name}} ]] && . /etc/default/${{app_name}}
+# $JAVA_OPTS used in $RUN_CMD wrapper
+export JAVA_OPTS
+
 prog="${{exec}}"
 
 # FIXME The pid file should be handled by the executed script

--- a/src/sphinx/archetypes/java_server/customize.rst
+++ b/src/sphinx/archetypes/java_server/customize.rst
@@ -34,6 +34,7 @@ Create ``src/templates/etc-default`` with the following template
     # ${{daemon_user}}      daemon user
     # -------------------------------------------------
 
+    # Using $JAVA_OPTS envars
     # Setting -Xmx and -Xms in Megabyte
     # -mem 1024
 
@@ -58,8 +59,15 @@ Create ``src/templates/etc-default`` with the following template
     # using a reserved parameter. See #184
     # -d -- -d
 
+    # Example:
+    # JAVA_OPTS=" -Dpidfile.path=/var/run/${{app_name}}/play.pid $JAVA_OPTS"
+    # JAVA_OPTS=" -mem 1024 -Dkey=val -jvm-debug $JAVA_OPTS"
+
 The file will be installed to ``/etc/default/<normalizedName>`` and read from there
 by the startscript.
+
+*Warning: the format changed, from java option list only, to a shell script setting environment variables.
+A project using previous version should adapts its configuration file.*
 
 Environment variables
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Simply use wildly used JAVA_OPTS envars to set exec parameters.
I don't know how to tests this :/

BTW tests passes on unversal and debian