### PR TITLE
overridable bash and bat templates

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
@@ -9,6 +9,7 @@ import sbt._
 trait JavaAppKeys {
 
   val makeBashScript = TaskKey[Option[File]]("makeBashScript", "Creates or discovers the bash script used by this project.")
+  val bashScriptTemplateLocation = TaskKey[File]("bashScriptTemplateLocation", "The location of the bash script template.")
   val bashScriptDefines = TaskKey[Seq[String]]("bashScriptDefines", "A list of definitions that should be written to the bash file template.")
   val bashScriptExtraDefines = TaskKey[Seq[String]]("bashScriptExtraDefines", "A list of extra definitions that should be written to the bash file template.")
   val bashScriptConfigLocation = TaskKey[Option[String]]("bashScriptConfigLocation", "The location where the bash script will load default argument configuration from.")
@@ -18,6 +19,7 @@ trait JavaAppKeys {
   val projectDependencyArtifacts = TaskKey[Seq[Attributed[File]]]("projectDependencyArtifacts", "The set of exported artifacts from our dependent projects.")
   val scriptClasspath = TaskKey[Seq[String]]("scriptClasspath", "A list of relative filenames (to the lib/ folder in the distribution) of what to include on the classpath.")
   val makeBatScript = TaskKey[Option[File]]("makeBatScript", "Creates or discovers the bat script used by this project.")
+  val batScriptTemplateLocation = TaskKey[File]("batScriptTemplateLocation", "The location of the bat script template.")
   val batScriptReplacements = TaskKey[Seq[(String, String)]](
     "batScriptReplacements",
     """|Replacements of template parameters used in the windows bat script.

--- a/src/sbt-test/bash/override-templates/build.sbt
+++ b/src/sbt-test/bash/override-templates/build.sbt
@@ -1,0 +1,26 @@
+import scala.io.Source
+
+enablePlugins(JavaAppPackaging)
+
+name := "override-templates"
+
+version := "0.1.0"
+
+bashScriptTemplateLocation := baseDirectory.value / "custom-templates" / "custom-bash-template"
+
+batScriptTemplateLocation := baseDirectory.value / "custom-templates" / "custom-bat-template"
+
+TaskKey[Unit]("run-check-bash") := {
+  val cwd = (stagingDirectory in Universal).value
+  val source = scala.io.Source.fromFile((cwd / "bin" / packageName.value).getAbsolutePath)
+  val contents = try source.getLines mkString "\n" finally source.close()
+  assert(contents contains "this is the custom bash template", "Bash template didn't contain the right text: \n" + contents)
+}
+
+TaskKey[Unit]("run-check-bat") := {
+  val cwd = (stagingDirectory in Universal).value
+  val batFilename = packageName.value + ".bat"
+  val source = scala.io.Source.fromFile((cwd / "bin" / batFilename).getAbsolutePath)
+  val contents = try source.getLines mkString "\n" finally source.close()
+  assert(contents contains "this is the custom bat template", "Bat template didn't contain the right text: \n" + contents)
+}

--- a/src/sbt-test/bash/override-templates/custom-templates/custom-bash-template
+++ b/src/sbt-test/bash/override-templates/custom-templates/custom-bash-template
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+# this is the custom bash template

--- a/src/sbt-test/bash/override-templates/custom-templates/custom-bat-template
+++ b/src/sbt-test/bash/override-templates/custom-templates/custom-bat-template
@@ -1,0 +1,1 @@
+@REM this is the custom bat template

--- a/src/sbt-test/bash/override-templates/project/plugins.sbt
+++ b/src/sbt-test/bash/override-templates/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/bash/override-templates/src/main/scala/MainApp.scala
+++ b/src/sbt-test/bash/override-templates/src/main/scala/MainApp.scala
@@ -1,0 +1,3 @@
+object MainApp extends App {
+  println("SUCCESS!")
+}

--- a/src/sbt-test/bash/override-templates/test
+++ b/src/sbt-test/bash/override-templates/test
@@ -1,0 +1,4 @@
+# Run the staging and check the script.
+> stage
+> run-check-bash
+> run-check-bat

--- a/src/sphinx/archetypes/java_app/customize.rst
+++ b/src/sphinx/archetypes/java_app/customize.rst
@@ -261,7 +261,8 @@ to ``bashScriptExtraDefines`` as other stages in the pipeline may be include lin
 Overriding Templates (Bash/Bat)
 -------------------------------
 
-In order to override full templates, like the default bash script, create a file in ``src/templates/bash-template`` 
+In order to override full templates, like the default bash script, you can create a file in ``src/templates/bash-template``.
+Alternatively, you can use a different file location by setting ``bashScriptTemplateLocation``.
 
 .. code-block:: bash
 
@@ -297,7 +298,8 @@ In order to override full templates, like the default bash script, create a file
     exec java -cp $app_classpath $app_mainclass $@
 
 
-Similarly the windows BAT template can be overridden by placing a new template in ``src/templates/bat-template``
+Similarly the windows BAT template can be overridden by placing a new template in ``src/templates/bat-template``.
+You can also use a different file location by setting ``batScriptTemplateLocation``.
 
 .. code-block:: bat
 
@@ -325,11 +327,10 @@ While we just replaced the default templates with simpler templates, this should
 In general, the templates are intended to provide enough utility that customization is only necessary for truly custom scripts.
 
 
-``src/templates/bat-template``
+Overriding bat templates (``src/templates/bat-template`` or a custom path using ``batScriptTemplateLocation``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Creating a file here will override the default template used to
-generate the ``.bat`` script for windows distributions.
+This will override the default template used to generate the ``.bat`` script for windows distributions.
 
 **Syntax**
 
@@ -342,11 +343,10 @@ generate the ``.bat`` script for windows distributions.
 
 You can define additional variable definitions using ``batScriptExtraDefines``.
 
-``src/templates/bash-template``
+Overriding bash templates (``src/templates/bash-template`` or a custom path using ``bashScriptTemplateLocation``)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Creating a file here will override the default template used to
-generate the BASH start script found in ``bin/<application>`` in the
+This will override the default template used to generate the BASH start script found in ``bin/<application>`` in the
 universal distribution
 
 **Syntax**


### PR DESCRIPTION
This implements feature request #635. 

I left the old method signatures in the [`JavaAppStartScript`](https://github.com/sbt/sbt-native-packager/blob/6cd1c3a04591dba721ea7e022c5d98c1230bbc7d/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala#L282) trait, for backwards compatibility. Is this something that you could use? Should I add an example test project demonstrating this feature?