### PR TITLE
Allow to override systemd start script name

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
@@ -102,7 +102,7 @@ object JavaServerAppPackaging extends AutoPlugin {
         linuxScriptReplacements in Debian,
         target in Universal,
         serverLoading in Debian) map makeStartScript,
-      linuxPackageMappings <++= (packageName, linuxMakeStartScript, serverLoading, defaultLinuxStartScriptLocation) map startScriptMapping
+      linuxPackageMappings <++= (packageName, linuxMakeStartScript, serverLoading, defaultLinuxStartScriptLocation, linuxStartScriptName) map startScriptMapping
     )) ++ Seq(
       // === Daemon User and Group ===
       daemonUser in Debian <<= daemonUser in Linux,
@@ -154,7 +154,7 @@ object JavaServerAppPackaging extends AutoPlugin {
         serverLoading in Rpm) map makeStartScript,
 
       defaultLinuxStartScriptLocation in Rpm <<= (serverLoading in Rpm) apply getStartScriptLocation,
-      linuxPackageMappings in Rpm <++= (packageName in Rpm, linuxMakeStartScript in Rpm, serverLoading in Rpm, defaultLinuxStartScriptLocation in Rpm) map startScriptMapping,
+      linuxPackageMappings in Rpm <++= (packageName in Rpm, linuxMakeStartScript in Rpm, serverLoading in Rpm, defaultLinuxStartScriptLocation in Rpm, linuxStartScriptName in Rpm) map startScriptMapping,
 
       // == Maintainer scripts ===
       // TODO this is very basic - align debian and rpm plugin
@@ -235,11 +235,11 @@ object JavaServerAppPackaging extends AutoPlugin {
     }
   }
 
-  protected def startScriptMapping(name: String, script: Option[File], loader: ServerLoader, scriptDir: String): Seq[LinuxPackageMapping] = {
+  protected def startScriptMapping(name: String, script: Option[File], loader: ServerLoader, scriptDir: String, scriptName: Option[String]): Seq[LinuxPackageMapping] = {
     val (path, permissions, isConf) = loader match {
-      case Upstart => ("/etc/init/" + name + ".conf", "0644", "true")
-      case SystemV => ("/etc/init.d/" + name, "0755", "false")
-      case Systemd => ("/usr/lib/systemd/system/" + name + ".service", "0644", "true")
+      case Upstart => ("/etc/init/" + scriptName.getOrElse(name + ".conf"), "0644", "true")
+      case SystemV => ("/etc/init.d/" + scriptName.getOrElse(name), "0755", "false")
+      case Systemd => ("/usr/lib/systemd/system/" + scriptName.getOrElse(name + ".service"), "0644", "true")
     }
     for {
       s <- script.toSeq

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
@@ -64,6 +64,7 @@ object JavaServerAppPackaging extends AutoPlugin {
       if (overrideScript.exists) overrideScript.toURI.toURL
       else etcDefaultTemplateSource
     },
+    linuxStartScriptName := None,
     makeEtcDefault <<= (packageName in Linux, target in Universal, linuxEtcDefaultTemplate, linuxScriptReplacements)
       map makeEtcDefaultScript,
     linuxPackageMappings <++= (makeEtcDefault, bashScriptEnvConfigLocation) map { (conf, envLocation) =>
@@ -154,6 +155,7 @@ object JavaServerAppPackaging extends AutoPlugin {
         serverLoading in Rpm) map makeStartScript,
 
       defaultLinuxStartScriptLocation in Rpm <<= (serverLoading in Rpm) apply getStartScriptLocation,
+      linuxStartScriptName in Rpm <<= linuxStartScriptName in Linux,
       linuxPackageMappings in Rpm <++= (packageName in Rpm, linuxMakeStartScript in Rpm, serverLoading in Rpm, defaultLinuxStartScriptLocation in Rpm, linuxStartScriptName in Rpm) map startScriptMapping,
 
       // == Maintainer scripts ===

--- a/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
@@ -26,6 +26,7 @@ trait LinuxKeys {
 
   val linuxMakeStartScript = TaskKey[Option[File]]("makeStartScript", "Creates or discovers the start script used by this project")
   val linuxStartScriptTemplate = TaskKey[URL]("linuxStartScriptTemplate", "The location of the template start script file we use for debian (upstart or init.d")
+  val linuxStartScriptName = TaskKey[Option[String]]("linuxStartScriptName", "The name of the start script for debian (primary useful for systemd)")
   val linuxEtcDefaultTemplate = TaskKey[URL]("linuxEtcDefaultTemplate", "The location of the /etc/default/<pkg> template script.")
   val linuxScriptReplacements = SettingKey[Seq[(String, String)]](
     "linuxScriptReplacements",

--- a/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/Keys.scala
@@ -26,7 +26,7 @@ trait LinuxKeys {
 
   val linuxMakeStartScript = TaskKey[Option[File]]("makeStartScript", "Creates or discovers the start script used by this project")
   val linuxStartScriptTemplate = TaskKey[URL]("linuxStartScriptTemplate", "The location of the template start script file we use for debian (upstart or init.d")
-  val linuxStartScriptName = TaskKey[Option[String]]("linuxStartScriptName", "The name of the start script for debian (primary useful for systemd)")
+  val linuxStartScriptName = SettingKey[Option[String]]("linuxStartScriptName", "The name of the start script for debian (primary useful for systemd)")
   val linuxEtcDefaultTemplate = TaskKey[URL]("linuxEtcDefaultTemplate", "The location of the /etc/default/<pkg> template script.")
   val linuxScriptReplacements = SettingKey[Seq[(String, String)]](
     "linuxScriptReplacements",


### PR DESCRIPTION
This allows to add "@" to the script name which is useful when using systemd. Any unit name containing "@" in name is used as template unit which allows to create multiple units from single start script. More information: https://wiki.archlinux.org/index.php/Systemd (in section "Using units" -> "Note")

