### PR TITLE
Added launcher jar plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   - linux
 script:
   - sbt ++$TRAVIS_SCALA_VERSION "test"
-  - sbt ++$TRAVIS_SCALA_VERSION "scripted rpm/* debian/* universal/*"
+  - sbt ++$TRAVIS_SCALA_VERSION "scripted rpm/* debian/* universal/* jar/*"
 scala:
   - 2.10.3
 jdk:

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
@@ -62,7 +62,7 @@ object JavaAppPackaging extends AutoPlugin with JavaAppStartScript {
     scriptClasspath <<= scriptClasspathOrdering map makeRelativeClasspathNames,
     bashScriptExtraDefines := Nil,
     bashScriptConfigLocation <<= bashScriptConfigLocation ?? None,
-    bashScriptDefines <<= (Keys.mainClass in Compile, scriptClasspath, bashScriptExtraDefines, bashScriptConfigLocation) map { (mainClass, cp, extras, config) =>
+    bashScriptDefines <<= (Keys.mainClass in (Compile, bashScriptDefines), scriptClasspath in bashScriptDefines, bashScriptExtraDefines, bashScriptConfigLocation) map { (mainClass, cp, extras, config) =>
       val hasMain =
         for {
           cn <- mainClass
@@ -72,7 +72,7 @@ object JavaAppPackaging extends AutoPlugin with JavaAppStartScript {
     // TODO - Overridable bash template.
     makeBashScript <<= (bashScriptDefines, target in Universal, executableScriptName, sourceDirectory) map makeUniversalBinScript(bashTemplate),
     batScriptExtraDefines := Nil,
-    batScriptReplacements <<= (packageName, Keys.mainClass in Compile, scriptClasspath, batScriptExtraDefines) map { (name, mainClass, cp, extras) =>
+    batScriptReplacements <<= (packageName, Keys.mainClass in (Compile, batScriptReplacements), scriptClasspath in batScriptReplacements, batScriptExtraDefines) map { (name, mainClass, cp, extras) =>
       mainClass map { mc =>
         JavaAppBatScript.makeReplacements(name = name, mainClass = mc, appClasspath = cp, extras = extras)
       } getOrElse Nil

--- a/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
@@ -1,46 +1,54 @@
 package com.typesafe.sbt.packager
 package archetypes.jar
 
+import java.io.File
+import java.util.jar.Attributes
+
+import sbt.Package.ManifestAttributes
 import sbt._
-import sbt.Keys.{ mappings, target, name, mainClass, sourceDirectory }
-import com.typesafe.sbt.packager.Keys.{ scriptClasspath }
-import com.typesafe.sbt.SbtNativePackager.{ Universal }
+import sbt.Keys._
+import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.SbtNativePackager.Universal
 
 object ClasspathJarPlugin extends AutoPlugin {
 
   object autoImport {
-    val classspathJarName = TaskKey[String]("classpath-jar-name", "classpath-jar name")
+    val packageJavaClasspathJar = TaskKey[File]("packageJavaClasspathJar", "Creates a Java classpath jar that specifies the classpath in its manifest")
   }
   import autoImport._
 
   override def requires = archetypes.JavaAppPackaging
 
-  override lazy val projectSettings = Seq[Setting[_]](
-    classspathJarName <<= (Keys.packageBin in Compile, Keys.projectID, Keys.artifact in Compile in Keys.packageBin) map { (jar, id, art) =>
-      makeJarName(id.organization, id.name, id.revision, art.name, art.classifier)
+  override lazy val projectSettings = Defaults.packageTaskSettings(packageJavaClasspathJar, mappings in packageJavaClasspathJar) ++ Seq(
+    mappings in packageJavaClasspathJar := Nil,
+
+    artifactClassifier in packageJavaClasspathJar := Option("classpath"),
+
+    packageOptions in packageJavaClasspathJar := {
+      val classpath = (scriptClasspath in packageJavaClasspathJar).value
+      val manifestClasspath = Attributes.Name.CLASS_PATH -> classpath.mkString(" ")
+      Seq(
+        ManifestAttributes(manifestClasspath)
+      )
     },
+
+    artifactName in packageJavaClasspathJar := { (scalaVersion, moduleId, artifact) =>
+      moduleId.organization + "." + artifact.name + "-" + moduleId.revision +
+        artifact.classifier.fold("")("-" + _) + "." + artifact.extension
+    },
+
+    scriptClasspath in bashScriptDefines := Seq(
+      (artifactPath in packageJavaClasspathJar).value.getName
+    ),
+
+    scriptClasspath in batScriptReplacements := Seq(
+      (artifactPath in packageJavaClasspathJar).value.getName
+    ),
+
     mappings in Universal += {
-      ((target in Universal).value / "lib" / classspathJarName.value) -> ("lib/" + classspathJarName.value)
-    },
-    scriptClasspath := {
-      writeJar((target in Universal).value / "lib" / classspathJarName.value, scriptClasspath.value)
-      Seq(classspathJarName.value)
+      val classpathJar = packageJavaClasspathJar.value
+      classpathJar -> ("lib/" + classpathJar.getName)
     }
+
   )
-
-  // Constructs a jar name from components...(ModuleID/Artifact)
-  private def makeJarName(org: String, name: String, revision: String, artifactName: String, artifactClassifier: Option[String]): String =
-    (org + "." +
-      name + "-" +
-      Option(artifactName.replace(name, "")).filterNot(_.isEmpty).map(_ + "-").getOrElse("") +
-      revision +
-      artifactClassifier.filterNot(_.isEmpty).map("-" + _).getOrElse("") +
-      "-classpath.jar")
-
-  /** write jar file */
-  private def writeJar(jarFile: File, allClasspath: Seq[String]) = {
-    val manifest = new java.util.jar.Manifest()
-    manifest.getMainAttributes().putValue("Class-Path", allClasspath.mkString(" "))
-    IO.jar(Seq.empty, jarFile, manifest)
-  }
 }

--- a/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
@@ -1,0 +1,60 @@
+package com.typesafe.sbt.packager
+package archetypes.jar
+
+import java.io.File
+import java.util.jar.Attributes
+
+import sbt.Package.ManifestAttributes
+import sbt._
+import sbt.Keys._
+import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.SbtNativePackager.Universal
+
+object LauncherJarPlugin extends AutoPlugin {
+
+  object autoImport {
+    val packageJavaLauncherJar = TaskKey[File]("packageJavaLauncherJar", "Creates a Java launcher jar that specifies the main class and classpath in its manifest")
+  }
+
+  import autoImport._
+
+  override def requires = archetypes.JavaAppPackaging
+
+  override lazy val projectSettings = Defaults.packageTaskSettings(packageJavaLauncherJar, mappings in packageJavaLauncherJar) ++ Seq(
+    mappings in packageJavaLauncherJar := Nil,
+
+    artifactClassifier in packageJavaLauncherJar := Option("launcher"),
+
+    packageOptions in packageJavaLauncherJar := {
+      val classpath = (scriptClasspath in packageJavaLauncherJar).value
+      val manifestClasspath = Attributes.Name.CLASS_PATH -> classpath.mkString(" ")
+      val manifestMainClass = (mainClass in (Compile, packageJavaLauncherJar)).value.map(Attributes.Name.MAIN_CLASS -> _)
+      Seq(
+        ManifestAttributes(
+          manifestMainClass.toSeq :+ manifestClasspath : _*
+        )
+      )
+    },
+
+    artifactName in packageJavaLauncherJar := { (scalaVersion, moduleId, artifact) =>
+      moduleId.organization + "." + artifact.name + "-" + moduleId.revision +
+        artifact.classifier.fold("")("-" + _) + "." + artifact.extension
+    },
+
+    mainClass in (Compile, bashScriptDefines) := {
+      Some("-jar $lib_dir/" + (artifactPath in packageJavaLauncherJar).value.getName)
+    },
+    scriptClasspath in bashScriptDefines := Nil,
+
+    mainClass in (Compile, batScriptReplacements) := {
+      Some("-jar %APP_LIB_DIR%\\" + (artifactPath in packageJavaLauncherJar).value.getName)
+    },
+    scriptClasspath in batScriptReplacements := Nil,
+
+    mappings in Universal += {
+      val javaLauncher = packageJavaLauncherJar.value
+      javaLauncher -> ("lib/" + javaLauncher.getName)
+    }
+
+  )
+}

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerHelper.scala
@@ -1,11 +1,8 @@
 package com.typesafe.sbt.packager.jdkpackager
 
-import java.io.FileNotFoundException
-
 import com.typesafe.sbt.packager.chmod
 import sbt._
 
-import scala.tools.util.PathResolver
 import scala.util.Try
 /**
  * Support/helper functions for interacting with the `javapackager` tool.
@@ -67,7 +64,7 @@ object JDKPackagerHelper {
     description: String,
     maintainer: String,
     packageType: String,
-    mainJar: String,
+    mainJar: File,
     mainClass: Option[String],
     basename: String,
     iconPath: Option[File],
@@ -114,7 +111,7 @@ object JDKPackagerHelper {
 
     val singles = Seq(
       s"-BappVersion=$version",
-      s"-BmainJar=lib/$mainJar"
+      s"-BmainJar=lib/${mainJar.getName}"
     ) ++ iconArg ++ jvmOptsArgs
 
     // Merge singles into argument pair map. (Need a cleaner abstraction)

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
@@ -45,7 +45,7 @@ object JDKPackagerPlugin extends AutoPlugin {
         packageDescription,
         maintainer,
         jdkPackagerType,
-        ClasspathJarPlugin.autoImport.classspathJarName,
+        artifactPath in ClasspathJarPlugin.autoImport.packageJavaClasspathJar,
         mainClass,
         jdkPackagerBasename,
         jdkAppIcon,

--- a/src/sbt-test/jar/launcher-jar/build.sbt
+++ b/src/sbt-test/jar/launcher-jar/build.sbt
@@ -1,0 +1,35 @@
+enablePlugins(LauncherJarPlugin)
+
+name := "launcher-jar-test"
+
+version := "0.1.0"
+
+// test dependencies sample
+libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-kernel" % "2.3.4"
+)
+
+TaskKey[Unit]("check-classpath") := {
+  val dir = (stagingDirectory in Universal).value
+  val bat = IO.read(dir / "bin" / "launcher-jar-test.bat")
+  assert(bat contains "set \"APP_CLASSPATH=\"")
+  assert(bat contains "set \"APP_MAIN_CLASS=-jar %APP_LIB_DIR%\\launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\"")
+  val bash = IO.read(dir / "bin" / "launcher-jar-test")
+  assert(bash contains "declare -r app_classpath=\"\"")
+  assert(bash contains "declare -r app_mainclass=\"-jar $lib_dir/launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\"")
+  val jar = new java.util.jar.JarFile(dir / "lib" / "launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar")
+  val attributes = jar.getManifest().getMainAttributes()
+  assert(attributes.getValue("Class-Path").toString() contains "com.typesafe.akka.akka-actor")
+  assert(attributes.getValue("Main-Class").toString() contains "test.Test")
+  jar close
+}
+
+TaskKey[Unit]("run-check") := { 
+  val dir = (stagingDirectory in Universal).value
+  val cmd = if(System.getProperty("os.name").contains("Windows")){
+    Seq("cmd", "/c", (dir / "bin" / "launcher-jar-test.bat").getAbsolutePath)
+  }else{
+    Seq((dir / "bin" / "launcher-jar-test").getAbsolutePath)
+  }
+  assert(Process(cmd).!! contains "SUCCESS!")
+}

--- a/src/sbt-test/jar/launcher-jar/project/plugins.sbt
+++ b/src/sbt-test/jar/launcher-jar/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/jar/launcher-jar/src/main/scala/test/Test.scala
+++ b/src/sbt-test/jar/launcher-jar/src/main/scala/test/Test.scala
@@ -1,0 +1,19 @@
+package test
+
+// use dependency library
+
+import akka.actor._
+import akka.routing.RoundRobinRouter
+
+class PrintActor extends Actor{
+  def receive = {
+    case msg => println(msg)
+  }
+}
+
+object Test extends App {
+  val system = ActorSystem("testSystem")
+  val router = system.actorOf(Props[PrintActor])
+  router ! "SUCCESS!!"
+  system.shutdown
+}

--- a/src/sbt-test/jar/launcher-jar/src/templates/bat-template
+++ b/src/sbt-test/jar/launcher-jar/src/templates/bat-template
@@ -1,0 +1,21 @@
+@echo off
+rem this template is minimal for test independent
+
+@setlocal enabledelayedexpansion
+@echo off
+
+set "@@APP_ENV_NAME@@_HOME=%~dp0\\.."
+
+set "APP_LIB_DIR=%@@APP_ENV_NAME@@_HOME%\lib\"
+
+set _JAVACMD=%JAVACMD%
+
+if "%_JAVACMD%"=="" (
+  if not "%JAVA_HOME%"=="" (
+    if exist "%JAVA_HOME%\bin\java.exe" set "_JAVACMD=%JAVA_HOME%\bin\java.exe"
+  )
+)
+
+@@APP_DEFINES@@
+
+"%_JAVACMD%" -cp "%APP_CLASSPATH%" %APP_MAIN_CLASS% %*

--- a/src/sbt-test/jar/launcher-jar/test
+++ b/src/sbt-test/jar/launcher-jar/test
@@ -1,0 +1,5 @@
+# Run the staging and check the script.
+> stage
+$ exists target/universal/stage/lib/launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar
+> check-classpath
+> run-check

--- a/src/sphinx/topics/index.rst
+++ b/src/sphinx/topics/index.rst
@@ -7,6 +7,7 @@ Advanced Topics
    :maxdepth: 2
    
    custom.rst
+   longclasspath.rst
    play.rst
    deployment.rst
    documentation.rst

--- a/src/sphinx/topics/longclasspath.rst
+++ b/src/sphinx/topics/longclasspath.rst
@@ -1,0 +1,55 @@
+Dealing with long classpaths
+============================
+
+By default, when the native packager generates a script for starting your application, it will generate an invocation
+of java that that passes every library on the classpath to the classpath argument, ``-cp``.  If you have a lot of
+dependencies, this may result in a very long command being executed, which, aside from being aesthetically unpleasing
+and difficult to work with when using tools like ``ps``, causes problems on some platforms, notably Windows, that have
+limits to how long commands can be.
+
+There are a few ways you can work around this in the native packager.
+
+Generate a launcher jar
+-----------------------
+
+The native packager includes a plugin that allows generating a launcher jar.  This launcher jar will contain no classes,
+but will have your projects main class and classpath in its manifest.  The script that sbt then generates executes this
+jar like so:
+
+.. code-block:: bash
+
+    java -jar myproject-launcher.jar
+
+To enable the launcher jar, enable the ``LauncherJarPlugin``:
+
+.. code-block:: scala
+
+    enablePlugins(LauncherJarPlugin)
+
+Generate a classpath jar
+------------------------
+
+The classpath jar is very similar to the launcher jar, in that it also has the classpath on its manifiest, but it does
+not include the main class in its manifest, and so executed by the start script by invoking:
+
+.. code-block:: bash
+
+    java -cp myproject-classpath.jar some.Main
+
+To enable the classpath jar:
+
+.. code-block:: scala
+
+    enablePlugins(ClasspathJarPlugin)
+
+Configure a wildcard classpath
+------------------------------
+
+JDK 6 and above supports configuring the classpath using wildcards.  To enable this, simply override the
+``scriptClasspath`` task to only contain ``*``, for example:
+
+.. code-block:: scala
+
+    scriptClasspath := Seq("*")
+
+One downside of this approach is that the classpath ordering will no longer match the classpath ordering that sbt uses.


### PR DESCRIPTION
The launcher jar plugin generates a jar with a classpath and main class in the manifest.

Also refactored the classpath jar plugin to use standard sbt ways of building jars, and to depend on the scriptClasspath so that projects that modify it (such as Play) will still work with it.