### PR TITLE
!Update default dockerBaseImage to official repo

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -60,7 +60,7 @@ object DockerPlugin extends AutoPlugin {
   override def requires = universal.UniversalPlugin
 
   override lazy val projectSettings = Seq(
-    dockerBaseImage := "dockerfile/java:latest",
+    dockerBaseImage := "java:latest",
     dockerExposedPorts := Seq(),
     dockerExposedVolumes := Seq(),
     dockerRepository := None,


### PR DESCRIPTION
according to https://blog.docker.com/2015/03/updates-available-to-popular-repos-update-your-images/, all dockerfile/* repos will be replaced with an official repository. This may be a better default configuration.