### PR TITLE
Fix duplicate RPM scriptlet override

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
@@ -237,7 +237,7 @@ object JavaServerAppPackaging extends AutoPlugin {
     val rpmScripts = Option(scriptDirectory.listFiles) getOrElse Array.empty
 
     // remove all non files and already processed templates
-    rpmScripts.diff(predefined).filter(_.isFile).foldLeft(predefinedScripts) {
+    rpmScripts.filter(s => s.isFile && !predefined.contains(s.getName)).foldLeft(predefinedScripts) {
       case (scripts, scriptlet) =>
         val script = scriptlet.getName
         val existingContent = scripts.getOrElse(script, Nil)

--- a/src/sbt-test/rpm/scriptlets-override-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriptlets-override-rpm/build.sbt
@@ -34,3 +34,16 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
     ()
 }
 
+def countSubstring( str:String, substr:String ) = substr.r.findAllMatchIn(str).length
+
+def isUnique(str:String, searchstr: String) = countSubstring(str, searchstr) == 1
+
+TaskKey[Unit]("unique-scripts-in-spec-file") <<= (target, streams) map { (target, out) =>
+    val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
+    assert( isUnique(spec, "echo postinst"), "'echo 'postinst' not unique in \n" + spec)
+    assert( isUnique(spec, "echo preinst"), "'echo 'preinst' not unique in \n" + spec)
+    assert( isUnique(spec, "echo postun"), "'echo 'postun' not unique in \n" + spec)
+    assert( isUnique(spec, "echo preun"), "'echo 'preun' not unique in \n" + spec)
+    ()
+}
+

--- a/src/sbt-test/rpm/scriptlets-override-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriptlets-override-rpm/build.sbt
@@ -34,9 +34,11 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
     ()
 }
 
-def countSubstring( str:String, substr:String ) = substr.r.findAllMatchIn(str).length
+def countSubstring(str: String, substr: String): Int =
+    substr.r.findAllMatchIn(str).length
 
-def isUnique(str:String, searchstr: String) = countSubstring(str, searchstr) == 1
+def isUnique(str: String, searchstr: String): Boolean =
+    countSubstring(str, searchstr) == 1
 
 TaskKey[Unit]("unique-scripts-in-spec-file") <<= (target, streams) map { (target, out) =>
     val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")

--- a/src/sbt-test/rpm/scriptlets-override-rpm/test
+++ b/src/sbt-test/rpm/scriptlets-override-rpm/test
@@ -23,3 +23,4 @@ $ exists var/run/rpm-test
 > set NativePackagerKeys.rpmBrpJavaRepackJars := true
 > check-spec-file
 
+> unique-scripts-in-spec-file


### PR DESCRIPTION
Fix incorrect logic when detecting processed RPM scriptlets override file.

Includes cherry-picked test from #819.

Fixes #812.