### PR TITLE
Updates version of DockerSpotifyClient to 3.5.13 and fixes NullPointerException

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
     // for jdkpackager
     "org.apache.ant" % "ant" % "1.9.6",
     // these dependencies have to be explicitly added by the user
-    "com.spotify" % "docker-client" % "3.2.1" % "provided",
+    "com.spotify" % "docker-client" % "3.5.13" % "provided",
     "org.vafer" % "jdeb" % "1.3"  % "provided" artifacts (Artifact("jdeb", "jar", "jar")),
     "org.scalatest" %% "scalatest" % "2.2.4" % "test"
 )

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -6,7 +6,7 @@ import java.nio.file.Paths
 
 import com.spotify.docker.client.messages.ProgressMessage
 import com.spotify.docker.client.{ ProgressHandler, DockerClient, DefaultDockerClient }
-import com.spotify.docker.client.DockerClient.BuildParameter._
+import com.spotify.docker.client.DockerClient.BuildParam
 import sbt._
 import sbt.Keys._
 import packager.Keys._
@@ -42,7 +42,7 @@ import universal.UniversalPlugin.autoImport.stage
  * and add the dependency in your `plugins.sbt`
  * 
  * {{{
- *   libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"
+ *   libraryDependencies += "com.spotify" % "docker-client" % "3.5.13"
  * }}}
  * 
  * The Docker-spotify client is a provided dependency so you have to add it on your own. 
@@ -77,10 +77,10 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
       def progress(message: ProgressMessage) = {
         Option(message.error()) match {
           case Some(error) if error.nonEmpty => log.error(message.error())
-          case _ => log.info(message.stream())
+          case _ => Option(message.stream()) foreach (v => log.info(v))
         }
       }
-    }, FORCE_RM)
+    }, BuildParam.forceRm())
 
     if (latest) {
       val name = tag.substring(0, tag.lastIndexOf(":")) + ":latest"

--- a/src/sbt-test/docker/spotify-client/project/plugins.sbt
+++ b/src/sbt-test/docker/spotify-client/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
 
 // needs to be added for the docker spotify client
-libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"
+libraryDependencies += "com.spotify" % "docker-client" % "3.5.13"

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -53,7 +53,7 @@ and this to your ``plugins.sbt``
 
 .. code-block:: scala
 
-  libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"
+  libraryDependencies += "com.spotify" % "docker-client" % "3.5.13"
 
 The Docker-spotify client is a provided dependency so you have to add it on your own. 
 It brings a lot of dependenciesthat could slow your build times. This is the reason 

--- a/test-project-docker/project/plugins.sbt
+++ b/test-project-docker/project/plugins.sbt
@@ -3,4 +3,4 @@ lazy val root = Project("plugins", file(".")).dependsOn(plugin)
 lazy val plugin = file("../").getCanonicalFile.toURI
 
 // needs to be added for the docker spotify client
-libraryDependencies += "com.spotify" % "docker-client" % "3.2.1"
+libraryDependencies += "com.spotify" % "docker-client" % "3.5.13"


### PR DESCRIPTION
NullPointerException is appeared, when i try to build & publish an image to a local Docker Registry at first time (after clean):

    [info] PublishLocal using Docker API 1.22
    [info] Step 1 : FROM lwieske/java-8:jre-8u72-slim
    [trace] Stack trace suppressed: run last server/docker:publishLocal for the full output.
    [error] (server/docker:publishLocal) java.lang.NullPointerException
    [error] Total time: 154 s, completed Mar 3, 2016 1:25:22 PM
    > last server/docker:publishLocal
    [info] PublishLocal using Docker API 1.22
    [info] Step 1 : FROM lwieske/java-8:jre-8u72-slim
    java.lang.NullPointerException
      at sbt.ConsoleLogger.log(ConsoleLogger.scala:195)
      at sbt.ConsoleLogger.log(ConsoleLogger.scala:185)
      at sbt.AbstractLogger.log(Logger.scala:28)
      at sbt.MultiLogger$$anonfun$dispatch$1.apply(MultiLogger.scala:35)
      at sbt.MultiLogger$$anonfun$dispatch$1.apply(MultiLogger.scala:33)
      at scala.collection.immutable.List.foreach(List.scala:318)
      at sbt.MultiLogger.dispatch(MultiLogger.scala:33)
      at sbt.MultiLogger.log(MultiLogger.scala:27)
      at sbt.Logger$class.info(Logger.scala:118)
      at sbt.AbstractLogger.info(Logger.scala:11)
      at com.typesafe.sbt.packager.docker.DockerSpotifyClientPlugin$$anonfun$publishLocalDocker$1$$anon$1.progress(DockerSpotifyClientPlugin.scala:80)
      at com.spotify.docker.client.DefaultDockerClient.build(DefaultDockerClient.java:939)
      at com.spotify.docker.client.DefaultDockerClient.build(DefaultDockerClient.java:888)
      at com.typesafe.sbt.packager.docker.DockerSpotifyClientPlugin$$anonfun$publishLocalDocker$1.apply(DockerSpotifyClientPlugin.scala:76)
      at com.typesafe.sbt.packager.docker.DockerSpotifyClientPlugin$$anonfun$publishLocalDocker$1.apply(DockerSpotifyClientPlugin.scala:65)
      at scala.Function1$$anonfun$compose$1.apply(Function1.scala:47)
      at sbt.$tilde$greater$$anonfun$$u2219$1.apply(TypeFunctions.scala:40)
      at sbt.std.Transform$$anon$4.work(System.scala:63)
      at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
      at sbt.Execute$$anonfun$submit$1$$anonfun$apply$1.apply(Execute.scala:226)
      at sbt.ErrorHandling$.wideConvert(ErrorHandling.scala:17)
      at sbt.Execute.work(Execute.scala:235)
      at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
      at sbt.Execute$$anonfun$submit$1.apply(Execute.scala:226)
      at sbt.ConcurrentRestrictions$$anon$4$$anonfun$1.apply(ConcurrentRestrictions.scala:159)
      at sbt.CompletionService$$anon$2.call(CompletionService.scala:28)
      at java.util.concurrent.FutureTask.run(FutureTask.java:266)
      at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
      at java.util.concurrent.FutureTask.run(FutureTask.java:266)
      at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
      at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
      at java.lang.Thread.run(Thread.java:745)
    [error] (server/docker:publishLocal) java.lang.NullPointerException

This PR fixes that issue.