### PR TITLE
Don't compress debian packages

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -158,7 +158,8 @@ object DebianPlugin extends AutoPlugin with DebianNativePackaging {
       (maintainerScripts in Debian).value,
       (linuxScriptReplacements in Debian).value,
       (target in Universal).value
-    )
+    ),
+    debianNativeBuildOptions := Nil
   )
 
   /**

--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -49,4 +49,6 @@ trait DebianKeys {
   val debianMakeChownReplacements = TaskKey[(String, String)]("debianMakeChownReplacements", "Creates the chown commands for correct own files and directories")
 
   val debianPackageInstallSize = TaskKey[Long]("debian-installed-size")
+
+  val debianNativeBuildOptions = SettingKey[Seq[String]]("debian-native-build-options", "Options passed to dpkg-deb, e.g. compression level")
 }

--- a/src/sbt-test/debian/native-build-compress/build.sbt
+++ b/src/sbt-test/debian/native-build-compress/build.sbt
@@ -1,0 +1,14 @@
+enablePlugins(DebianPlugin)
+
+debianNativeBuildOptions in Debian := Nil
+
+maintainer := "Maintainer <maintainer@example.com>"
+
+packageDescription := "Description"
+
+packageSummary := "Summary"
+
+TaskKey[Unit]("check-deb-compression") := {
+  val deb = target.value / s"${(name in Debian).value}_${(version in Debian).value}_all.deb"
+  assert(Seq("ar", "-t", deb.toString).lines.exists(_.startsWith("data.tar."))) // exact extension varies by dpkg-deb version
+}

--- a/src/sbt-test/debian/native-build-compress/project/plugins.sbt
+++ b/src/sbt-test/debian/native-build-compress/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/debian/native-build-compress/test
+++ b/src/sbt-test/debian/native-build-compress/test
@@ -1,0 +1,2 @@
+> debian:packageBin
+> check-deb-compression

--- a/src/sbt-test/debian/native-build-default/build.sbt
+++ b/src/sbt-test/debian/native-build-default/build.sbt
@@ -1,0 +1,12 @@
+enablePlugins(DebianPlugin)
+
+maintainer := "Maintainer <maintainer@example.com>"
+
+packageDescription := "Description"
+
+packageSummary := "Summary"
+
+TaskKey[Unit]("check-deb-compression") := {
+  val deb = target.value / s"${(name in Debian).value}_${(version in Debian).value}_all.deb"
+  assert(Seq("ar", "-t", deb.toString).lines.contains("data.tar"))
+}

--- a/src/sbt-test/debian/native-build-default/project/plugins.sbt
+++ b/src/sbt-test/debian/native-build-default/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/debian/native-build-default/test
+++ b/src/sbt-test/debian/native-build-default/test
@@ -1,0 +1,2 @@
+> debian:packageBin
+> check-deb-compression

--- a/src/sphinx/formats/debian.rst
+++ b/src/sphinx/formats/debian.rst
@@ -56,6 +56,21 @@ Enable the debian plugin to activate the native package implementation.
 
   enablePlugins(DebianPlugin)
 
+Native packaging
+~~~~~~~~~~~~~~~~
+
+Since JARs are by default already compressed, `DebianPlugin` disables additional compression of the debian package
+contents.
+
+To compress the debian package, override `debianNativeBuildOptions` with
+`options <http://man7.org/linux/man-pages/man1/dpkg-deb.1.html>`_ for `dpkg-deb`.
+
+.. code-block:: scala
+
+  debianNativeBuildOptions in Debian := Nil // dpkg-deb's default compression (currently xz)
+
+  debianNativeBuildOptions in Debian := Seq("-Zgzip", "-z3") // gzip compression at level 3
+
 Java based packaging
 ~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Representative example:

A Play project takes 30 seconds for `dpkg-deb` to build a 70MB deb with compression.
The same project takes 1 second to build a 79MB deb without compression.

Since JARs are already compressed archives, a sensible default is to not compress them again. (In fact, I'd be surprised if the small gains in client downloads weren't almost entirely overcome by the time to decompress.)

Users can use `debianNativeBuildOptions` to override options for `dpkg-deb` if they would like a different compression type, level, etc.