### PR TITLE
Use docker on windows #573

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -57,6 +57,12 @@ object DockerPlugin extends AutoPlugin {
 
   import autoImport._
 
+  /**
+   * The separator for makeAdd force UNIX separator.
+   * The separator doesn't depend to OS where i build Dockerfile.
+   */
+  val UnixSeparatorChar = '/'
+
   override def requires = universal.UniversalPlugin
 
   override lazy val projectSettings = Seq(
@@ -149,7 +155,7 @@ object DockerPlugin extends AutoPlugin {
    * @return ADD command adding all files inside the installation directory
    */
   private final def makeAdd(dockerBaseDirectory: String): CmdLike = {
-    val files = dockerBaseDirectory.split(java.io.File.separator)(1)
+    val files = dockerBaseDirectory.split(UnixSeparatorChar)(1)
     Cmd("ADD", s"$files /$files")
   }
 


### PR DESCRIPTION
When native-packager add a folder in Dockerfile, it uses "File.separator" but this add doesn't depend to context of build.