### PR TITLE
Expand the java home argument

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template
@@ -192,7 +192,7 @@ process_args () {
 
           -main) custom_mainclass="$2" && shift 2 ;;
 
-     -java-home) require_arg path "$1" "$2" && java_cmd="$2/bin/java" && shift 2 ;;
+     -java-home) require_arg path "$1" "$2" && jre=`eval echo $2` && java_cmd="$jre/bin/java" && shift 2 ;;
 
  -D*|-agentlib*) addJava "$1" && shift ;;
             -J*) addJava "${1:2}" && shift ;;

--- a/src/sbt-test/bash/java-home-var-expansion/build.sbt
+++ b/src/sbt-test/bash/java-home-var-expansion/build.sbt
@@ -1,0 +1,19 @@
+enablePlugins(JavaAppPackaging)
+
+name := "java-home-override"
+
+version := "0.1.0"
+
+javaOptions in Universal ++= Seq(
+  "-java-home ${app_home}/../jre"
+)
+
+TaskKey[Unit]("run-check") := {
+  val cwd = (stagingDirectory in Universal).value
+  // Don't check for java but it will fail since the jre is not in place
+  val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath, "-v", "-no-version-check")
+  val output = Process(cmd, cwd).lines_!
+  val outStr = output.mkString("\n")
+  // Check that ${app_home} has been substitued
+  assert(outStr.contains("stage/bin/../jre/bin/java"), "Output didn't contain success: " + output)
+}

--- a/src/sbt-test/bash/java-home-var-expansion/project/plugins.sbt
+++ b/src/sbt-test/bash/java-home-var-expansion/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/bash/java-home-var-expansion/src/main/scala/MainApp.scala
+++ b/src/sbt-test/bash/java-home-var-expansion/src/main/scala/MainApp.scala
@@ -1,0 +1,3 @@
+object MainApp extends App {
+  println("SUCCESS!")
+}

--- a/src/sbt-test/bash/java-home-var-expansion/test
+++ b/src/sbt-test/bash/java-home-var-expansion/test
@@ -1,0 +1,3 @@
+# Run the staging and check the script.
+> stage
+> run-check

--- a/src/sphinx/archetypes/java_app/index.rst
+++ b/src/sphinx/archetypes/java_app/index.rst
@@ -119,6 +119,10 @@ The start script provides a few standard options you can pass:
   ``-jvm-debug <port>``
     Turn on JVM debugging, open at the given port
 
+  ``-java-home <java home>``
+    Override the default JVM home, it accept variable expansions, e.g.
+    ``-java-home ${app_home}/../jre``
+
   ``-main``
     Define a custom main class
 

--- a/src/sphinx/recipes/embedded-jvm.rst
+++ b/src/sphinx/recipes/embedded-jvm.rst
@@ -1,0 +1,48 @@
+Embedding JVM in Universal
+==========================
+
+Sbt Native Packager supports embedding the jvm using the :ref:`jdkpackager-plugin`,
+however, in some cases you may want instead to embed the JVM/JRE in other formats,
+e.g. a tarball with one of the java archetypes.
+
+To accomplish this you need to:
+
+* Add the JVM/JRE of your choice to the `mappings`
+* Make the launcher use the embedded `jre`
+
+Adding the JVM
+--------------
+
+The JRE is by definition OS dependent, hence you must choose the one appropriate
+for your case. The example below assumes a Linux 64 JRE, whose files are at
+``$HOME/.jre/linux64``. The files will be copied to a ``jre`` directory in your
+distribution
+
+.. code-block:: scala
+
+      import NativePackagerHelper._
+
+      ...
+
+      mappings in Universal ++= {
+        val jresDir = Path.userHome / ".jre"
+        val linux64Jre = jresDir.toPath.resolve("linux64")
+        directory(linux64Jre.toFile).map { j =>
+          j._1 -> j._2.replace(jreLink, "jre")
+        }
+      }
+
+Application Configuration
+-------------------------
+
+In order to run your application in production you also need to make the launcher
+use the jre added above. This can be done using the ``-java-home`` option with a
+relative path.
+
+.. code-block:: scala
+
+  javaOptions in Universal ++= Seq(
+    // Your original options
+
+   "-java-home ${app_home}/../jre"
+  )

--- a/src/sphinx/recipes/index.rst
+++ b/src/sphinx/recipes/index.rst
@@ -16,7 +16,6 @@ This section provides recipes for common configurations. If you can't find what 
    deployment
    scalajs
    package_configuration
-
-
+   embedded-jvm
 
 .. _sbt-native-packager examples: https://github.com/muuki88/sbt-native-packager-examples


### PR DESCRIPTION
This PR is related to #816 and it changes the bash launcher to expand variables inside the `java-home` variable. This lets you build self-contained tarballs that contain the jre and use it to launch the application

With this PR you can define, e.g.

`-java-home ${app_home}/../jre` and the `app_home` variable will be resolved

A test is included, execute with
```
scripted bash/java-home-override
```

The updated launcher has been tested with bash 3.2.7 in OSX and bash 4.1.2 in CentOS 6

If this is accepted I would provide documentation for the website too