### PR TITLE
Added translation of `jvmopts` contents and enhanced example app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,38 +79,16 @@ packageBin in Debian <<= debianJDebPackaging in Debian
 
 JDK 8 from Oracle includes the tool `javapackager` (née `javafxpackager`) to generate application
 launchers and native installers for MacOS X, Windows, and Linux. This plugin complements the existing
-`sbt-native-packager` formats by taking the staged output from `JavaAppPackaging` and `Universal`
-settings and passing them through `javapackager`.
+`sbt-native-packager` formats by taking the settings and staged output from `JavaAppPackaging`
+and passing them through `javapackager`.
 
-This plugin's most significant complement to the core capabilities is the generation of
-MacOS X App bundles and derived `.dmg` and `.pkg` packages. It can also generate Linux `.deb` and `.rpm`
-packages, and Windows `.exe` and `.msi` installers, provided the requisite tools are available on the
-build platform.
+This plugin's most significant complement to the core `sbt-native-packager` capabilities is the
+generation of MacOS X App bundles, and associated `.dmg` and `.pkg` package formats.
+It can also generate Windows `.exe` and `.msi` installers provided the requisite tools are
+available on the Windows build platform.
 
-For details on the capabilities of `javapackager`, see the [windows](http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javapackager.html) and [Unix](http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javapackager.html) references. (Note: only a few of the possible
-settings are exposed through this plugin. Please submit a github issue or pull request if something
-specific is desired.)
+For usage details see the [JDKPackager Plugin guide](http://www.scala-sbt.org/sbt-native-packager/formats/jdkpackager.html).
 
-Using this plugin requires running SBT under JDK 8, or setting `jdkPackagerTool` to the location
-of the tool.
-
-To use, first get your application working per `JavaAppPackaging` instructions (including `mainClass`),
-then add
-
-```scala
-enablePlugins(JDKPackagerPlugin)
-```
-
-to your build file. Then run `sbt jdkPackager:packageBin`.
-
-By default, the plugin makes the installer type that is native to the current build platform in
-the directory `target/jdkpackager`. The key `jdkPackageType` can be used to modify this behavior.
-Run `help jdkPackageType` in sbt for details. The most popular setting is likely to be `jdkAppIcon`. See
-[the example build file](test-project-jdkpackager/build.sbt) on how to use it.
-
-To take it for a test spin, run `sbt jdkPackager:packageBin` in the `test-project-jdkpackager` directory
-and then look in the `target/jdkpackager/bundles` directory for the result. See [Oracle documentation](http://docs.oracle.com/javase/8/docs/technotes/guides/deploy/self-contained-packaging.html) for Windows and
-Linux build prerequisites.
 
 ## Documentation ##
 

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerHelper.scala
@@ -10,7 +10,7 @@ import sbt._
  */
 object JDKPackagerHelper {
 
-  // Try to compute determine a default path for the java packager tool.
+  /** Attempts to compute the path to the `javapackager` tool. */
   def locateJDKPackagerTool(): Option[File] = {
     val jdkHome = sys.props.get("java.home").map(p ⇒ file(p))
 
@@ -26,7 +26,73 @@ object JDKPackagerHelper {
       .filter(_.exists())
   }
 
-  def mkProcess(
+  /**
+   * Generates key-value pairs to be converted into command line arguments fed to `javapackager`.
+   * If an argument is mono/standalone (not key/value) then the key stores the complete argument
+   * and the value is the empty string.
+   */
+  private[jdkpackager] def makeArgMap(
+    name: String,
+    version: String,
+    description: String,
+    maintainer: String,
+    packageType: String,
+    mainJar: String,
+    mainClass: Option[String],
+    basename: String,
+    iconPath: Option[File],
+    outputDir: File,
+    sourceDir: File): Map[String, String] = {
+
+    val iconArg = iconPath.toSeq
+      .map(_.getAbsolutePath)
+      .map(p ⇒ s"-Bicon=$p")
+
+    val mainClassArg = mainClass
+      .map(c ⇒ Map("-appclass" -> c))
+      .getOrElse(Map.empty)
+
+    // Make a setting?
+    val jvmOptsFile = (sourceDir ** "jvmopts").getPaths.headOption.map(file)
+
+    val jvmOptsArgs = jvmOptsFile.toSeq.flatMap { jvmopts ⇒
+      IO.readLines(jvmopts).map {
+        case a if a startsWith "-X" ⇒ s"-BjvmOptions=$a"
+        case b if b startsWith "-D" ⇒ s"-BjvmProperties=${b.drop(2)}"
+        case c                      ⇒ "" // Ignoring others.... is this OK?
+      }.filter(_.nonEmpty)
+    }
+
+    // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javapackager.html and
+    // http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javapackager.html for
+    // command line options. NB: Built-in `-help` is incomplete.
+
+    // TODO:
+    // * copyright/license ( -BlicenseFile=LICENSE )
+    // * environment variables?
+    // * category ?
+
+    val pairs = Map(
+      "-name" -> name,
+      "-srcdir" -> sourceDir.getAbsolutePath,
+      "-native" -> packageType,
+      "-outdir" -> outputDir.getAbsolutePath,
+      "-outfile" -> basename,
+      "-description" -> description,
+      "-vendor" -> maintainer
+    ) ++ mainClassArg
+
+    val singles = Seq(
+      s"-BappVersion=$version",
+      s"-BmainJar=lib/$mainJar"
+    ) ++ iconArg ++ jvmOptsArgs
+
+    // Merge singles into argument pair map. (Need a cleaner abstraction)
+    pairs ++ singles.map((_, "")).toMap
+  }
+
+  /** Generates a configure Process instance, ready to run. */
+  private[jdkpackager] def makeProcess(
     tool: File,
     mode: String,
     argMap: Map[String, String],
@@ -43,7 +109,7 @@ object JDKPackagerHelper {
     }.mkString(" ")
     log.debug(s"Package command: $argString")
 
-    // To help debug arguments
+    // To help debug arguments, create a bash script doing the same.
     val script = file(argMap("-outdir")) / "jdkpackager.sh"
     IO.write(script, s"#!/bin/bash\n$argString\n")
     chmod.safe(script, "766")
@@ -51,51 +117,4 @@ object JDKPackagerHelper {
     Process(args)
   }
 
-  def mkArgMap(
-    name: String,
-    version: String,
-    description: String,
-    maintainer: String,
-    packageType: String,
-    mainJar: String,
-    mainClass: Option[String],
-    basename: String,
-    iconPath: Option[File],
-    outputDir: File,
-    sourceDir: File) = {
-
-    def iconArg = iconPath
-      .map(_.getAbsolutePath)
-      .map(p ⇒ Map(s"-Bicon=$p" -> ""))
-      .getOrElse(Map.empty)
-
-    def mainClassArg = mainClass
-      .map(c ⇒ Map("-appclass" -> c))
-      .getOrElse(Map.empty)
-
-    //    val cpSep = sys.props("path.separator")
-    //    val cp = classpath.map(p ⇒ "lib/" + p)
-    //    val cpStr = cp.mkString(cpSep)
-
-    // See http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javapackager.html and
-    // http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javapackager.html for
-    // command line options. NB: Built-in `-help` is incomplete.
-    Map(
-      "-name" -> name,
-      "-srcdir" -> sourceDir.getAbsolutePath,
-      "-native" -> packageType,
-      "-outdir" -> outputDir.getAbsolutePath,
-      "-outfile" -> basename,
-      "-description" -> description,
-      "-vendor" -> maintainer,
-      s"-BappVersion=$version" -> "",
-      s"-BmainJar=lib/$mainJar" -> ""
-    ) ++ mainClassArg ++ iconArg
-
-    // TODO:
-    // * copyright/license
-    // * JVM options
-    // * application arguments
-    // * environment variables?
-  }
 }

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerKeys.scala
@@ -3,22 +3,28 @@ package com.typesafe.sbt.packager.jdkpackager
 import sbt._
 
 /**
- * Keys specific to deployment via the `javapackger` too.
+ * Keys specific to deployment via the `javapackger` tool.
+ *
+ * @author <a href="mailto:fitch@datamininglab.com">Simeon H.K. Fitch</a>
+ * @since 2/11/15
  */
 trait JDKPackagerKeys {
   val jdkPackagerTool = SettingKey[Option[File]]("jdkPackagerTool",
-    "Path to `javapackager` or `javafxpackager` tool in JDK")
+    "Path to `javapackager` or `javafxpackager` tool in JDK.")
+
   val packagerArgMap = TaskKey[Map[String, String]]("packagerArgMap",
     "An intermediate task for computing the command line argument key/value pairs passed to " +
       "`javapackager -deploy`")
+
   val jdkPackagerBasename = SettingKey[String]("jdkPackagerOutputBasename",
     "Filename sans extension for generated installer package.")
-  val jdkPackageType = SettingKey[String]("jdkPackageType",
+
+  val jdkPackagerType = SettingKey[String]("jdkPackagerType",
     """Value passed as the `-native` argument to `javapackager -deploy`.
       | Per `javapackager` documentation, this may be one of the following:
       |
       |    * `all`: Runs all of the installers for the platform on which it is running,
-      |      and creates a disk image for the application. This value is used if type is not specified.
+      |      and creates a disk image for the application.
       |    * `installer`: Runs all of the installers for the platform on which it is running.
       |    * `image`: Creates a disk image for the application. On OS X, the image is
       |      the .app file. On Linux, the image is the directory that gets installed.
@@ -30,7 +36,7 @@ trait JDKPackagerKeys {
       |    * `exe`: Generates a Windows .exe package.
       |    * `msi`: Generates a Windows Installer package.
       |
-      | (NB: Your mileage may vary.)
+      | Defaults to `image`.
     """.stripMargin)
 
   val jdkAppIcon = SettingKey[Option[File]]("jdkAppIcon",
@@ -38,5 +44,12 @@ trait JDKPackagerKeys {
       |    * `icns`: MacOS
       |    * `ico`: Windows
       |    * `png`: Linux
+      |
+      | Defaults to generic Java icon.
     """.stripMargin)
+
+  // To consider:
+  //  val jvmOptionFile = SettingKey[Option[File]]("jvmOptionFile",
+  //    "File with line delimited options to pass to the application JVM. " +
+  //      "Defaults to `stage/conf/jvmopts")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
@@ -27,9 +27,10 @@ object JDKPackagerPlugin extends AutoPlugin {
   def javaPackagerSettings: Seq[Setting[_]] = Seq(
     jdkPackagerTool := JDKPackagerHelper.locateJDKPackagerTool(),
     jdkAppIcon := None,
-    jdkPackageType := "image",
-    jdkPackagerBasename <<= packageName apply (_ + "-pkg"),
-    mappings in JDKPackager <<= (mappings in Universal) map (_.filter(!_._2.startsWith("bin/")))
+    jdkPackagerType := "image",
+    jdkPackagerBasename <<= packageName apply (_ + "-pkg")
+    // jvmOptionFile <<= sourceDirectory apply (src ⇒ Some(src / "conf" / "jvmopts")))
+    // mappings in JDKPackager <<= (mappings in Universal) map (_.filter(!_._2.startsWith("bin/")))
   ) ++ inConfig(JDKPackager)(
     Seq(
       sourceDirectory <<= sourceDirectory apply (_ / dirname),
@@ -45,13 +46,13 @@ object JDKPackagerPlugin extends AutoPlugin {
         version,
         packageDescription,
         maintainer,
-        jdkPackageType,
+        jdkPackagerType,
         ClasspathJarPlugin.autoImport.classspathJarName,
         mainClass,
         jdkPackagerBasename,
         jdkAppIcon,
         target,
-        stage in Universal) map JDKPackagerHelper.mkArgMap
+        stage in Universal) map JDKPackagerHelper.makeArgMap
     )  ++ makePackageBuilder
   )
 
@@ -60,10 +61,10 @@ object JDKPackagerPlugin extends AutoPlugin {
   )
 
   private def makePackageBuilder = Seq(
-    packageBin <<= (jdkPackagerTool, jdkPackageType, packagerArgMap, target, streams) map { (pkgTool, pkg, args, target, s) ⇒
+    packageBin <<= (jdkPackagerTool, jdkPackagerType, packagerArgMap, target, streams) map { (pkgTool, pkg, args, target, s) ⇒
 
       val tool = checkTool(pkgTool)
-      val proc = JDKPackagerHelper.mkProcess(tool, "-deploy", args, s.log)
+      val proc = JDKPackagerHelper.makeProcess(tool, "-deploy", args, s.log)
 
       (proc ! s.log) match {
         case 0 ⇒ ()

--- a/src/sphinx/formats/index.rst
+++ b/src/sphinx/formats/index.rst
@@ -12,3 +12,4 @@ Packaging Formats
    rpm.rst
    docker.rst
    windows.rst
+   jdkpackager.rst

--- a/src/sphinx/formats/jdkpackager.rst
+++ b/src/sphinx/formats/jdkpackager.rst
@@ -1,0 +1,141 @@
+JDKPackager Plugin
+==================
+
+JDK 8 from Oracle includes the tool `javapackager` (née `javafxpackager`), which generates native application launchers and installers for MacOS X, Windows, and Linux. This plugin complements the existing `sbt-native-packager` formats by taking the settings and staged output from `JavaAppPackaging` and passing them through `javapackager` to create native formats per Oracle's defined mechanisms.
+
+This plugin's most relevant addition to the core `sbt-native-packager` capabilities is the generation of MacOS X App bundles, and associated `.dmg` and `.pkg` package formats. With this plugin complete drag-and-drop installable application bundles are possible, including the embedding of the JRE. It can also generate Windows `.exe` and `.msi` installers provided the requisite tools are available on the Windows build platform.
+
+.. contents::
+  :depth: 2
+
+.. raw:: html
+
+  <div class="alert alert-info" role="alert">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+    The JDKPackagerPlugin depends on the Universal and JavaAppPackaging plugins. For inherited settings read the <a href="../archetypes/java_app/index.html">Java Applicaiton Plugin Documentation</a>
+  </div>
+
+
+Requirements
+------------
+
+The `javapackager` tool comes with JDK 8, and found in the `bin` directory along with `javac` and friends. (An earlier form of the tool was introduced in later forms of JDK 7 as `javafxpackager`.)  If `sbt` is running under the JVM in JDK 8, then the plugin should be able to find the path to `javapcakger`. If `sbt` is running under a different JVM, then the path to the tool will have to be specified via the ``jdkPackagerTool`` setting.
+
+This plugin must be run on the platform of the target installer. The `javapackager` tool does not provide a means of creating, say, Windows installers on MacOS, etc.
+
+To use create Windows launchers & installers, the WIX Toolset is required:
+
+* `WIX Toolset <http://wixtoolset.org/>`_
+
+For further details on the capabilities of `javapackager`, see the `windows <http://docs.oracle.com/javase/8/docs/technotes/tools/windows/javapackager.html>`_ and `Unix <http://docs.oracle.com/javase/8/docs/technotes/tools/unix/javapackager.html>`_ references. (Note: only a few of the possible settings are exposed through this plugin. Please submit a `Github <https://github.com/sbt/sbt-native-packager/issues>`_ issue or pull request if something specific is desired.)
+
+
+Enabling
+--------
+
+The plugin is enabled via the ``AutoPlugins`` facility:
+
+.. code-block:: scala
+
+  enablePlugins(JDKPackagerPlugin)
+
+Build
+-----
+
+To use, first get your application working per `JavaAppPackaging` instructions (including the ``mainClass`` setting). Once that is working, run
+
+.. code-block:: scala
+
+  sbt jdkPackager:packageBin
+
+By default, the plugin makes the installer type that is native to the current build platform in the directory `target/jdkpackager`. The key `jdkPackageType` can be used to modify this behavior. Run `help jdkPackageType` in sbt for details. The most popular setting is likely to be `jdkAppIcon`.
+
+Settings
+--------
+
+``jdkPackagerTool``
+  Path to `javapackager` or `javafxpackager` tool in JDK.
+
+``jdkPackagerBasename``
+  Filename sans extension for generated installer package. Defaults to ``packageName``.
+
+``jdkPackagerType``
+  Value passed as the `-native` argument to `javapackager -deploy` command.
+  Per `javapackager` documentation, this may be one of the following:
+
+  * ``all``: Runs all of the installers for the platform on which it is running, and creates a disk image for the application.
+  * ``installer``: Runs all of the installers for the platform on which it is running.
+  * ``image``: Creates a disk image for the application. On OS X, the image is the .app file. On Linux, the image is the directory that gets installed.
+  * ``dmg``: Generates a DMG file for OS X.
+  * ``pkg``: Generates a .pkg package for OS X.
+  * ``mac.appStore``: Generates a package for the Mac App Store.
+  * ``rpm``: Generates an RPM package for Linux.
+  * ``deb``: Generates a Debian package for Linux.
+  * ``exe``: Generates a Windows .exe package.
+  * ``msi``: Generates a Windows Installer package.
+
+.. raw:: html
+
+  <div class="alert alert-info" role="alert">
+    <span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span>
+    Because only a subset of the possible settings are exposed through he plugin, updates are likely required to fully make use of all formats. ``dmg`` currently the most tested type.
+  </div>
+
+``jdkAppIcon``
+  Path to platform-specific application icon:
+
+  * `icns`: MacOS
+  * `ico`: Windows
+  * `png`: Linux
+
+  Defaults a generically bland Java icon.
+
+JVM Options
+-----------
+
+Relevant JVM settings specified in the ``src/universal/conf/jvmopts`` file are processed and added to the `javapackager` call. See :doc:`Customize Java Applications</customizejavaapplications>` for details.
+
+
+Example
+-------
+
+To take it for a test spin, run ``sbt jdkPackager:packageBin`` in the ``test-project-jdkpackager`` directory of the `sbt-native-packager` soruce. Then look in the ``target/jdkpackager/bundles`` directory for the result (specific name depends on platform built).
+
+Here's what the build file looks like:
+
+.. code-block:: scala
+
+    name := "JDKPackagerPlugin Example"
+
+    version := "0.1.0"
+
+    organization := "com.foo.bar"
+
+    libraryDependencies ++= Seq(
+        "com.typesafe" % "config" % "1.2.1"
+    )
+
+    mainClass in Compile := Some("ExampleApp")
+
+    enablePlugins(JDKPackagerPlugin)
+
+    maintainer := "Simeon H.K Fitch <fitch@datamininglab.com>"
+
+    packageSummary := "JDKPackagerPlugin example package thingy"
+
+    packageDescription := "A test package using Oracle's JDK bundled javapackager tool."
+
+    lazy val iconGlob = sys.props("os.name").toLowerCase match {
+      case os if os.contains("mac") ⇒ "*.icns"
+      case os if os.contains("win") ⇒ "*.ico"
+      case _ ⇒ "*.png"
+    }
+
+    jdkAppIcon :=  (sourceDirectory.value ** iconGlob).getPaths.headOption.map(file)
+
+    jdkPackagerType := "installer"
+
+
+
+
+

--- a/test-project-jdkpackager/build.sbt
+++ b/test-project-jdkpackager/build.sbt
@@ -27,6 +27,6 @@ lazy val iconGlob = sys.props("os.name").toLowerCase match {
 
 jdkAppIcon :=  (sourceDirectory.value ** iconGlob).getPaths.headOption.map(file)
 
-jdkPackageType := "installer"
+jdkPackagerType := "installer"
 
 fork := true

--- a/test-project-jdkpackager/src/main/scala/ExampleApp.scala
+++ b/test-project-jdkpackager/src/main/scala/ExampleApp.scala
@@ -1,10 +1,13 @@
 import javafx.application.Application
+import javafx.event.{ActionEvent, EventHandler}
+import javafx.geometry.Pos
 import javafx.scene.Scene
+import javafx.scene.control.{TextArea, Button}
 import javafx.scene.effect.InnerShadow
-import javafx.scene.layout.Pane
+import javafx.scene.layout.{FlowPane, HBox, BorderPane, Pane}
 import javafx.scene.paint.Color
 import javafx.scene.text.{Font, FontWeight, Text}
-import javafx.stage.Stage
+import javafx.stage.{Modality, StageStyle, Stage}
 
 
 /** Silly GUI app launcher. */
@@ -16,18 +19,40 @@ object ExampleApp {
 
 /** Silly GUI app. */
 class ExampleApp extends Application {
+
+  def showProps(stage: Stage) = new EventHandler[ActionEvent] {
+    def handle(event: ActionEvent): Unit = {
+      val win = new Stage(StageStyle.UTILITY)
+      win.initModality(Modality.APPLICATION_MODAL)
+      win.initOwner(stage)
+      val content = new TextArea(
+        sys.props.toSeq.sortBy(_._1).map(p⇒s"${p._1}=${p._2}").mkString("\n")
+      )
+      content.setPrefHeight(400)
+      win.setScene(new Scene(content))
+      win.sizeToScene()
+      win.showAndWait()
+    }
+  }
+
   def start(primaryStage: Stage): Unit = {
     primaryStage.setTitle("Scala on the Desktop!")
-    val stuff = new Text(90, 100, "Hello World")
-    stuff.setFont(Font.font(null, FontWeight.BOLD, 36))
+    val stuff = new Text("Hello World")
+    stuff.setFont(Font.font(null, FontWeight.BOLD, 42))
     stuff.setFill(Color.PEACHPUFF)
     val is = new InnerShadow()
     is.setOffsetX(4.0f)
     is.setOffsetY(4.0f)
     stuff.setEffect(is)
-    val root = new Pane(stuff)
+    val root = new BorderPane(stuff)
     root.setPrefWidth(400)
     root.setPrefHeight(200)
+
+    val b = new Button("Show me props!")
+    b.setOnAction(showProps(primaryStage))
+    root.setBottom(b)
+    BorderPane.setAlignment(b, Pos.CENTER)
+
     primaryStage.setScene(new Scene(root))
     primaryStage.sizeToScene()
     primaryStage.show()

--- a/test-project-jdkpackager/src/universal/conf/jvmopts
+++ b/test-project-jdkpackager/src/universal/conf/jvmopts
@@ -1,0 +1,5 @@
+-Xms512m
+-Xmx1024m
+-XX:ReservedCodeCacheSize=128m
+-DjvmoptsProperty=yehitis
+-Dfizzbuzz=ONAMONAPIA


### PR DESCRIPTION
Added this so standard JVM options encoded in the `con/jvmopts` file are translated and passed on to `javapackager`.