### PR TITLE
FIX #770 add ExitStatusSuccess setting for systemd

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemd/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemd/start-template
@@ -10,6 +10,7 @@ ExecStart=${{chdir}}/bin/${{exec}}
 ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=${{retryTimeout}}
+SuccessExitStatus=${{SuccessExitStatus}}
 User=${{daemon_user}}
 ExecStartPre=/bin/mkdir -p /run/${{app_name}}
 ExecStartPre=/bin/chown ${{daemon_user}}:${{daemon_group}} /run/${{app_name}}

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemdPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemdPlugin.scala
@@ -30,6 +30,12 @@ object SystemdPlugin extends AutoPlugin {
 
   override def requires = SystemloaderPlugin
 
+  object autoImport {
+    val systemdSuccessExitStatus = settingKey[Seq[String]]("SuccessExitStatus property")
+  }
+
+  import autoImport._
+
   override def projectSettings: Seq[Setting[_]] =
     debianSettings ++ inConfig(Debian)(systemdSettings) ++ rpmSettings ++ inConfig(Rpm)(systemdSettings)
 
@@ -41,6 +47,7 @@ object SystemdPlugin extends AutoPlugin {
     stopRunlevels := None,
     requiredStartFacilities := Some("network.target"),
     requiredStopFacilities := Some("network.target"),
+    systemdSuccessExitStatus := Seq.empty,
     linuxStartScriptName := Some(packageName.value + ".service"),
     // add systemloader to mappings
     linuxPackageMappings ++= startScriptMapping(
@@ -48,7 +55,9 @@ object SystemdPlugin extends AutoPlugin {
       linuxMakeStartScript.value,
       defaultLinuxStartScriptLocation.value,
       isConf = true
-    )
+    ),
+    // add additional system configurations to script replacements
+    linuxScriptReplacements += ("SuccessExitStatus" -> systemdSuccessExitStatus.value.mkString(" "))
   )
 
   def debianSettings: Seq[Setting[_]] = inConfig(Debian)(

--- a/src/sbt-test/debian/systemd-deb/build.sbt
+++ b/src/sbt-test/debian/systemd-deb/build.sbt
@@ -12,11 +12,14 @@ requiredStartFacilities in Debian := Some("network.target")
 
 daemonUser in Linux := "testuser"
 
+systemdSuccessExitStatus in Debian += "1"
+
 TaskKey[Unit]("check-startup-script") <<= (target, streams) map { (target, out) =>
   val script = IO.read(target / "debian-test-0.1.0" / "lib" / "systemd" / "system" / "debian-test.service")
   assert(script.contains("Requires=network.target"), "script doesn't contain Default-Start header\n" + script)
   assert(script.contains("User=testuser"), "script doesn't contain `User` header\n" + script)
   assert(script.contains("EnvironmentFile=/etc/default/debian-test"), "script doesn't contain EnvironmentFile header\n" + script)
+  assert(script.contains("SuccessExitStatus=1"), "script doesn't contain SuccessExitStatus header\n" + script)
   out.log.success("Successfully tested systemd start up script")
   ()
 }

--- a/src/sbt-test/rpm/systemd-rpm/build.sbt
+++ b/src/sbt-test/rpm/systemd-rpm/build.sbt
@@ -26,6 +26,7 @@ TaskKey[Unit]("checkStartupScript") <<= (target, streams) map { (target, out) =>
   val script = IO.read(file("usr/lib/systemd/system/rpm-test.service"))
   val runScript = file("usr/share/rpm-test/bin/rpm-test")
   assert(script.contains("Requires=serviceA.service"), "script doesn't contain Default-Start header\n" + script)
+  assert(script.contains("SuccessExitStatus="), "script doesn't contain SuccessExitStatus header\n" + script)
   out.log.success("Successfully tested systemd start up script")
   ()
 }

--- a/src/sphinx/archetypes/systemloaders.rst
+++ b/src/sphinx/archetypes/systemloaders.rst
@@ -69,6 +69,14 @@ In order to enable Systemd add this plugin:
 
     enablePlugins(SystemdPlugin)
 
+Settings
+~~~~~~~~
+
+  ``systemdSuccessExitStatus``
+    Takes a list of exit status definitions that when returned by the main service process will be considered successful
+    termination, in addition to the normal successful exit code ``0`` and the signals ``SIGHUP``, ``SIGINT``,
+    ``SIGTERM``, and ``SIGPIPE``. Exit status definitions can either be numeric exit codes or termination signal names.
+
 Upstart
 -------
 


### PR DESCRIPTION
You can now add the `ExitSuccessStatus` as a setting

```scala
enablePlugins(JavaAppPackaging, SystemdPlugin)

// for rpm
systemdSuccessExitStatus in Rpm += Seq("143")
// for deb
systemdSuccessExitStatus in Debian += Seq("143")
```