### PR TITLE
Compilation warning cleanup, including removal of deprecated octal literals.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/FileUtil.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/FileUtil.scala
@@ -70,4 +70,10 @@ object permissions {
     case 6 => "rw-"
     case 7 => "rwx"
   }
+
+  /** Enriches string with `oct` interpolator, parsing string as base 8 integer. */
+  implicit class OctalString(val sc: StringContext) extends AnyVal {
+    def oct(args: Any*) = Integer.parseInt(sc.s(args: _*), 8)
+  }
+
 }

--- a/src/main/scala/com/typesafe/sbt/packager/universal/ZipHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/ZipHelper.scala
@@ -64,11 +64,12 @@ object ZipHelper {
    * @param outputZip The location of the output file.
    */
   def zip(sources: Traversable[(File, String)], outputZip: File): Unit = {
+    import permissions.OctalString
     val mappings =
       for {
         (file, name) <- sources.toSeq
         // TODO - Figure out if this is good enough....
-        perm = if (file.isDirectory || file.canExecute) 0755 else 0644
+        perm = if (file.isDirectory || file.canExecute) oct"0755" else oct"0644"
       } yield FileMapping(file, name, Some(perm))
     archive(mappings, outputZip)
   }

--- a/src/main/scala/com/typesafe/sbt/packager/windows/WixHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/windows/WixHelper.scala
@@ -140,7 +140,7 @@ object WixHelper {
                   val name = simpleName(target)
                   val desc = "Edit configuration file: " + name
                   val cleanName = name.replaceAll("[\\.-\\\\//]+", "_")
-                  <Shortcut Id={ id + "_SC" + (s"%0${targetSize}d").format(i+1) } Name={ cleanName } Description={ desc } Target={ "[INSTALLDIR]\\" + target.replaceAll("\\/", "\\\\") } WorkingDirectory="INSTALLDIR"/>
+                  <Shortcut Id={ id + "_SC" + (s"%0${targetSize}d").format(i + 1) } Name={ cleanName } Description={ desc } Target={ "[INSTALLDIR]\\" + target.replaceAll("\\/", "\\\\") } WorkingDirectory="INSTALLDIR"/>
                 }
               }
               <RemoveFolder Id="ApplicationProgramsFolderRemove" Directory="ApplicationProgramsFolder" On="uninstall"/>
@@ -238,7 +238,7 @@ object WixHelper {
    * @return A tuple where the first item is all the Component Ids created,
    *         and the second is the Directory/File/Component XML.
    */
-  @deprecated
+  @deprecated("Use higher level abstraction", "6/28/13")
   def generateComponentsAndDirectoryXml(dir: File, id_prefix: String = ""): (Seq[String], scala.xml.Node) = {
     def makeId(f: File) = cleanStringForId(IO.relativize(dir, f) map (id_prefix+) getOrElse (id_prefix + f.getName))
     def handleFile(f: File): (Seq[String], scala.xml.Node) = {

--- a/src/test/scala/com/typesafe/sbt/packager/FileUtilSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/FileUtilSpec.scala
@@ -22,7 +22,17 @@ class FileUtilSpec extends FlatSpec with Matchers {
     val perm2 = permissions("0755")
     perm2 should not be (empty)
     perm2 should contain only (OWNER_READ, OWNER_WRITE, OWNER_EXECUTE, GROUP_READ, GROUP_EXECUTE, OTHERS_READ, OTHERS_EXECUTE)
-
   }
 
+  "oct" should "parse octal string and convert to an integer" taggedAs (LinuxTag, WindowsTag) in {
+    import permissions._
+    oct"0000" should equal (0)
+    oct"0" should equal (0)
+    oct"777" should equal (511)
+    oct"0777" should equal (511)
+    oct"070" should equal (56)
+    oct"123" should equal (83)
+
+    a [NumberFormatException] should be thrownBy oct"foobar"
+  }
 }


### PR DESCRIPTION
To remove the use of deprecated (in Scala) octal literals, took the approach of parsing octal strings via a string interpolator, in line with this SO on the issue:

http://stackoverflow.com/questions/16590236/scala-2-10-octal-escape-is-deprecated-how-to-do-octal-idiomatically-now/16591277#16591277