### PR TITLE
SystemD services now source /etc/default/{{app_name}} (resolves #737)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ project/project
 log/
 target/
 .cache
+.ensime*

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-systemd-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-systemd-template
@@ -1,0 +1,29 @@
+# #####################################
+# ##### Environment Configuration #####
+# #####################################
+
+# This file is parsed by systemd. You can modify it to specify environment
+# variables for your application.
+#
+# For a description of the format, see: `man systemd.exec`, section
+# `EnvironmentFile`.
+
+# Available replacements
+# ------------------------------------------------
+# ${{author}}			debian author
+# ${{descr}}			debian package description
+# ${{exec}}				startup script name
+# ${{chdir}}			app directory
+# ${{retries}}			retries for startup
+# ${{retryTimeout}}		retry timeout
+# ${{app_name}}			normalized app name
+# ${{daemon_user}}		daemon user
+# -------------------------------------------------
+
+# Setting JAVA_OPTS
+# -----------------
+# JAVA_OPTS="-Dpidfile.path=/var/run/${{app_name}}/play.pid"
+
+# Setting PIDFILE
+# ---------------
+# PIDFILE="/var/run/${{app_name}}/play.pid"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemd/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemd/start-template
@@ -5,6 +5,7 @@ Requires=${{start_facilities}}
 [Service]
 Type=simple
 WorkingDirectory=${{chdir}}
+EnvironmentFile=${{env_config}}
 ExecStart=${{chdir}}/bin/${{exec}}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
@@ -13,6 +13,8 @@ trait JavaAppKeys {
   val bashScriptDefines = TaskKey[Seq[String]]("bashScriptDefines", "A list of definitions that should be written to the bash file template.")
   val bashScriptExtraDefines = TaskKey[Seq[String]]("bashScriptExtraDefines", "A list of extra definitions that should be written to the bash file template.")
   val bashScriptConfigLocation = TaskKey[Option[String]]("bashScriptConfigLocation", "The location where the bash script will load default argument configuration from.")
+  // TODO - we should change this key name in future versions; it also specified
+  // the location of the systemd EnvironmentFile
   val bashScriptEnvConfigLocation = SettingKey[Option[String]]("bashScriptEnvConfigLocation", "The location of a bash script that will be sourced before running the app.")
   val batScriptExtraDefines = TaskKey[Seq[String]]("batScriptExtraDefines", "A list of extra definitions that should be written to the bat file template.")
   val scriptClasspathOrdering = TaskKey[Seq[(File, String)]]("scriptClasspathOrdering", "The order of the classpath used at runtime for the bat/bash scripts.")

--- a/src/sbt-test/debian/override-etc-default/build.sbt
+++ b/src/sbt-test/debian/override-etc-default/build.sbt
@@ -1,0 +1,35 @@
+import com.typesafe.sbt.packager.archetypes.ServerLoader
+
+enablePlugins(JavaServerAppPackaging, JDebPackaging)
+
+serverLoading in Debian := ServerLoader.Upstart
+
+// TODO change this after #437 is fixed
+daemonUser in Linux := "root"
+
+daemonGroup in Linux := "app-group"
+
+mainClass in Compile := Some("empty")
+
+name := "debian-test"
+
+name in Debian := "debian-test"
+
+version := "0.1.0"
+
+maintainer := "Josh Suereth <joshua.suereth@typesafe.com>"
+
+packageSummary := "Test debian package"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+TaskKey[Unit]("check-etc-default") <<= (target, streams) map { (target, out) =>
+  val extracted = target / "tmp" / "extracted-package"
+  extracted.mkdirs()
+  Seq("dpkg-deb", "-R", (target / "debian-test_0.1.0_all.deb").absolutePath, extracted.absolutePath).!
+
+  val script = IO.read(extracted / "etc" / "default" / "debian-test")
+  assert(script.startsWith("# right etc-default template"), s"etc-default script wasn't picked, contents instead are:\n$script")
+  ()
+}

--- a/src/sbt-test/debian/override-etc-default/project/plugins.sbt
+++ b/src/sbt-test/debian/override-etc-default/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+
+libraryDependencies += "org.vafer" % "jdeb" % "1.3" artifacts (Artifact("jdeb", "jar", "jar"))

--- a/src/sbt-test/debian/override-etc-default/src/templates/etc-default
+++ b/src/sbt-test/debian/override-etc-default/src/templates/etc-default
@@ -1,0 +1,1 @@
+# right etc-default template

--- a/src/sbt-test/debian/override-etc-default/test
+++ b/src/sbt-test/debian/override-etc-default/test
@@ -1,0 +1,6 @@
+# Run the debian packaging.
+> debian:packageBin
+$ exists target/debian-test_0.1.0_all.deb
+
+# Check files for defaults
+> check-etc-default

--- a/src/sbt-test/debian/systemd-deb/build.sbt
+++ b/src/sbt-test/debian/systemd-deb/build.sbt
@@ -23,6 +23,13 @@ TaskKey[Unit]("check-startup-script") <<= (target, streams) map { (target, out) 
   val script = IO.read(target / "debian-test-0.1.0" / "usr" / "lib" / "systemd" / "system" / "debian-test.service")
   assert(script.contains("Requires=network.target"), "script doesn't contain Default-Start header\n" + script)
   assert(script.contains("User=testuser"), "script doesn't contain `User` header\n" + script)
+  assert(script.contains("EnvironmentFile=/etc/default/debian-test"), "script doesn't contain EnvironmentFile header\n" + script)
   out.log.success("Successfully tested systemd start up script")
+  ()
+}
+
+TaskKey[Unit]("check-etc-default") <<= (target, streams) map { (target, out) =>
+  val script = IO.read(target / "debian-test-0.1.0" / "etc" / "default" / "debian-test")
+  assert(script.contains("systemd"), s"systemd etc-default template wasn't selected; contents are:\n" + script)
   ()
 }

--- a/src/sbt-test/debian/systemd-deb/test
+++ b/src/sbt-test/debian/systemd-deb/test
@@ -5,3 +5,4 @@ $ exists target/debian-test_0.1.0_all.deb
 $ exists target/debian-test-0.1.0/usr/lib/systemd/system/debian-test.service
 
 > check-startup-script
+> check-etc-default

--- a/src/sphinx/archetypes/cheatsheet.rst
+++ b/src/sphinx/archetypes/cheatsheet.rst
@@ -228,9 +228,21 @@ You can use ``${{variable_name}}`` to reference variables when writing your scri
 
 .. _server-app-config:
 
-Server App Config - ``src/templates/etc-default``
+Server App Config - ``src/templates/etc-default-{systemv,systemd}``
 -------------------------------------------------
 
 Creating a file here will override the ``/etc/default/<application>`` template
-used when SystemV is the server loader.
+for the corresponding loader.
 
+The file `/etc/default/<application>` is used as follows given the loader:
+
+- `systemv`: sourced as a bourne script.
+- `systemd`: used as an EnvironmentFile directive parameter (see `man
+systemd.exec`, section `EnvironmentFile` for a description of the expected file
+format).
+- `upstart`: presently ignored.
+
+If you're only overriding `JAVA_OPTS`, your environment file could be compatible
+with both systemv and systemd loaders; if such is the case, you can specify a
+single file at `src/templates/etc-default` which will serve as an override for
+all loaders.

--- a/src/sphinx/archetypes/java_server/customize.rst
+++ b/src/sphinx/archetypes/java_server/customize.rst
@@ -21,10 +21,12 @@ Linux Configuration
 There are different ways described in :doc:`Customizing the Application </archetypes/java_app/customize>`
 and can be used the same way.
 
-
-The server archetype adds an additional way with an ``etc-default`` file placed in ``src/templates``, which currently
-only works for **SystemV**. The file gets sourced before the actual startscript is executed.
+The server archetype adds an additional way with an ``etc-default`` file placed
+in ``src/templates``, which currently only works for **SystemV** and
+**systemd**. The file gets sourced before the actual startscript is executed.
 The file will be installed to ``/etc/default/<normalizedName>``
+
+Example `/etc/default/<normalizedName>` for SystemV:
 
 .. code-block :: bash
 

--- a/src/sphinx/archetypes/java_server/my-first-project.rst
+++ b/src/sphinx/archetypes/java_server/my-first-project.rst
@@ -86,7 +86,7 @@ rights. **<package>** is a placeholder for your actual application name. By defa
 Folder                           User    Permissions  Purpose
 ===============================  ======  ===========  =======
 /usr/share/**<package>**         root    755 / (655)  static, non-changeable files
-/etc/default/**<package>**.conf  root    644          default config file
+/etc/default/**<package>**       root    644          default config file
 /etc/**<package>**               root    644          config folder -> link to /usr/share/**<package-name>**/conf
 /var/run/**<package>**           daemon  644          if the application generates a pid on its own
 /var/log/**<package>**           daemon  644          log folder -> symlinked from /usr/share/**<package>**/log


### PR DESCRIPTION
This change modifies the SystemD template to include the packaged
/etc/default environment settings file. Since a sourced SystemD
environment file is not the same thing as a bourne shell source script,
a different template is used.

Those deploying their package to multiple platforms can also specify
different /etc/default templates by suffixing `-systemd` to their name,
ie: src/templates/etc-default-systemd