### PR TITLE
Fix #531: Simplify stop() function on Debian based systems.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -36,18 +36,10 @@ start_daemon() {
 
 
 stop_daemon() {
-
-  log_daemon_msg "Stopping" "${{app_name}}"
-	  if start-stop-daemon --status --pidfile "$PIDFILE"; then
-		  start-stop-daemon --stop --pidfile "$PIDFILE" --retry=TERM/${{term_timeout}}/KILL/${{kill_timeout}}
-		  log_end_msg $?
-	  else
-		  log_progress_msg "not running"
-		  log_end_msg 1
-	  fi
-
-    RETVAL=$?
-    [ $RETVAL -eq 0 ] && [ -e "$PIDFILE" ] && rm -f $PIDFILE
+    log_daemon_msg "Stopping" "${{app_name}}"
+    start-stop-daemon --stop --quiet --oknodo --pidfile "$PIDFILE" --retry=TERM/${{term_timeout}}/KILL/${{kill_timeout}}
+    log_end_msg $?
+    rm -f "$PIDFILE"
 }
 
 case "$1" in


### PR DESCRIPTION
Avoid complex logic with unhandled corner cases. If a process has
crashed leaving an invalid PID file behind, the current logic does
not remove the invalid PID file, although the process is not running.