### PR TITLE
Different start script replacements for different system loaders

### DIFF
--- a/src/sbt-test/debian/override-start-script/build.sbt
+++ b/src/sbt-test/debian/override-start-script/build.sbt
@@ -1,0 +1,35 @@
+import com.typesafe.sbt.packager.archetypes.ServerLoader
+
+enablePlugins(JavaServerAppPackaging, JDebPackaging)
+
+serverLoading in Debian := ServerLoader.Upstart
+
+// TODO change this after #437 is fixed
+daemonUser in Linux := "root"
+
+daemonGroup in Linux := "app-group"
+
+mainClass in Compile := Some("empty")
+
+name := "debian-test"
+
+name in Debian := "debian-test"
+
+version := "0.1.0"
+
+maintainer := "Josh Suereth <joshua.suereth@typesafe.com>"
+
+packageSummary := "Test debian package"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+TaskKey[Unit]("check-startup-script") <<= (target, streams) map { (target, out) =>
+  val extracted = target / "tmp" / "extracted-package"
+  extracted.mkdirs()
+  Seq("dpkg-deb", "-R", (target / "debian-test_0.1.0_all.deb").absolutePath, extracted.absolutePath).!
+
+  val script = IO.read(extracted / "etc" / "init" / "debian-test.conf")
+  assert(script.startsWith("# right upstart template"), s"override script wasn't picked, script is\n$script")
+  ()
+}

--- a/src/sbt-test/debian/override-start-script/project/plugins.sbt
+++ b/src/sbt-test/debian/override-start-script/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/debian/override-start-script/src/templates/debian/systemv
+++ b/src/sbt-test/debian/override-start-script/src/templates/debian/systemv
@@ -1,0 +1,1 @@
+# right systemV template

--- a/src/sbt-test/debian/override-start-script/src/templates/debian/upstart
+++ b/src/sbt-test/debian/override-start-script/src/templates/debian/upstart
@@ -1,0 +1,1 @@
+# right upstart template

--- a/src/sbt-test/debian/override-start-script/src/templates/start
+++ b/src/sbt-test/debian/override-start-script/src/templates/start
@@ -1,0 +1,2 @@
+# check that old start template isn't picked
+# wrong upstart start template

--- a/src/sbt-test/debian/override-start-script/test
+++ b/src/sbt-test/debian/override-start-script/test
@@ -1,0 +1,6 @@
+# Run the debian packaging.
+> debian:packageBin
+$ exists target/debian-test_0.1.0_all.deb
+
+# Check files for defaults
+> check-startup-script

--- a/src/sphinx/archetypes/cheatsheet.rst
+++ b/src/sphinx/archetypes/cheatsheet.rst
@@ -191,13 +191,16 @@ the ``bashScriptExtraDefines`` that will be used in addition to the default set:
 
 
 
-Service Manager - ``src/templates/start``
+Service Manager
 -----------------------------------------
 
-Creating a file here will override either the init.d startup script or
-the upstart start script.  It will either be located at
-``/etc/init/<application>`` or ``/etc/init.d/<application>`` depending on which
-serverLoader is being used.
+It's also possible to override the entire script/configuration for your service manager.
+Create a file ``src/templates/$format/$loader`` and it will be used instead.
+
+Possible values:
+
+* ``$format`` - ``debian`` or ``rpm``
+* ``$loader`` - ``upstart``, ``systemv`` or ``systemd``
 
 **Syntax**
 

--- a/src/sphinx/archetypes/java_server/customize.rst
+++ b/src/sphinx/archetypes/java_server/customize.rst
@@ -116,11 +116,16 @@ which will add the following resource file to use start/stop instead of initctl 
 The :doc:`debian </formats/debian>` and :doc:`redhat </formats/rpm>` pages have further information on overriding 
 distribution specific actions.
 
-Override Start Script - ``src/templates/start``
+Override Start Script
 -----------------------------------------------
 
 It's also possible to override the entire script/configuration for your service manager.
-Create a file ``src/templates/start`` and it will be used instead.
+Create a file ``src/templates/$format/$loader`` and it will be used instead.
+
+Possible values:
+
+* ``$format`` - ``debian`` or ``rpm``
+* ``$loader`` - ``upstart``, ``systemv`` or ``systemd``
 
 **Syntax**
 


### PR DESCRIPTION
The reason is that somebody may want to build rpm with customized systemV script and deb with default upstart script.