### PR TITLE
[Fix #476] Fixing -jvm-debug flags so that they use args compatible with the latest JDKs

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -148,8 +148,7 @@ addResidual () {
   residual_args+=( "$1" )
 }
 addDebugger () {
-  addJava "-Xdebug"
-  addJava "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=$1"
+  addJava "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$1"
 }
 # a ham-fisted attempt to move some memory settings in concert
 # so they need not be messed around with individually.


### PR DESCRIPTION
When providing the -jvm-debug flag the sbt native packager's bash template currently passes the following jvm debug flags:

-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=[debug port]

This is outdated (it is for JVM 1.4.x) and for newer JVMs should be:

-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=[debug port]