### PR TITLE
fix #766

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/ash-template
@@ -29,7 +29,7 @@ realpath () {
 
 # Loads a configuration file full of default command line options for this script.
 loadConfigFile() {
-  cat "$1" | sed '/^\#/d'
+  cat "$1" | sed '/^\#/d' | sed 's/^-J-X/-X/' | tr '\r\n' ' '
 }
 
 
@@ -40,7 +40,6 @@ lib_dir="$(realpath "${app_home}/../lib")"
 ${{template_declares}}
 
 # If a configuration file exist, read the contents to $opts
-[ -f "$script_conf_file" ] && set -- $(loadConfigFile "$script_conf_file") "$opts"
+[ -f "$script_conf_file" ] && opts=$(loadConfigFile "$script_conf_file")
 
 java -classpath $app_classpath $opts $app_mainclass $@
-


### PR DESCRIPTION
I don't fully understand this: `set -- $(loadConfigFile "$script_conf_file") "$opts"`
But I tested in alpipe:3.3  docker image:
```bash
docker run --rm -ti alpine sh
```

inside alpipe:
```bash
cat <<EOF > application.ini
-Dfoo="-J-Xms512M"
-J-Xms512M
-Xmx512M
EOF

touch test && chmod +x test

cat <<'EOF' > test
#!/bin/sh
loadConfigFile() {
  cat "$1" | sed '/^\#/d'
}
set -- $(loadConfigFile "application.ini") "$opts"
echo "[$opts]"
EOF

# ./test 
[]

cat <<'EOF' > test
#!/bin/sh
loadConfigFile() {
  cat "$1" | sed '/^\#/d'
}
set -- $(loadConfigFile "application.ini") "$@"
echo "[$@]"
EOF

# ./test 
[-Dfoo="-J-Xms512M" -J-Xms512M -Xmx512M]

cat <<'EOF' > test
#!/bin/sh
loadConfigFile() {
  cat "$1" | sed '/^\#/d'
}
set -- $(loadConfigFile "application.ini")
echo "[$@]"
EOF

# ./test 
[-Dfoo="-J-Xms512M" -J-Xms512M -Xmx512M]

cat <<'EOF' > test
#!/bin/sh
loadConfigFile() {
  cat "$1" | sed '/^\#/d' | sed 's/^-J-X/-X/' | tr '\r\n' ' '
}
opts=$(loadConfigFile "application.ini")
echo "[$opts]"
EOF

# ./test 
[-Dfoo="-J-Xms512M" -Xms512M -Xmx512M ]
```