### PR TITLE
Use spotify docker-client for docker:publishLocal goal

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ scalacOptions in Compile ++= Seq("-deprecation", "-target:jvm-1.6")
 
 libraryDependencies ++= Seq(
     "org.apache.commons" % "commons-compress" % "1.4.1",
+    "com.spotify" % "docker-client" % "3.1.3",
     "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar")),
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -279,7 +279,7 @@ object DockerPlugin extends AutoPlugin {
   def publishLocalDocker(context: File, tag: String, latest: Boolean, log: Logger): Unit = {
     val cmd = Seq("docker", "build", "--force-rm", "-t", tag, ".")
 
-    log.debug("Executing " + cmd.mkString(" "))
+    log.debug("Executing Native " + cmd.mkString(" "))
     log.debug("Working directory " + context.toString)
 
     val ret = Process(cmd, context) ! publishLocalLogger(log)

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -1,0 +1,83 @@
+package com.typesafe.sbt
+package packager
+package docker
+
+import java.nio.file.Paths
+
+import com.spotify.docker.client.messages.ProgressMessage
+import com.spotify.docker.client.{ProgressHandler, DockerClient, DefaultDockerClient}
+import com.spotify.docker.client.DockerClient.BuildParameter._
+import sbt._
+import sbt.Keys._
+import packager.Keys._
+import universal.UniversalPlugin.autoImport.stage
+
+
+/**
+ * == DockerSpotifyClientPlugin Plugin ==
+ *
+ * This plugin helps you build docker containers using Spotify Docker Client.
+ *
+ * == Configuration ==
+ *
+ * In order to configure this plugin take a look at the available [[com.typesafe.sbt.packager.docker.DockerKeys]]
+ *
+ * == Requirements ==
+ *
+ * You need docker to have docker installed on your system.
+ * Check with a single command:
+ *
+ * {{{
+ * docker version
+ * }}}
+ *
+ *
+ * @note this plugin is not intended to build very customizable docker images, but turn your mappings
+ *       configuration in a docker image with almost no ''any'' configuration.
+ *
+ * @example Enable the plugin in the `build.sbt`
+ *          {{{
+ *              enablePlugins(DockerSpotifyClientPlugin)
+ *          }}}
+ */
+object DockerSpotifyClientPlugin extends AutoPlugin {
+
+  override def requires = DockerPlugin
+
+  import DockerPlugin.autoImport._
+
+  override lazy val projectSettings = inConfig(Docker)(clientSettings)
+
+  def clientSettings = Seq(
+    publishLocal := publishLocalDocker.value
+
+  )
+
+  def publishLocalDocker = Def.task {
+    val context = stage.value
+    val tag = dockerTarget.value
+    val latest = dockerUpdateLatest.value
+    val log = streams.value.log
+
+    val dockerDirectory = context.toString
+    val docker: DockerClient = DefaultDockerClient.fromEnv().build()
+
+    log.info(s"PublishLocal using Docker API ${docker.version().apiVersion()}")
+
+    val id = docker.build(Paths.get(dockerDirectory), tag, new ProgressHandler() {
+      def progress(message: ProgressMessage) = {
+        Option(message.error()) match {
+          case Some(error) if error.nonEmpty => log.error(message.error())
+          case _ => log.info(message.stream())
+        }
+      }
+    }, FORCE_RM)
+
+    if (latest) {
+      val name = tag.substring(0, tag.lastIndexOf(":")) + ":latest"
+      docker.tag(tag, name, true)
+    }
+  }
+
+
+}

--- a/test-project-docker/build.sbt
+++ b/test-project-docker/build.sbt
@@ -1,6 +1,7 @@
 import com.typesafe.sbt.packager.docker._
 
 enablePlugins(JavaAppPackaging)
+enablePlugins(DockerSpotifyClientPlugin)
 
 name := "docker-test"
 


### PR DESCRIPTION
Handle #558 only for `publishLocal`.

`publish` is a little bit complex as it requires to handle push to private repositories and credentials.