### PR TITLE
Ensure pidfile dir on systemv rpm template exists

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -51,6 +51,12 @@ export JAVA_OPTS
 
 [ -z "${DAEMON_USER:-}" ] && DAEMON_USER=${{daemon_user}}
 
+# create PIDDIR where PIDFILE will be kept
+if [ -z "${PIDDIR:-}" ]; then
+    PIDDIR=/var/run/${{app_name}}/
+    mkdir -p $PIDDIR && chown $DAEMON_USER:$DAEMON_USER $PIDDIR
+fi
+
 # If program manages its own PID file then it
 # should declare its location in PIDFILE
 if [ -z "${PIDFILE:-}" ]; then


### PR DESCRIPTION
On CentOS 7 /run is tmpfs, and /var/run is a symlink to /run.

Upon reboot the /var/run/${{app_name}} directory (created by the RPM)
will be blown away, causing the init script to fail - but still spawn
the service as a side effect.

This change will create the /var/run/${{app_name}} directory if it does
not already exist, and change the owner to $DAEMON_USER.