### PR TITLE
Mark docker and jdeb as provided dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,9 @@ scalacOptions in Compile ++= Seq("-deprecation", "-target:jvm-1.7")
 
 libraryDependencies ++= Seq(
     "org.apache.commons" % "commons-compress" % "1.4.1",
-    "com.spotify" % "docker-client" % "3.2.1",
-    "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar")),
+    // these dependencies have to be explicitly added by the user
+    "com.spotify" % "docker-client" % "3.2.1" % "provided",
+    "org.vafer" % "jdeb" % "1.3"  % "provided" artifacts (Artifact("jdeb", "jar", "jar")),
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )
 

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -5,13 +5,12 @@ package docker
 import java.nio.file.Paths
 
 import com.spotify.docker.client.messages.ProgressMessage
-import com.spotify.docker.client.{ProgressHandler, DockerClient, DefaultDockerClient}
+import com.spotify.docker.client.{ ProgressHandler, DockerClient, DefaultDockerClient }
 import com.spotify.docker.client.DockerClient.BuildParameter._
 import sbt._
 import sbt.Keys._
 import packager.Keys._
 import universal.UniversalPlugin.autoImport.stage
-
 
 /**
  * == DockerSpotifyClientPlugin Plugin ==
@@ -36,9 +35,19 @@ import universal.UniversalPlugin.autoImport.stage
  *       configuration in a docker image with almost no ''any'' configuration.
  *
  * @example Enable the plugin in the `build.sbt`
- *          {{{
- *              enablePlugins(DockerSpotifyClientPlugin)
- *          }}}
+ * {{{
+ *   enablePlugins(DockerSpotifyClientPlugin)
+ * }}}
+ * 
+ * and add the dependency in your `plugins.sbt`
+ * 
+ * {{{
+ *   libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"
+ * }}}
+ * 
+ * The Docker-spotify client is a provided dependency so you have to add it on your own. 
+ * It brings a lot of dependenciesthat could slow your build times. This is the reason 
+ * the dependency is marked as provided.
  */
 object DockerSpotifyClientPlugin extends AutoPlugin {
 
@@ -78,6 +87,5 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
       docker.tag(tag, name, true)
     }
   }
-
 
 }

--- a/src/sbt-test/debian/jdeb-dependencies/project/plugins.sbt
+++ b/src/sbt-test/debian/jdeb-dependencies/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/src/sbt-test/debian/jdeb-dir-mappings/project/plugins.sbt
+++ b/src/sbt-test/debian/jdeb-dir-mappings/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/src/sbt-test/debian/jdeb-script-replacements/project/plugins.sbt
+++ b/src/sbt-test/debian/jdeb-script-replacements/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/src/sbt-test/debian/override-start-script/project/plugins.sbt
+++ b/src/sbt-test/debian/override-start-script/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/src/sbt-test/debian/simple-jdeb/project/plugins.sbt
+++ b/src/sbt-test/debian/simple-jdeb/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/src/sbt-test/docker/spotify-client/build.sbt
+++ b/src/sbt-test/docker/spotify-client/build.sbt
@@ -1,5 +1,3 @@
-import com.typesafe.sbt.packager.docker._
-
 enablePlugins(JavaAppPackaging, DockerSpotifyClientPlugin)
 
 name := "docker-test"

--- a/src/sbt-test/docker/spotify-client/project/plugins.sbt
+++ b/src/sbt-test/docker/spotify-client/project/plugins.sbt
@@ -1,0 +1,4 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+
+// needs to be added for the docker spotify client
+libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"

--- a/src/sbt-test/docker/spotify-client/src/main/scala/Main.scala
+++ b/src/sbt-test/docker/spotify-client/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}

--- a/src/sbt-test/docker/spotify-client/test
+++ b/src/sbt-test/docker/spotify-client/test
@@ -1,0 +1,3 @@
+# Generate the Docker image locally
+> docker:publishLocal
+$ exec bash -c 'docker run docker-test:0.1.0 | grep -q "Hello world"'

--- a/src/sphinx/formats/debian.rst
+++ b/src/sphinx/formats/debian.rst
@@ -57,8 +57,6 @@ you have these settings in your build:
     packageDescription := """A fun package description of our software,
       with multiple lines."""
 
-1.0 or higher
-~~~~~~~~~~~~~
 
 Enable the debian plugin to activate the native package implementation.
 
@@ -66,24 +64,24 @@ Enable the debian plugin to activate the native package implementation.
 
   enablePlugins(DebianPlugin)
 
+Java based packaging
+~~~~~~~~~~~~~~~~~~~~
+
 If you want to use the java based implementation, enable the following plugin.
 
 .. code-block:: scala
 
   enablePlugins(JDebPackaging)
-
-0.8 or lower
-~~~~~~~~~~~~
-
-For this versions debian packaging is automatically activated.
-See the :doc:`Getting Started </gettingstarted>` page for information
-on how to enable sbt native packager.
-
-If you want to enable `jdeb` packaging add the following to your `build.sbt`
+  
+and this to your ``plugins.sbt``
 
 .. code-block:: scala
 
-    packageBin in Debian <<= debianJDebPackaging in Debian
+  libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))
+  
+JDeb is a provided dependency so you have to add it on your own. It brings a lot of dependencies
+that could slow your build times. This is the reason the dependency is marked as provided.
+
 
 
 Configurations

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -34,19 +34,30 @@ Build
 Required Settings
 ~~~~~~~~~~~~~~~~~
     
-1.0 or higher
-~~~~~~~~~~~~~
-
 .. code-block:: scala
 
   enablePlugins(DockerPlugin)
+  
+Spotify java based docker client
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-0.8.x
-~~~~~
+You can also use the java-based spotify Docker client. Add this to your ``build.sbt``
 
-For this versions docker packaging is automatically activated.
-See the :doc:`Getting Started </gettingstarted>` page for information
-on how to enable sbt native packager.
+
+.. code-block:: scala
+
+  enablePlugins(DockerSpotifyClientPlugin)
+  
+  
+and this to your ``plugins.sbt``
+
+.. code-block:: scala
+
+  libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"
+
+The Docker-spotify client is a provided dependency so you have to add it on your own. 
+It brings a lot of dependenciesthat could slow your build times. This is the reason 
+the dependency is marked as provided.
 
 Configuration
 -------------

--- a/test-project-docker/project/plugins.sbt
+++ b/test-project-docker/project/plugins.sbt
@@ -1,3 +1,6 @@
 lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 
 lazy val plugin = file("../").getCanonicalFile.toURI
+
+// needs to be added for the docker spotify client
+libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"

--- a/test-project-simple/project/plugins.sbt
+++ b/test-project-simple/project/plugins.sbt
@@ -1,3 +1,5 @@
 lazy val root = Project("plugins", file(".")) dependsOn(packager)
 
 lazy val packager = file("..").getAbsoluteFile.toURI
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))


### PR DESCRIPTION
Follow up to the discussion in #693

## Goals

- java-based packaging alternatives dependencies are marked as `provided`
- less dependencies per default, faster builds, less dependency conflict potential