### PR TITLE
Make daemonStdoutLogFile working on SystemV/Debian wheezy

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemv/start-debian-template
@@ -48,9 +48,9 @@ start_daemon() {
     fi
 
     if [ "$create_pidfile" = true ]; then
-        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS "$stdout_redirect"
+        eval "start-stop-daemon --no-close --background --chdir ${{chdir}} --chuid '$DAEMON_USER' --make-pidfile --pidfile '$PIDFILE' --startas '$RUN_CMD' --start -- $RUN_OPTS $stdout_redirect"
     else
-        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS "$stdout_redirect"
+        eval "start-stop-daemon --no-close --background --chdir ${{chdir}} --chuid '$DAEMON_USER' --pidfile '$PIDFILE' --startas '$RUN_CMD' --start -- $RUN_OPTS $stdout_redirect"
     fi
     log_end_msg $?
 }

--- a/src/sbt-test/debian/sysvinit-deb/build.sbt
+++ b/src/sbt-test/debian/sysvinit-deb/build.sbt
@@ -40,7 +40,7 @@ TaskKey[Unit]("check-startup-script") <<= (target, streams) map { (target, out) 
   assert(script.contains("# Default-Stop: 0 1 6"), "script doesn't contain Default-Stop header\n" + script)
   assert(script.contains("# Required-Start: $test-deb-service"), "script doesn't contain Required-Start header\n" + script)
   assert(script.contains("# Required-Stop: $remote_fs $syslog"), "script doesn't contain Required-Stop header\n" + script)
-  assert(script.contains("""start-stop-daemon --background --chdir /usr/share/debian-test --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS "$stdout_redirect"""), "script has wrong startup line\n" + script)
+  assert(script.contains("""start-stop-daemon --no-close --background --chdir /usr/share/debian-test --chuid '$DAEMON_USER' --make-pidfile --pidfile '$PIDFILE' --startas '$RUN_CMD' --start -- $RUN_OPTS $stdout_redirect"""), "script has wrong startup line\n" + script)
   assert(script.contains("""logfile="test.log"""") ,"script contains wrong log file for stdout\n" + script)
 
   out.log.success("Successfully tested systemV start up script")


### PR DESCRIPTION
The `daemonStdoutLogFile` setting is not working with SysV/Debian wheezy :  

```
/etc/init.d/showcase start
[....] Starting: showcase
Bad root server path: /var/novapost/showcase/ >> /var/log/showcase/boot.log 2>&1
 (warning).
```

Quotes of `$stdout_redirect` variable are  not working correctly in `start-stop-daemon` command. 
I  propose this solution using eval command, what do you think ? 

(thanks @jpic for help) 
