### PR TITLE
Add: dockerAdditionalVersions

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -74,6 +74,7 @@ object DockerPlugin extends AutoPlugin {
     dockerExposedVolumes := Seq(),
     dockerRepository := None,
     dockerUpdateLatest := false,
+    dockerAdditionalVersions := Seq(),        
     dockerEntrypoint := Seq("bin/%s" format executableScriptName.value),
     dockerCmd := Seq(),
     dockerCommands := {
@@ -104,16 +105,20 @@ object DockerPlugin extends AutoPlugin {
       mappings ++= Seq(dockerGenerateConfig.value) pair relativeTo(target.value),
       name := name.value,
       packageName := packageName.value,
-      publishLocal <<= (stage, dockerTarget, dockerUpdateLatest, streams) map {
-        (context, target, updateLatest, s) =>
-          publishLocalDocker(context, target, updateLatest, s.log)
+      publishLocal <<= (stage, dockerTarget, dockerUpdateLatest, dockerAdditionalVersions, streams) map {
+        (context, target, updateLatest, additionalVersions, s) =>
+          publishLocalDocker(context, target, updateLatest, additionalVersions, s.log)
       },
-      publish <<= (publishLocal, dockerTarget, dockerUpdateLatest, streams) map {
-        (_, target, updateLatest, s) =>
+      publish <<= (publishLocal, dockerTarget, dockerUpdateLatest, dockerAdditionalVersions, streams) map {
+        (_, target, updateLatest, additionalVersions, s) =>
           publishDocker(target, s.log)
           if (updateLatest) {
             val name = target.substring(0, target.lastIndexOf(":")) + ":latest"
             publishDocker(name, s.log)
+          }
+          additionalVersions foreach { v =>
+            val name = target.substring(0, target.lastIndexOf(":")) + ":" + v
+            publishDocker(name, s.log) 
           }
       },
       sourceDirectory := sourceDirectory.value / "docker",
@@ -279,7 +284,7 @@ object DockerPlugin extends AutoPlugin {
     }
   }
 
-  def publishLocalDocker(context: File, tag: String, latest: Boolean, log: Logger): Unit = {
+  def publishLocalDocker(context: File, tag: String, latest: Boolean, additionalVersions: Seq[String], log: Logger): Unit = {
     val cmd = Seq("docker", "build", "--force-rm", "-t", tag, ".")
 
     log.debug("Executing Native " + cmd.mkString(" "))
@@ -297,6 +302,15 @@ object DockerPlugin extends AutoPlugin {
       val latestCmd = Seq("docker", "tag", "-f", tag, name)
       Process(latestCmd).! match {
         case 0 => log.info("Update Latest from image " + tag)
+        case n => sys.error("Failed to run docker tag")
+      }
+    }
+
+    additionalVersions foreach { v =>
+      val name = tag.substring(0, tag.lastIndexOf(":")) + ":" + v
+      val cmd = Seq("docker", "tag", "-f", tag, name)
+      Process(cmd).! match {
+        case 0 => log.info("Update version " + v + " from image " + tag)
         case n => sys.error("Failed to run docker tag")
       }
     }

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -17,6 +17,7 @@ trait DockerKeys {
   val dockerExposedVolumes = SettingKey[Seq[String]]("dockerExposedVolumes", "Volumes exposed by Docker image")
   val dockerRepository = SettingKey[Option[String]]("dockerRepository", "Repository for published Docker image")
   val dockerUpdateLatest = SettingKey[Boolean]("dockerUpdateLatest", "Set to update latest tag")
+  val dockerAdditionalVersions = SettingKey[Seq[String]]("dockerAdditionalVersions", "Set additional version tags  such as git branch or git tag")
   val dockerEntrypoint = SettingKey[Seq[String]]("dockerEntrypoint", "Entrypoint arguments passed in exec form")
   val dockerCmd = SettingKey[Seq[String]]("dockerCmd", "Docker CMD. Used together with dockerEntrypoint. Arguments passed in exec form")
 


### PR DESCRIPTION
Useful if you want other version tags added to Docker Image in addition
to the project version. Examples include tagging by the git hash or git
branch using the sbt-git plugin