### PR TITLE
Add hint for windows-users (configuration)

### DIFF
--- a/src/sphinx/archetypes/java_app/customize.rst
+++ b/src/sphinx/archetypes/java_app/customize.rst
@@ -38,6 +38,7 @@ Via Application.ini
 ^^^^^^^^^^^^^^^^^^^
 
 The second option is to create ``src/universal/conf/application.ini`` with the following template
+(For Windows-user: Create ``src/universal/<APP_ENV_NAME>_config.txt`` instead of the application.ini, it is expected that way by the BAT-template. Inside the <App_ENV_NAME>_config.txt the jvm-options are expected like in the command-line  (e.g. -Xms2G -Xmx3G) without an leading ``J``)
 
 .. code-block:: bash
 


### PR DESCRIPTION
Add a hint for Window-users that the bat.script expects the configuration on the differnt place and in a differnt way
https://github.com/sbt/sbt-native-packager/issues/768#issuecomment-207745671