### PR TITLE
Support for multiple Prefix values in RPM spec.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/Keys.scala
@@ -11,7 +11,7 @@ trait RpmKeys {
   val rpmVendor = SettingKey[String]("rpm-vendor", "Name of the vendor for this RPM.")
   val rpmOs = SettingKey[String]("rpm-os", "Name of the os for this RPM.")
   val rpmRelease = SettingKey[String]("rpm-release", "Special release number for this rpm (vs. the software).")
-  val rpmPrefix = SettingKey[Option[String]]("rpm-prefix", "File system prefix for relocatable package.")
+  val rpmPrefix = SettingKey[Seq[String]]("rpm-prefix", "File system prefix for relocatable package.")
   val rpmMetadata = SettingKey[RpmMetadata]("rpm-metadata", "Metadata associated with the generated RPM.")
 
   // Changelog

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmMetadata.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmMetadata.scala
@@ -10,7 +10,7 @@ case class RpmMetadata(
   name: String,
   version: String,
   release: String,
-  prefix: Option[String] = None,
+  prefix: Seq[String] = Seq.empty,
   arch: String,
   vendor: String,
   os: String,
@@ -206,7 +206,7 @@ case class RpmSpec(
     sb append ("Version: %s\n" format meta.version)
     sb append ("Release: %s\n" format meta.release)
     sb append ("Summary: %s\n" format meta.summary)
-    meta.prefix foreach { v => sb append ("prefix: %s\n" format v) }
+    meta.prefix foreach { v => sb append ("Prefix: %s\n" format v) }
 
     desc.license foreach { v => sb append ("License: %s\n" format v) }
     desc.distribution foreach { v => sb append ("Distribution: %s\n" format v) }

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -52,7 +52,7 @@ object RpmPlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     rpmOs := "Linux", // TODO - default to something else?
     rpmRelease := "1",
-    rpmPrefix := None,
+    rpmPrefix := Seq.empty,
     rpmVendor := "", // TODO - Maybe pull in organization?
     rpmLicense := None,
     rpmDistribution := None,

--- a/src/sphinx/formats/rpm.rst
+++ b/src/sphinx/formats/rpm.rst
@@ -232,7 +232,7 @@ Example Settings:
 .. code-block:: scala
 
     defaultLinuxInstallLocation := "/opt/package_root",
-    rpmPrefix := Some(defaultLinuxInstallLocation),
+    rpmPrefix ++= Seq(defaultLinuxInstallLocation),
     linuxPackageSymlinks := Seq.empty,
     defaultLinuxLogsLocation := defaultLinuxInstallLocation + "/" + name
   


### PR DESCRIPTION
Added support for multiple Prefix values in the RPM spec.  This is not backward compatible, the interface has changed.  Also fixed it so when the RPM spec is written, "prefix:" is now "Prefix:".