### PR TITLE
Added rpm-build as a Requirement for *.rpm

### DIFF
--- a/src/sphinx/formats/rpm.rst
+++ b/src/sphinx/formats/rpm.rst
@@ -26,6 +26,7 @@ Requirements
 You need the following applications installed
 
 * rpm
+* rpm-build
 
 Build
 -----


### PR DESCRIPTION
Currently rpm-build is a requirement of the rpm format aswell, it will fail hardly if you don't have it installed.