### PR TITLE
Fix typo in debian systemv script

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/java_server/systemloader/systemv/start-debian-template
@@ -43,9 +43,9 @@ start_daemon() {
     [ -d "/var/run/${{app_name}}" ] || install -d -o "$DAEMON_USER" -g "$DAEMON_GROUP" -m755 "/var/run/${{app_name}}"
     logfile="${{daemon_log_file}}"
     stdout_redirect=""
-    if [ ! -z "${logfile:-}"]; then
+    if [ ! -z "${logfile:-}" ]; then
       stdout_redirect=" >> ${{logdir}}/${{app_name}}/$logfile 2>&1"
-    if
+    fi
 
     if [ "$create_pidfile" = true ]; then
         start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS "$stdout_redirect"


### PR DESCRIPTION
As already corrected in 1.2.x - https://github.com/sbt/sbt-native-packager/commit/a1d6023d29eccbf11e24e05de0d76bc4434c7170