### PR TITLE
Undo change adding --force-local option to invocation of tar

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
@@ -179,7 +179,7 @@ object Archives {
 
       val tmptar = f / (relname + ".tar")
 
-      Process(Seq("tar", "--force-local", "-pcvf", tmptar.getAbsolutePath) ++ distdirs, Some(rdir)).! match {
+      Process(Seq("tar", "-pcvf", tmptar.getAbsolutePath) ++ distdirs, Some(rdir)).! match {
         case 0 => ()
         case n => sys.error("Error tarballing " + tarball + ". Exit code: " + n)
       }

--- a/src/sphinx/formats/universal.rst
+++ b/src/sphinx/formats/universal.rst
@@ -166,6 +166,11 @@ Tasks
   ``universal-docs:package-xz-tarball``
     Creates the ``txz`` universal documentation package.  The ``xz`` command can get better compression
     for some types of archives.
+
+**Note: Some versions of ``tar`` interpret archive file-names that contain a colon as being the name of a remote tape drive.
+Since the name of the archive file is derived from the name of your ``sbt`` project, if the ``tar`` on your system supports the
+``--force-local`` option and you wish to create a tar-format output package then you should refrain from including colons in the
+name of your project.**
     
 Customize
 ---------


### PR DESCRIPTION
[A commit](https://github.com/sbt/sbt-native-packager/commit/888e8ad2396e8c19e57a3ca220b3fe8fe637ef14) on June 15 changed the invocation of `tar` always to use the `--force-local` option, which some common versions of `tar` lack and which will cause such versions of tar to fail to run.  I understand [the reason for the change](https://github.com/sbt/sbt-native-packager/pull/597) is based on the behavior of the version of `tar` used by [http://www.mingw.org/wiki/msys](MinGW).

The option in question changes `tar`'s interpretation of archive names that contain a colon.  Versions of  `tar` that support the `--force-local` option will generally interpret a colon as meaning that the archive name refers to a remote tape drive, and using that option disables that behavior.  Meanwhile, versions that lack that option also lack support for remote archives.  For reference, see:

* [Gnu Tar Manual](http://www.gnu.org/software/tar/manual/tar.html#local-and-remote-archives)
* [FreeBSD Tar Manual](https://www.freebsd.org/cgi/man.cgi?query=tar&apropos=0&sektion=0&manpath=FreeBSD+10.2-RELEASE&arch=default&format=html)

The June 15 change was a consequence of someone having a problem caused by a colon in the name of an archive, which apparently is a situation caused by the nature of absolute paths in Windows.  I lack knowledge of anything further regarding such problem, in particular the number of people affected.

What I do know is that this plugin, `sbt-native-packager`, is used by the popular [_Play Framework_](https://www.playframework.com/documentation/2.4.x/Production#The-Native-Packager).  The latest version of _Play_ depends on [version 1.0.1](https://github.com/playframework/playframework/blob/master/framework/project/plugins.sbt#L7) of `sbt-native-packager`, and thus still invokes `tar` without the `--force-local` option.  If and when a new version of _Play_ is released that depends on a newer version of `sbt-native-packager` that invokes `tar` with the `--force-local` option, an untold number of projects that are currently deployable will become undeployable as a result of upgrading the _Play_ version.

If I had to guess, I would expect that use of `sbt-native-packager` on systems with non-gnu versions of `tar`, such as FreeBSD, is more widespread than its use on Windows systems with MinGW.  I admit I lack an objective measurement to support that guess.  Whether or not that guess is consistent with reality, but more so if it is, the change of June 15 swaps a problem for some people with a problem for other people.  While I agree a problem for anyone is undesirable, the principle of backwards-compatibility prefers the _status quo_, wherein those with a problem are aware of it already, over changing one problem for another, whereby an indeterminate number of working projects will break unexpectedly.

I also note that I could not find any warnings in the `sbt-native-packager` documentation alerting users that upgrading `sbt-native-packager` so as to apply the change introduced on June 15 will cause some previously working configurations to break.

For the foregoing reasons I conclude that while neither always nor never invoking `tar` with `--force-local` is optimal for everyone, the choice of always omitting that option is less bad than the alternative of always including it, and thus reverting this plugin's invocation of `tar` to its _status quo_ before June 15 will place this project in a less-bad state than it currently is in.  Merging this pull-request will effect that reversion.

----

For further reference see [Issue 662](https://github.com/sbt/sbt-native-packager/issues/662)