### PR TITLE
ArtifactoryDeployPlugin

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianArtifactoryDeployPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianArtifactoryDeployPlugin.scala
@@ -1,0 +1,85 @@
+package com.typesafe.sbt
+package packager
+package debian
+
+import sbt._
+import sbt.Keys._
+import SbtNativePackager._
+import packager.Keys._
+
+import java.net.HttpURLConnection
+import javax.xml.bind.DatatypeConverter.printBase64Binary
+
+trait DebianArtifactoryDeployKeys {
+  val debianArtifactoryUrl = SettingKey[String]("debian-artifactory-url", " Url of Atrifactory server")
+  val debianArtifactoryRepo = SettingKey[String]("debian-artifactory-repo", "Name of Artifactory repository with deb layout to publish artifacts to")
+  val debianArtifactoryCredentials = SettingKey[Option[Credentials]]("debian-artifactory-credentials", "Credentials with permissions to publish to Artifactory server")
+
+  val debianArtifactoryPath = SettingKey[String]("debian-artifactory-path", "The path in repository where the package should be stored")
+
+  val debianArtifactoryDistribution = SettingKey[Seq[String]]("debian-artifactory-distribution", "The value to assign to the deb.distribution property used to specify the Debian package distribution")
+  val debianArtifactoryComponent = SettingKey[Seq[String]]("debian-artifactory-component", "The value to assign to the deb.component property used to specify the Debian package component name")
+  val debianArtifactoryArchitecture = SettingKey[Seq[String]]("debian-artifactory-architecture", "The value to assign to the deb.architecture property used to specify the Debian package architecture")
+
+  val debianArtifactoryTargetPath = TaskKey[String]("debian-artifactory-apt-target-path", "Construct Atrifactory specific url path used for publishing")
+  val debianArtifactoryPublish = TaskKey[Unit]("debian-artifactory-publish", "Publish debian package to Artifactory")
+}
+
+object DebianArtifactoryDeployPlugin extends AutoPlugin {
+
+  override def requires = DebianPlugin
+
+  object autoImport extends DebianArtifactoryDeployKeys
+
+  import autoImport._
+
+  override def projectSettings = inConfig(Debian)(Seq(
+    debianArtifactoryArchitecture := Seq((packageArchitecture in Debian).value),
+    debianArtifactoryTargetPath <<= (debianArtifactoryPath, debianArtifactoryDistribution, debianArtifactoryComponent, debianArtifactoryArchitecture) map makeTargetPath,
+    debianArtifactoryPublish <<= (debianArtifactoryUrl, debianArtifactoryRepo, debianArtifactoryTargetPath, packageBin in Debian, debianArtifactoryCredentials, streams) map publishToArtifactory
+  ))
+
+  private def makeTargetPath(repoPath: String, distribution: Seq[String], component: Seq[String], arch: Seq[String]): String = {
+    val dists = distribution.map(d => s"deb.distribution=$d")
+    val comps = component.map(c => s"deb.component=$c")
+    val archs = arch.map(a => s"deb.architecture=$a")
+    (repoPath +: dists ++: comps ++: archs).mkString(";")
+  }
+
+  private def publishToArtifactory(artUrl: String, repo: String, targetPath: String, pkg: File, creds: Option[Credentials], streams: TaskStreams): Unit = {
+    val putTo = url(s"$artUrl/$repo/$targetPath")
+
+    val connection = putTo.openConnection().asInstanceOf[HttpURLConnection]
+    connection.setRequestMethod("PUT")
+    connection.setDoOutput(true)
+
+    Credentials.forHost(creds.toSeq, putTo.getHost) match {
+      case None if creds.isEmpty =>
+        streams.log.info(s"Artifactory credentials weren't supplied, proceeding without authentication")
+      case None if creds.isDefined =>
+        streams.log.warn(s"Couldn't find corresponding credentials for Artifactory host ${putTo.getHost}, proceeding without authentication")
+      case Some(dc) =>
+        streams.log.info(s"Found credentials for Artifactory host ${putTo.getHost}, proceeding with Basic authentication")
+        val userpass = s"${dc.userName}:${dc.passwd}"
+        val authHeader = "Basic " + printBase64Binary(userpass.getBytes)
+        connection.setRequestProperty("Authorization", authHeader)
+    }
+
+    streams.log.info(s"Publishing package ${pkg.name} to $putTo")
+
+    connection.connect()
+    IO.transfer(pkg, connection.getOutputStream)
+    connection.getOutputStream.flush()
+    connection.getOutputStream.close()
+
+    if (connection.getResponseCode == HttpURLConnection.HTTP_OK || connection.getResponseCode == HttpURLConnection.HTTP_CREATED) {
+      val response = IO.readStream(connection.getInputStream)
+      connection.getInputStream.close()
+      streams.log.info(s"Package published:\n$response")
+    } else {
+      streams.log.error(s"Publish failed: ${connection.getResponseMessage}")
+    }
+    connection.disconnect()
+  }
+
+}

--- a/src/sbt-test/debian/artifactory-publish/build.sbt
+++ b/src/sbt-test/debian/artifactory-publish/build.sbt
@@ -1,0 +1,28 @@
+enablePlugins(DebianPlugin)
+
+enablePlugins(DebianArtifactoryDeployPlugin)
+
+name := "debian-test"
+
+version := "0.1.0"
+
+maintainer := "Dmytro Aleksandrov <alkersan@gmail.com>"
+
+packageSummary := "Test debian package"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+debianArtifactoryUrl in Debian := "http://localhost:8081/artifactory"
+
+debianArtifactoryCredentials in Debian := Some(Credentials("Artifactory", "localhost", "admin", "password"))
+
+debianArtifactoryRepo in Debian := "apt"
+
+debianArtifactoryPath in Debian := s"pool/${packageName.value}_${version.value}_${(packageArchitecture in Debian).value}.deb"
+
+debianArtifactoryDistribution in Debian := Seq("trusty", "wily")
+
+debianArtifactoryComponent in Debian := Seq("main", "contrib")
+
+publish in Debian <<= (debianArtifactoryPublish in Debian)

--- a/src/sbt-test/debian/artifactory-publish/project/plugins.sbt
+++ b/src/sbt-test/debian/artifactory-publish/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/debian/artifactory-publish/test
+++ b/src/sbt-test/debian/artifactory-publish/test
@@ -1,0 +1,3 @@
+# Package deb and publish
+> debian:publish
+$ exec curl -s http://localhost:8081/artifactory/api/search/artifact?name=debian-test&repos=apt


### PR DESCRIPTION
Please review another deploy plugin for deb packages.

It can push deploy to [Artifactory Debian Repository](https://www.jfrog.com/confluence/display/RTF/Debian+Repositories)
[Multi-layout deployments](https://www.jfrog.com/confluence/display/RTF/Debian+Repositories#DebianRepositories-Specifyingmultiplelayouts) are supported

Zero added dependencies:
 - HTTP `PUT` is done with java `HttpURLConnection`
 - base64 encoding for Basic Auth comes from `javax.xml.bind.DatatypeConverter` (didn't use java8 [ Base64](https://docs.oracle.com/javase/8/docs/api/java/util/Base64.html) as java7 support is declared on front page)