### PR TITLE
Remove `in Docker` from dockerExposedPorts in docs

### DIFF
--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -85,7 +85,7 @@ Environment Settings
   ``daemonUser in Docker``
     The user to use when executing the application. Files below the install path also have their ownership set to this user.
 
-  ``dockerExposedPorts in Docker``
+  ``dockerExposedPorts``
     A list of ports to expose from the Docker image.
 
   ``dockerExposedVolumes in Docker``


### PR DESCRIPTION
I found out the hard way that putting `dockerExposedPorts in Docker := Seq(9000, 9443)` into your build.sbt does nothing. The correct setting is `dockerExposedPorts := Seq(9000, 9443)`. I believe the docs, as they are, are misleading.