### PR TITLE
Ensure systemd works with RPM relocatable packages

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemd/loader-functions
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemd/loader-functions
@@ -5,6 +5,16 @@
 startService() {
     app_name=$1
 
+    app_sys_config="/etc/sysconfig/${app_name}"
+    [ -e "${app_sys_config}" ] && . "${app_sys_config}"
+    if [ -n "${PACKAGE_PREFIX}" ] ;
+    then
+      default_install_location="${{chdir}}"
+      actual_install_location="${PACKAGE_PREFIX}/${app_name}"
+
+      sed -i "s|$default_install_location|$actual_install_location|g" "/usr/lib/systemd/system/${app_name}.service"
+    fi
+
     systemctl enable "$app_name.service"
     systemctl start "$app_name.service"
 }
@@ -16,6 +26,7 @@ startService() {
 
 stopService() {
     app_name=$1
+
     systemctl stop "$app_name.service"
     systemctl disable "$app_name.service"
 }
@@ -26,6 +37,7 @@ stopService() {
 #
 restartService() {
    app_name=$1
+
    systemctl daemon-reload
    systemctl try-restart "$app_name.service"
 }

--- a/src/sbt-test/rpm/systemd-rpm/build.sbt
+++ b/src/sbt-test/rpm/systemd-rpm/build.sbt
@@ -38,3 +38,62 @@ TaskKey[Unit]("checkStartupScript") <<= (target, streams) map { (target, out) =>
   out.log.success("Successfully tested systemd start up script")
   ()
 }
+
+TaskKey[Unit]("checkSpecFile") <<= (target, streams) map { (target, out) =>
+  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
+  assert(spec contains
+    """
+      |#
+      |# Adding service to autostart
+      |# $1 = service name
+      |#
+      |startService() {
+      |    app_name=$1
+      |
+      |    app_sys_config="/etc/sysconfig/${app_name}"
+      |    [ -e "${app_sys_config}" ] && . "${app_sys_config}"
+      |    if [ -n "${PACKAGE_PREFIX}" ] ;
+      |    then
+      |      default_install_location="/usr/share/rpm-test"
+      |      actual_install_location="${PACKAGE_PREFIX}/${app_name}"
+      |
+      |      sed -i "s|$default_install_location|$actual_install_location|g" "/usr/lib/systemd/system/${app_name}.service"
+      |    fi
+      |
+      |    systemctl enable "$app_name.service"
+      |    systemctl start "$app_name.service"
+      |}
+      |""".stripMargin, "rpm scriptlet does not systemd service registration and startup")
+
+  assert(spec contains
+    """
+      |#
+      |# Removing service from autostart
+      |# $1 = service name
+      |#
+      |
+      |stopService() {
+      |    app_name=$1
+      |
+      |    systemctl stop "$app_name.service"
+      |    systemctl disable "$app_name.service"
+      |}
+      |""".stripMargin, "rpm scriptlet does not systemd stop service and disable")
+
+  assert(spec contains
+    """
+      |#
+      |# Restarting the service after package upgrade
+      |# $1 = service name
+      |#
+      |restartService() {
+      |   app_name=$1
+      |
+      |   systemctl daemon-reload
+      |   systemctl try-restart "$app_name.service"
+      |}
+      |""".stripMargin, "rpm scriptlet does not systemd reload during restart")
+
+  out.log.success("Successfully tested rpm test file")
+  ()
+}

--- a/src/sbt-test/rpm/systemd-rpm/test
+++ b/src/sbt-test/rpm/systemd-rpm/test
@@ -6,3 +6,5 @@ $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 $ exists usr/lib/systemd/system/rpm-test.service
 
 > checkStartupScript
+
+> checkSpecFile


### PR DESCRIPTION
Ensure correct installation path is being used in the service file required by systemd.

This is done by replacing the default installation path with the actual installation path
within the service file during install time of the RPM package.