### PR TITLE
Fix errors when .bat file path contains paranthesis.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bat-template
@@ -20,7 +20,7 @@ for %%x in (!cmdcmdline!) do if %%~x==/c set DOUBLECLICKED=1
 rem FIRST we load the config file of extra options.
 set "CFG_FILE=%@@APP_ENV_NAME@@_HOME%\@@APP_ENV_NAME@@_config.txt"
 set CFG_OPTS=
-if exist %CFG_FILE% (
+if exist "%CFG_FILE%" (
   FOR /F "tokens=* eol=# usebackq delims=" %%i IN ("%CFG_FILE%") DO (
     set DO_NOT_REUSE_ME=%%i
     rem ZOMG (Part #2) WE use !! here to delay the expansion of


### PR DESCRIPTION
Without double quotes the path with paranthesis gets evaluated causing an error on Windows systems. Specifically the error text is "\\\.. was unexpected at this time."

I got the error when I moved my Play distro inside a Dropbox folder with name "Dropbox (COMPANYNAME)". The path (COMPANYNAME) part gets evaluated as the if condition clause and makes the batch throw the error above and close. 

Double quoting the %CFG_FILE% variable seems to be fixing the error.