### PR TITLE
Fix typo (enablePlugis → enablePlugins)

### DIFF
--- a/archetypes/index.html
+++ b/archetypes/index.html
@@ -231,7 +231,7 @@ To define a config location for your bash script, you can manually override the 
 <h2>Java Server<a class="headerlink" href="#java-server" title="Permalink to this headline">¶</a></h2>
 <p>This archetype is designed for Java applications that are intended to run as
 servers or services.  This archetype includes wiring an application to start
-immediately upon startup. To activate this archetype replace <tt class="docutils literal"><span class="pre">enablePlugins(JavaAppPackaging)</span></tt> with <tt class="docutils literal"><span class="pre">enablePlugis(JavaServerAppPackaging)</span></tt>.</p>
+immediately upon startup. To activate this archetype replace <tt class="docutils literal"><span class="pre">enablePlugins(JavaAppPackaging)</span></tt> with <tt class="docutils literal"><span class="pre">enablePlugins(JavaServerAppPackaging)</span></tt>.</p>
 <p>The Java Server archetype has a similar installation layout as the java
 application archetype. The primary differences are:</p>
 <ul class="simple">


### PR DESCRIPTION
Was introduced in 78611a323cf8177791ea9469ad162e5a603d8678.