### PR TITLE
under upstart, use start-stop-daemon -c instead of sudo -u

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/upstart/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/upstart/start-template
@@ -24,10 +24,7 @@ pre-start script
 	[ -d /var/run/${{app_name}} ] || install -m 755 -o ${{daemon_user}} -g ${{daemon_group}} -d /var/run/${{app_name}}
 end script
 
-# set the working directory of the job processes
-chdir ${{chdir}}
-
 # Start the process
 script
-  exec sudo -u ${{daemon_user}} bin/${{exec}}
+  start-stop-daemon --start -c ${{daemon_user}} --exec {{chdir}}/bin/${{exec}}
 end script


### PR DESCRIPTION
Using ```start-stop-daemon``` instead of ```exec sudo -u``` allows, for example, setting environment variables in ```/etc/init/$service.override```. Using ```sudo``` resets the environment, so these overrides are lost.

Probably I miss some reasons why ```sudo``` was chosen, though.

An even more upstart-correct way of doing things would be just using ```exec``` with correct ```setuid/setgid``` stanzas, but this will prevent us from being able to run pre-start/post-stop sections as root, which might be useful for some.