### PR TITLE
Upstart: source /etc/default/${{app_name}}

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/upstart/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/upstart/start-template
@@ -6,7 +6,7 @@ author "${{author}}"
 # Stanzas
 #
 # Stanzas control when and how a process is started and stopped
-# See a list of stanzas here: http://upstart.ubuntu.com/wiki/Stanzas#respawn
+# See a list of stanzas here: http://upstart.ubuntu.com/wiki/Stanzas
 
 # When to start the service
 start on runlevel ${{start_runlevels}}
@@ -27,7 +27,11 @@ end script
 # set the working directory of the job processes
 chdir ${{chdir}}
 
+setuid ${{daemon_user}}
+setgid ${{daemon_group}}
+
 # Start the process
 script
-  exec sudo -u ${{daemon_user}} bin/${{exec}}
+  . /etc/default/${{app_name}}
+  bin/${{exec}}
 end script


### PR DESCRIPTION
This should fix the limitation mentioned in http://www.scala-sbt.org/sbt-native-packager/archetypes/java_server/customize.html#linux-configuration:

> The server archetype adds an additional way with an etc-default file placed in src/templates, which currently only works for SystemV.
