### PR TITLE
Upgrade spotify docker-client to 3.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ scalacOptions in Compile ++= Seq("-deprecation", "-target:jvm-1.6")
 
 libraryDependencies ++= Seq(
     "org.apache.commons" % "commons-compress" % "1.4.1",
-    "com.spotify" % "docker-client" % "3.1.3",
+    "com.spotify" % "docker-client" % "3.2.1",
     "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar")),
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )


### PR DESCRIPTION
Using the spotify docker client in Play 2.4.x projects leads to jackson errors like :
```[error] (docker:publishLocal) com.spotify.docker.client.DockerException: java.util.concurrent.ExecutionException: javax.ws.rs.ProcessingException: java.lang.AbstractMethodError: com.fasterxml.jackson.jaxrs.base.ProviderBase._configForReading(Lcom/fasterxml/jackson/databind/ObjectReader;[Ljava/lang/annotation/Annotation;)Lcom/fasterxml/jackson/jaxrs/cfg/EndpointConfigBase;```

Upgrading to 3.2.1 fixes it.