### PR TITLE
Fix #776 using $DAEMON_GROUP to indicate group in Redhat startup temp…

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-rpm-template
@@ -54,7 +54,7 @@ export JAVA_OPTS
 # create PIDDIR where PIDFILE will be kept
 if [ -z "${PIDDIR:-}" ]; then
     PIDDIR=/var/run/${{app_name}}/
-    mkdir -p $PIDDIR && chown $DAEMON_USER:$DAEMON_USER $PIDDIR
+    mkdir -p $PIDDIR && chown $DAEMON_USER:$DAEMON_GROUP $PIDDIR
 fi
 
 # If program manages its own PID file then it


### PR DESCRIPTION
Implemented fix for the small bug as indicated in:
https://github.com/sbt/sbt-native-packager/issues/776#issuecomment-209407795

The incorrect group was assigned in the Redhat startup script.