### PR TITLE
Fix scoping in RPM plugin for #789

### DIFF
--- a/src/sbt-test/rpm/simple-rpm/build.sbt
+++ b/src/sbt-test/rpm/simple-rpm/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.sbt.packager.linux._
+
 enablePlugins(RpmPlugin)
 
 name := "rpm-test"
@@ -19,6 +21,21 @@ rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
 
 rpmLicense := Some("BSD")
 
+packageArchitecture in Rpm := "x86_64"
+
+linuxPackageMappings in Rpm := {
+  val mapping1 = ((baseDirectory.value / "test"), "tmp/test")
+  val mapping2 = ((baseDirectory.value / "build.sbt"), "/tmp/build.sbt")
+  Seq(LinuxPackageMapping(Seq(mapping1, mapping2)))
+}
+
+linuxPackageSymlinks in Rpm := Seq(
+  LinuxSymlink("/etc/link1", "destination1"),
+  LinuxSymlink("link2", "destination2")
+)
+
+defaultLinuxInstallLocation in Rpm := "/opt/foo"
+
 TaskKey[Unit]("unzip") <<= (packageBin in Rpm, streams) map { (rpmFile, streams) =>
   val rpmPath = Seq(rpmFile.getAbsolutePath)
   Process("rpm2cpio" , rpmPath) #| Process("cpio -i --make-directories") ! streams.log
@@ -26,8 +43,6 @@ TaskKey[Unit]("unzip") <<= (packageBin in Rpm, streams) map { (rpmFile, streams)
 
 TaskKey[Unit]("checkSpecFile") <<= (target, streams) map { (target, out) =>
   val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
-  println(spec)
-
   assert(spec contains "Name: rpm-test", "Contains project name")
   assert(spec contains "Version: 0.1.0", "Contains project version")
   assert(spec contains "Release: 1", "Contains project release")
@@ -35,11 +50,26 @@ TaskKey[Unit]("checkSpecFile") <<= (target, streams) map { (target, out) =>
   assert(spec contains "License: BSD", "Contains project license")
   assert(spec contains "Vendor: typesafe", "Contains project vendor")
   assert(spec contains "URL: http://github.com/sbt/sbt-native-packager", "Contains project url")
-  assert(spec contains "BuildArch: noarch", "Contains noarch for BuildArch")
+  assert(spec contains "BuildArch: x86_64", "Contains project package architecture")
 
   assert(spec contains
     "%description\nA fun package description of our software,\n  with multiple lines.",
     "Contains project description"
+  )
+
+  assert(spec contains
+    "%files\n%attr(755,root,root) /tmp/test\n%attr(755,root,root) /tmp/build.sbt",
+    "Contains package mappings"
+  )
+
+  assert(spec contains
+    "ln -s $(relocateLink destination1 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX) $(relocateLink /etc/link1 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX)",
+    "Contains package symlink link (1)"
+  )
+
+  assert(spec contains
+    "ln -s $(relocateLink destination2 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX) $(relocateLink link2 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX)",
+    "Contains package symlink link (2)"
   )
 
   out.log.success("Successfully tested rpm test file")

--- a/src/sbt-test/rpm/simple-rpm/build.sbt
+++ b/src/sbt-test/rpm/simple-rpm/build.sbt
@@ -19,4 +19,29 @@ rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
 
 rpmLicense := Some("BSD")
 
+TaskKey[Unit]("unzip") <<= (packageBin in Rpm, streams) map { (rpmFile, streams) =>
+  val rpmPath = Seq(rpmFile.getAbsolutePath)
+  Process("rpm2cpio" , rpmPath) #| Process("cpio -i --make-directories") ! streams.log
+}
 
+TaskKey[Unit]("checkSpecFile") <<= (target, streams) map { (target, out) =>
+  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
+  println(spec)
+
+  assert(spec contains "Name: rpm-test", "Contains project name")
+  assert(spec contains "Version: 0.1.0", "Contains project version")
+  assert(spec contains "Release: 1", "Contains project release")
+  assert(spec contains "Summary: Test rpm package", "Contains project summary")
+  assert(spec contains "License: BSD", "Contains project license")
+  assert(spec contains "Vendor: typesafe", "Contains project vendor")
+  assert(spec contains "URL: http://github.com/sbt/sbt-native-packager", "Contains project url")
+  assert(spec contains "BuildArch: noarch", "Contains noarch for BuildArch")
+
+  assert(spec contains
+    "%description\nA fun package description of our software,\n  with multiple lines.",
+    "Contains project description"
+  )
+
+  out.log.success("Successfully tested rpm test file")
+  ()
+}

--- a/src/sbt-test/rpm/simple-rpm/test
+++ b/src/sbt-test/rpm/simple-rpm/test
@@ -1,3 +1,7 @@
 # Run the debian packaging.
 > rpm:package-bin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+
+> unzip
+
+> checkSpecFile

--- a/src/sbt-test/rpm/simple-rpm/test
+++ b/src/sbt-test/rpm/simple-rpm/test
@@ -1,6 +1,6 @@
 # Run the debian packaging.
 > rpm:package-bin
-$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+$ exists target/rpm/RPMS/x86_64/rpm-test-0.1.0-1.x86_64.rpm
 
 > unzip
 


### PR DESCRIPTION
This change updates the RPM plugin settings so that keys starting with `rpm` are no longer scoped to the `Rpm` configuration. This should address #789.

I didn't see a formal testing process documented (though I may have missed it in the docs), so far I've only verified that `sbt test` and `sbt scripted rpm/*` are passing (both ran on a VM running centos7).

TODO 
- [x] Investigate if additional tests are needed, and if so add them