### PR TITLE
tar --force-local

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
@@ -179,7 +179,7 @@ object Archives {
 
       val tmptar = f / (relname + ".tar")
 
-      Process(Seq("tar", "-pcvf", tmptar.getAbsolutePath) ++ distdirs, Some(rdir)).! match {
+      Process(Seq("tar", "-pcvf", "--force-local", tmptar.getAbsolutePath) ++ distdirs, Some(rdir)).! match {
         case 0 => ()
         case n => sys.error("Error tarballing " + tarball + ". Exit code: " + n)
       }


### PR DESCRIPTION
MSYS/MinGW windows tar is not able to pack files with absolute paths because of the essence of the colons(i.e. "C:\Code\..."). Colons are treated by tar as links to remote machines. This is not the case of usage for sbt packager.

So, forcing local, from tar man page :
```
--force-local
    archive file is local even if it has a colon 
```