### PR TITLE
If the /var/run (aka /run) folder doesn't exist for the PID file, create it

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemd/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemd/start-template
@@ -9,6 +9,10 @@ ExecStart=${{chdir}}/bin/${{exec}}
 Restart=always
 RestartSec=${{retryTimeout}}
 User=${{daemon_user}}
+ExecStartPre=/bin/mkdir -p /run/${{app_name}}
+ExecStartPre=/bin/chown ${{daemon_user}}:${{daemon_group}} /run/${{app_name}}
+ExecStartPre=/bin/chmod 755 /run/${{app_name}}
+PermissionsStartOnly=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
CentOS 7 and many other recent Linuxes have switched to a non-persistent (tmpfs) /run folder, with /var/run being a symbolic link to the tmpfs /run mount.  The RPM creates the correct folder in /var/run for the PID file, but on reboot, that file is gone.  There are many ways to fix it.  This way will work on older systemd versions.

This change was tested on CentOS 7.
