### PR TITLE
Fix warnings from rpm lint

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -38,7 +38,7 @@
 
 exec="${{chdir}}/bin/${{exec}}"
 prog="${{app_name}}"
-lockfile=/var/lock/subsys/$prog
+lockfile="/var/lock/subsys/${{app_name}}"
 
 RUN_CMD="$exec >> /var/log/${{app_name}}/daemon.log 2>&1 &"
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
@@ -234,14 +234,14 @@ object JavaServerAppPackaging extends AutoPlugin {
   }
 
   protected def startScriptMapping(name: String, script: Option[File], loader: ServerLoader, scriptDir: String): Seq[LinuxPackageMapping] = {
-    val (path, permissions) = loader match {
-      case Upstart => ("/etc/init/" + name + ".conf", "0644")
-      case SystemV => ("/etc/init.d/" + name, "0755")
-      case Systemd => ("/usr/lib/systemd/system/" + name + ".service", "0644")
+    val (path, permissions, isConf) = loader match {
+      case Upstart => ("/etc/init/" + name + ".conf", "0644", "true")
+      case SystemV => ("/etc/init.d/" + name, "0755", "false")
+      case Systemd => ("/usr/lib/systemd/system/" + name + ".service", "0644", "true")
     }
     for {
       s <- script.toSeq
-    } yield LinuxPackageMapping(Seq(s -> path), LinuxFileMetaData(Users.Root, Users.Root, permissions, "true"))
+    } yield LinuxPackageMapping(Seq(s -> path), LinuxFileMetaData(Users.Root, Users.Root, permissions, isConf))
   }
 
   protected def makeStartScript(template: URL, replacements: Seq[(String, String)], tmpDir: File, loader: ServerLoader): Option[File] = {

--- a/src/sbt-test/rpm/test-executableScriptName/build.sbt
+++ b/src/sbt-test/rpm/test-executableScriptName/build.sbt
@@ -24,7 +24,7 @@ rpmLicense := Some("BSD")
 TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
   val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
   assert(spec contains "%attr(0644,root,root) /usr/share/rpm-test/lib/rpm-test.rpm-test-0.1.0.jar", "Wrong installation path\n" + spec)
-  assert(spec contains "%config %attr(0755,root,root) /etc/init.d/rpm-test", "Wrong /etc/init.d/\n" + spec)
+  assert(spec contains "%attr(0755,root,root) /etc/init.d/rpm-test", "Wrong /etc/init.d/\n" + spec)
   assert(spec contains "%config %attr(644,root,root) /etc/default/rpm-test", "Wrong etc default file\n" + spec)
   assert(spec contains "%dir %attr(755,rpm-test,rpm-test) /var/log/rpm-test", "Wrong logging dir path\n" + spec)
   assert(spec contains "%dir %attr(755,rpm-test,rpm-test) /var/run/rpm-test", "Wrong /var/run dir path\n" + spec)

--- a/src/sbt-test/rpm/test-packageName/build.sbt
+++ b/src/sbt-test/rpm/test-packageName/build.sbt
@@ -25,7 +25,7 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
   val spec = IO.read(target / "rpm" / "SPECS" / "rpm-package.spec")
   out.log.success(spec)
   assert(spec contains "%attr(0644,root,root) /usr/share/rpm-package/lib/rpm-test.rpm-test-0.1.0.jar", "Wrong installation path\n" + spec)
-  assert(spec contains "%config %attr(0755,root,root) /etc/init.d/rpm-package", "Wrong /etc/init.d path\n" + spec)
+  assert(spec contains "%attr(0755,root,root) /etc/init.d/rpm-package", "Wrong /etc/init.d path\n" + spec)
   assert(spec contains "%config %attr(644,root,root) /etc/default/rpm-package", "Wrong /etc default file\n" + spec)
   assert(spec contains "%dir %attr(755,rpm-package,rpm-package) /var/log/rpm-package", "Wrong logging dir path\n" + spec)
   assert(spec contains "%dir %attr(755,rpm-package,rpm-package) /var/run/rpm-package", "Wrong /var/run dir path\n" + spec)


### PR DESCRIPTION
- fix warning from start script about [lockfile name](https://github.com/matwey/rpmlint/blob/67aec2b86e24d67b0674f4a0a17ac9f9c76ba736/InitScriptCheck.py#L256)
- don’t mark SystemV init script as `%config`