### PR TITLE
docker: tag -f is deprecated (backport to 1.1.x)

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -294,7 +294,7 @@ object DockerPlugin extends AutoPlugin {
 
     if (latest) {
       val name = tag.substring(0, tag.lastIndexOf(":")) + ":latest"
-      val latestCmd = Seq("docker", "tag", "-f", tag, name)
+      val latestCmd = Seq("docker", "tag", tag, name)
       Process(latestCmd).! match {
         case 0 => log.info("Update Latest from image " + tag)
         case n => sys.error("Failed to run docker tag")


### PR DESCRIPTION
fixes #818, #838 in the 1.1.x branch