### PR TITLE
Adding ant dependency for jdkpackager builds. Follow up to #719

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ script:
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then
       ./sbt ++$SCALA_VERSION "scripted rpm/* debian/*";
     fi
+  - if [[ "$TRAVIS_JDK_VERSION" = "oraclejdk8" ]]; then
+      ./sbt ++$SCALA_VERSION "scripted jdkpackager/*";
+    fi
 notifications:
   email:
     - qbranch@typesafe.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
       ./sbt ++$SCALA_VERSION "scripted rpm/* debian/*";
     fi
   - if [[ "$TRAVIS_JDK_VERSION" = "oraclejdk8" ]]; then
-      ./sbt ++$SCALA_VERSION "scripted jdkpackager/*";
+      ./sbt ++$SCALA_VERSION "scripted jdkpackager/test-package-minimal jdkpackager/test-package-mappings";
     fi
 notifications:
   email:

--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,8 @@ scalacOptions in Compile ++= Seq("-deprecation", "-target:jvm-1.7")
 
 libraryDependencies ++= Seq(
     "org.apache.commons" % "commons-compress" % "1.4.1",
+    // for jdkpackager
+    "org.apache.ant" % "ant" % "1.9.6",
     // these dependencies have to be explicitly added by the user
     "com.spotify" % "docker-client" % "3.2.1" % "provided",
     "org.vafer" % "jdeb" % "1.3"  % "provided" artifacts (Artifact("jdeb", "jar", "jar")),


### PR DESCRIPTION
Changing `jdeb` to a provided dependency removed the `ant` dependency from the runtime  classpath, which is needed for the `jdkpackager` plugin.

Adding travis tests and dependency.