### PR TITLE
Relocatable rpm symlink fix

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
@@ -295,5 +295,4 @@ object JavaServerAppPackaging extends AutoPlugin {
       case script => TemplateWriter generateScriptFromString (content + script, replacements)
     }
   }
-
 }

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
@@ -79,7 +79,7 @@ object LinuxPlugin extends AutoPlugin {
       author = (maintainer in Linux).value,
       description = (packageSummary in Linux).value,
       execScript = (executableScriptName in Linux).value,
-      chdir = s"${defaultLinuxInstallLocation.value}/${(packageName in Linux).value}",
+      chdir = chdir(defaultLinuxInstallLocation.value, (packageName in Linux).value),
       logdir = defaultLinuxLogsLocation.value,
       appName = (packageName in Linux).value,
       version = sbt.Keys.version.value,
@@ -248,5 +248,8 @@ object LinuxPlugin extends AutoPlugin {
       packageMappingWithRename(remaining: _*) withUser user withGroup group withPerms "0644"
     )
   }
+
+  final def chdir(installLocation: String, packageName: String): String =
+    s"$installLocation/$packageName"
 
 }

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -48,9 +48,6 @@ object RpmHelper {
       if file.exists && !file.isDirectory()
       target = buildroot / dest
     } copyWithZip(file, target, mapping.zipped)
-
-    // Now we create symlinks
-    LinuxSymlink.makeSymLinks(spec.symlinks, buildroot)
   }
 
   private[this] def writeSpecFile(spec: RpmSpec, workArea: File, log: sbt.Logger): File = {

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -102,7 +102,7 @@ object RpmPlugin extends AutoPlugin {
       rpmScripts <<=
         (rpmPretrans, rpmPre, rpmPost, rpmVerifyscript, rpmPosttrans, rpmPreun, rpmPostun) apply RpmScripts,
       rpmSpecConfig <<=
-        (rpmMetadata, rpmDescription, rpmDependencies, rpmScripts, linuxPackageMappings, linuxPackageSymlinks) map RpmSpec,
+        (rpmMetadata, rpmDescription, rpmDependencies, rpmScripts, linuxPackageMappings, linuxPackageSymlinks, defaultLinuxInstallLocation) map RpmSpec,
       packageBin <<= (rpmSpecConfig, target, streams) map { (spec, dir, s) =>
         spec.validate(s.log)
         RpmHelper.buildRpm(spec, dir, s.log)

--- a/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
@@ -208,8 +208,7 @@ object Archives {
   def makeTarball(compressor: File => File, ext: String)(target: File, name: String, mappings: Seq[(File, String)], top: Option[String]): File =
     makeTarballWithOptions(compressor, ext)(target, name, mappings, top, options = Seq("--force-local", "-pcvf"))
 
-
-    /**
+  /**
    * Helper method used to construct tar-related compression functions.
    * @param target folder to build package in
    * @param name of output (without extension)

--- a/src/sbt-test/jar/classpath-jar/src/main/scala/test/Test.scala
+++ b/src/sbt-test/jar/classpath-jar/src/main/scala/test/Test.scala
@@ -3,17 +3,27 @@ package test
 // use dependency library
 
 import akka.actor._
+import akka.pattern._
 import akka.routing.RoundRobinRouter
+import akka.util.Timeout
+import scala.concurrent.duration._
 
 class PrintActor extends Actor{
   def receive = {
-    case msg => println(msg)
+    case msg =>
+      println(msg)
+      context.sender ! "ok"
   }
 }
 
 object Test extends App {
+  implicit val timeout = Timeout(3 seconds)
+
   val system = ActorSystem("testSystem")
+  import system.dispatcher
+
   val router = system.actorOf(Props[PrintActor])
-  router ! "SUCCESS!!"
-  system.shutdown
+  (router ? "SUCCESS!!").foreach { _ =>
+    system.shutdown
+  }
 }

--- a/src/sbt-test/rpm/scriptlets-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriptlets-rpm/build.sbt
@@ -35,10 +35,44 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
   val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
   assert(spec contains "%pre\necho \"pre-install\"", "Spec doesn't contain %pre scriptlet")
   assert(spec contains "%post\necho \"post-install\"", "Spec doesn't contain %post scriptlet")
+  assert(spec contains
+    """
+      |%post
+      |echo "post-install"
+      |
+      |relocateLink() {
+      |  if [ -n "$4" ] ;
+      |  then
+      |    RELOCATED_INSTALL_DIR="$4/$3"
+      |    echo "${1/$2/$RELOCATED_INSTALL_DIR}"
+      |  else
+      |    echo "$1"
+      |  fi
+      |}
+      |rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX) && ln -s $(relocateLink /usr/share/rpm-test/conf /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX) $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX)
+      |""".stripMargin, "%post scriptlet does not contain relocateLink")
+
   assert(spec contains "%pretrans\necho \"pretrans\"", "Spec doesn't contain %pretrans scriptlet")
   assert(spec contains "%posttrans\necho \"posttrans\"", "Spec doesn't contain %posttrans scriptlet")
   assert(spec contains "%preun\necho \"pre-uninstall\"", "Spec doesn't contain %preun scriptlet")
   assert(spec contains "%postun\necho \"post-uninstall\"", "Spec doesn't contain %postun scriptlet")
+  assert(spec contains
+    """
+      |%postun
+      |echo "post-uninstall"
+      |
+      |relocateLink() {
+      |  if [ -n "$4" ] ;
+      |  then
+      |    RELOCATED_INSTALL_DIR="$4/$3"
+      |    echo "${1/$2/$RELOCATED_INSTALL_DIR}"
+      |  else
+      |    echo "$1"
+      |  fi
+      |}
+      |[ -e /etc/sysconfig/rpm-test ] && . /etc/sysconfig/rpm-test
+      |rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $PACKAGE_PREFIX)
+      |""".stripMargin, "%postun scriptlet does not contain relocate link")
   out.log.success("Successfully tested rpm test file")
   ()
 }


### PR DESCRIPTION
When creating relocatable RPM packages, the symlink needs to take into account the relocated file paths.

RPM does not provide out of the box support for this, hence the pull request to manage symlinks as part of `%post` and `%postun` scriptlet. This will ensure the symlink will be created and removed as part of post-install and post-uninstall step.

When creating the symlink, both the source path and the symlink itself need to take into account the relocated path.