### PR TITLE
fix SystemV init script template for debian packaging

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
@@ -2,7 +2,7 @@
 # ##### Environment Configuration #####
 # #####################################
 
-# This file gets sourced before the actual bashscript
+# This file gets sourced before the actual startscript
 # gets executed. You can use this file to provide
 # environment variables
 

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -18,7 +18,12 @@ source /lib/lsb/init-functions
 # $JAVA_OPTS used in $RUN_CMD wrapper
 export JAVA_OPTS
 
-PIDFILE=/var/run/${{app_name}}/running.pid
+# If program manages its own PID file then it
+# should declare its location in PIDFILE
+if [ -z "$PIDFILE" ]; then
+    create_pidfile=true
+    PIDFILE=/var/run/${{app_name}}/running.pid
+fi
 
 if [ -z "$DAEMON_USER" ]; then
     DAEMON_USER=${{daemon_user}}
@@ -35,7 +40,11 @@ RUN_CMD="${{chdir}}/bin/${{exec}}"
 start_daemon() {
     log_daemon_msg "Starting" "${{app_name}}"
     [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -g "$DAEMON_GROUP" -m755 "/var/run/${{app_name}}"
-    start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS
+    if [ "$create_pidfile" = true ]; then
+        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS
+    else
+        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS
+    fi
     log_end_msg $?
 }
 

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -12,7 +12,8 @@
 source /lib/init/vars.sh
 source /lib/lsb/init-functions
 
-# adding bashScriptEnvConfigLocation
+# Source from package defined config. Defaults to,
+# bashScriptEnvConfigLocation := Some("/etc/default/" + (packageName in Linux).value)
 [[ -f ${{env_config}} ]] && . ${{env_config}}
 
 # $JAVA_OPTS used in $RUN_CMD wrapper
@@ -53,7 +54,9 @@ stop_daemon() {
     log_daemon_msg "Stopping" "${{app_name}}"
     start-stop-daemon --stop --quiet --oknodo --pidfile "$PIDFILE" --retry=TERM/${{term_timeout}}/KILL/${{kill_timeout}}
     log_end_msg $?
-    rm -f "$PIDFILE"
+    if [ "$create_pidfile" = true ]; then
+        rm -f "$PIDFILE"
+    fi
 }
 
 case "$1" in

--- a/src/sphinx/topics/play.rst
+++ b/src/sphinx/topics/play.rst
@@ -50,10 +50,10 @@ One way to provide this information is to append the following content in your b
 This way you should either store your production configuration under ``${{path_to_app_name}}/conf/production.conf``
 or put it under ``/usr/share/${{app_name}}/conf/production.conf`` by hand or using some configuration management system.
 
-RPM and SystemV
-~~~~~~~~~~~~~~~
+SystemV
+~~~~~~~
 
-If you use a system with rpm as a packaging managing system (Fedora, CentOS, RedHat,...) make sure to provide
+If you use a system using SystemV start script make sure to provide
 a `etc-default` in `src/templates` and set the `PIDFILE` environment variable.
 
 


### PR DESCRIPTION
For processes that manage their own pid file, they should define the `PIDFILE` variable (sourced either through `/etc/default/…` or `/etc/sysconfig/…`). Otherwise, if undefined, this script will capture the pid and write it to `/var/run/${{app_name}}/running.pid`.

This commit is related to https://github.com/sbt/sbt-native-packager/commit/45bc5dbaffdca8eaef4b498c6b93e3e03350428d that implements the same logic for rpm packaging