### PR TITLE
Fixes for RPM related functionality in 1.0.5-M2

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/rpm/preinst-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/rpm/preinst-template
@@ -10,5 +10,12 @@ then
     addUser ${{daemon_user}} "${{daemon_user_uid}}" ${{daemon_group}} "${{app_name}} user-daemon" "${{daemon_shell}}"
 fi
 
-[ -e /etc/sysconfig/${{app_name}} ] && sed -i 's/PACKAGE_PREFIX\=.*//g' /etc/sysconfig/${{app_name}}
-[ -n "$RPM_INSTALL_PREFIX" ] && echo "PACKAGE_PREFIX=${RPM_INSTALL_PREFIX}" >> /etc/sysconfig/${{app_name}}
+if [ -e /etc/sysconfig/${{app_name}} ] ;
+then
+  sed -i 's/PACKAGE_PREFIX\=.*//g' /etc/sysconfig/${{app_name}}
+fi
+
+if [ -n "$RPM_INSTALL_PREFIX" ] ;
+then
+  echo "PACKAGE_PREFIX=${RPM_INSTALL_PREFIX}" >> /etc/sysconfig/${{app_name}}
+fi

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -38,6 +38,7 @@
 
 INSTALL_DIR="${{chdir}}"
 [ -n "${PACKAGE_PREFIX}" ] && INSTALL_DIR="${PACKAGE_PREFIX}/${{app_name}}"
+cd $INSTALL_DIR
 
 exec="$INSTALL_DIR/bin/${{exec}}"
 prog="${{app_name}}"

--- a/src/sbt-test/rpm/sysvinit-rpm/build.sbt
+++ b/src/sbt-test/rpm/sysvinit-rpm/build.sbt
@@ -32,6 +32,12 @@ TaskKey[Unit]("unzipAndCheck") <<= (baseDirectory, packageBin in Rpm, streams) m
     assert(scriptlets contains "deleteUser rpm-test", "deleteUser rpm not present in \n" + scriptlets)
 
     val startupScript = IO.read(baseDir / "etc" / "init.d" / "rpm-test")
+    assert(startupScript contains
+      """
+        |INSTALL_DIR="/usr/share/rpm-test"
+        |[ -n "${PACKAGE_PREFIX}" ] && INSTALL_DIR="${PACKAGE_PREFIX}/rpm-test"
+        |cd $INSTALL_DIR
+        |""".stripMargin, "Ensuring application is running on the install directory is not present in \n" + startupScript)
     assert(startupScript contains """RUN_CMD="$exec >> /var/log/rpm-test/test.log 2>&1 &"""", "Setting key rpmDaemonLogFile not present in \n" + startupScript)
 
     // TODO check symlinks

--- a/src/sbt-test/rpm/sysvinit-rpm/build.sbt
+++ b/src/sbt-test/rpm/sysvinit-rpm/build.sbt
@@ -46,8 +46,15 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
     assert(spec contains "deleteUser rpm-test", "deleteUser rpm not present in \n" + spec)
     assert(spec contains
       """
-        |[ -e /etc/sysconfig/rpm-test ] && sed -i 's/PACKAGE_PREFIX\=.*//g' /etc/sysconfig/rpm-test
-        |[ -n "$RPM_INSTALL_PREFIX" ] && echo "PACKAGE_PREFIX=${RPM_INSTALL_PREFIX}" >> /etc/sysconfig/rpm-test
+        |if [ -e /etc/sysconfig/rpm-test ] ;
+        |then
+        |  sed -i 's/PACKAGE_PREFIX\=.*//g' /etc/sysconfig/rpm-test
+        |fi
+        |
+        |if [ -n "$RPM_INSTALL_PREFIX" ] ;
+        |then
+        |  echo "PACKAGE_PREFIX=${RPM_INSTALL_PREFIX}" >> /etc/sysconfig/rpm-test
+        |fi
         |""".stripMargin, "Persisting $RPM_INSTALL_PREFIX not present in \n" + spec)
     ()
 }


### PR DESCRIPTION
The fixes address the following issues.

**Ensure RPM preinst script continues normally when `rpmPrefix` is not declared**
Without this fix, when `rpmPrefix` is not declared, the `preinst` will terminate in error.

**Ensure application is running on the installed directory in the RPM-based distribution**
This was fixed as part of PR #653 which was accidentally removed in PR #661. Tests are added to prevent this regression from occurring.

