### PR TITLE
fix SystemV init script template for rpm packaging

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
@@ -22,6 +22,10 @@
 # -----------------
 # JAVA_OPTS="-Dpidfile.path=/var/run/${{app_name}}/play.pid $JAVA_OPTS"
 
+# Setting PIDFILE
+# ---------------
+# PIDFILE="/var/run/${{app_name}}/play.pid"
+
 # export env vars for 3rd party libs
 # ----------------------------------
 # COMPANY_API_KEY=123abc

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -34,7 +34,7 @@
 
 # Source from sysconfig
 # This order means system config appends/overrides package config
-[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+[ -e /etc/sysconfig/${{app_name}} ] && . /etc/sysconfig/${{app_name}}
 
 exec="${{chdir}}/bin/${{exec}}"
 prog="${{app_name}}"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -28,62 +28,48 @@
 # Source function library.
 . /etc/rc.d/init.d/functions
 
-# adding bashScriptEnvConfigLocation
-[[ -f ${{env_config}} ]] && . ${{env_config}}
+# Source from package defined config. Defaults to,
+# bashScriptEnvConfigLocation := Some("/etc/default/" + (packageName in Linux).value)
+[ -e ${{env_config}} ] && . ${{env_config}}
 
-# $JAVA_OPTS used in $RUN_CMD wrapper
+# Source from sysconfig
+# This order means system config appends/overrides package config
+[ -e /etc/sysconfig/$prog ] && . /etc/sysconfig/$prog
+
+exec="${{chdir}}/bin/${{exec}}"
+prog="${{app_name}}"
+lockfile=/var/lock/subsys/$prog
+
+RUN_CMD="$exec >> /var/log/${{app_name}}/daemon.log 2>&1 &"
+
+# $JAVA_OPTS used in $exec wrapper
 export JAVA_OPTS
 
-# FIXME The pid file should be handled by the executed script
-# The pid can be filled in in this script
-PIDFILE=/var/run/${{app_name}}/running.pid
+[ -z "${DAEMON_USER:-}" ] && DAEMON_USER=${{daemon_user}}
 
-if [ -z "$DAEMON_USER" ]; then
-    DAEMON_USER=${{daemon_user}}
+# If program manages its own PID file then it
+# should declare its location in PIDFILE
+if [ -z "${PIDFILE:-}" ]; then
+    PIDFILE=/var/run/${{app_name}}/running.pid
+    # echo $! must run in the shell started by `runuser` in `daemon`
+    RUN_CMD="$RUN_CMD echo \$! > $PIDFILE"
 fi
-
-if [ -z "$DAEMON_GROUP" ]; then
-    DAEMON_GROUP=${{daemon_group}}
-fi
-
-
-# smb could define some additional options in $RUN_OPTS
-RUN_CMD="${{chdir}}/bin/${{exec}}"
-
-[ -e /etc/sysconfig/${{app_name}} ] && . /etc/sysconfig/${{app_name}}
-
-lockfile=/var/lock/subsys/${{app_name}}
 
 start() {
-    [ -x $RUN_CMD ] || exit 5
-    echo -n $"Starting ${{app_name}}: "
-    cd ${{chdir}}
-
-    # FIXME figure out how to use daemon correctly
-    nohup runuser $DAEMON_USER ${RUN_CMD} >> /var/log/${{app_name}}/daemon.log 2>&1 &
-
-    # The way to go, but doesn't work properly
-	# If the app creates the pid file this gets messy
-	# daemon --user $DAEMON_USER --pidfile $PIDFILE $RUN_CMD &
-
-
-    retval=$?   # last error code
-    PID=$!      # pid of last backgrounded process
-    [ $retval -eq 0 ] && touch ${lockfile} && success || failure
-
-    # Insert pid into pid file for CentOS killproc function
-    [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -g "$DAEMON_GROUP" -m755 "/var/run/${{app_name}}"
+    [ -x $exec ] || exit 5
+    echo -n $"Starting $prog: "
+    daemon --check $prog --user $DAEMON_USER --pidfile $PIDFILE "$RUN_CMD"
+    retval=$?
     echo
-    echo $PID > ${PIDFILE}
-    return $retval
+    [ $retval -eq 0 ] && touch $lockfile
 }
 
 stop() {
-    echo -n $"Stopping ${{app_name}}: "
-    killproc -p $PIDFILE ${{app_name}}
+    echo -n $"Stopping $prog: "
+    killproc -p $PIDFILE $prog
     retval=$?
+    echo
     [ $retval -eq 0 ] && rm -f $lockfile
-    return $retval
 }
 
 restart() {
@@ -101,7 +87,7 @@ force_reload() {
 
 rh_status() {
     # run checks to determine if the service is running or use generic status
-    status -p $PIDFILE -l $lockfile ${{app_name}}
+    status -p $PIDFILE -l $lockfile $prog
 }
 
 rh_status_q() {


### PR DESCRIPTION
Main fix is to make use of the `daemon` library function in `start`, correcting broken invocation of `runuser`.

For processes that manage their own pid file, they should define the `PIDFILE` variable (sourced either through `/etc/default/…` or `/etc/sysconfig/…`). Otherwise, if undefined, this script will capture the pid and write it to `/var/run/${{app_name}}/running.pid`.

Other minor changes:

- don’t need to call `success`/`failure` in `start` as this is already done by `daemon`
- don’t need to create `/var/run/${{app_name}}` dir as this is already done by the linux package mappings and thus the dir is created at package install time.