### PR TITLE
Support for relocatable RPMs

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/rpm/preinst-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/rpm/preinst-template
@@ -9,3 +9,6 @@ then
     addGroup ${{daemon_group}} "${{daemon_group_gid}}"
     addUser ${{daemon_user}} "${{daemon_user_uid}}" ${{daemon_group}} "${{app_name}} user-daemon" "${{daemon_shell}}"
 fi
+
+[ -e /etc/sysconfig/${{app_name}} ] && sed -i 's/PACKAGE_PREFIX\=.*//g' /etc/sysconfig/${{app_name}}
+[ -n "$RPM_INSTALL_PREFIX" ] && echo "PACKAGE_PREFIX=${RPM_INSTALL_PREFIX}" >> /etc/sysconfig/${{app_name}}

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -36,9 +36,10 @@
 # This order means system config appends/overrides package config
 [ -e /etc/sysconfig/${{app_name}} ] && . /etc/sysconfig/${{app_name}}
 
-cd ${{chdir}}
+INSTALL_DIR="${{chdir}}"
+[ -n "${PACKAGE_PREFIX}" ] && INSTALL_DIR="${PACKAGE_PREFIX}/${{app_name}}"
 
-exec="${{chdir}}/bin/${{exec}}"
+exec="$INSTALL_DIR/bin/${{exec}}"
 prog="${{app_name}}"
 lockfile="/var/lock/subsys/${{app_name}}"
 


### PR DESCRIPTION
Save the value of `RPM_INSTALL_PREFIX` into application's sysconfig file.

Upon application start up, look for this value, else use the `chdir` value supplied via sbt templates.

--

I have two options in detecting where the RPM package is installed.

**Option 1: Use `RPM_INSTALL_PREFIX` provided during installation process**

The `RPM_INSTALL_PREFIX` environment variable is only provided during the install time. This value would need to be persisted so it can be retrieved during application start-up.

**Option 2: Use rpm command**

The command `rpm -q --queryformat "%{INSTPREFIXES}" ${{app_name}}` will print out the location where the package is installed. This command works for both Redhat 6 and 7.

I have decided to go with Option 1 because we are using the values provided to us by the operating system instead of trying to deduce this value ourselves.

The downside of this approach is:
* I am persisting the value of `RPM_INSTALL_PREFIX` in the `/etc/sysconfig/${{app_name}}`.
* I need to replace this information at re-install time or upgrade time.

@muuki88 and @edwardcallahan - can I get your thoughts on my approach please? Happy to change if you think Option 2 is a better way to move forward.
