### PR TITLE
Fix: `exec` the java entrypoint in ash-template

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/ash-template
@@ -42,4 +42,4 @@ ${{template_declares}}
 # If a configuration file exist, read the contents to $opts
 [ -f "$script_conf_file" ] && opts=$(loadConfigFile "$script_conf_file")
 
-java -classpath $app_classpath $opts $app_mainclass $@
+exec java -classpath $app_classpath $opts $app_mainclass $@


### PR DESCRIPTION
The bash-template correctly correctly wraps the `java` entrypoint in `exec`:

https://github.com/sbt/sbt-native-packager/blob/73cc27a920b8162fa55dafc4897acd160707837e/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template#L249-L255
https://github.com/sbt/sbt-native-packager/blob/73cc27a920b8162fa55dafc4897acd160707837e/src/main/resources/com/typesafe/sbt/packager/archetypes/bash-template#L136

however here it was missing.

This causes issues when using Docker, because exit signals are not
passed onto the java process, so e.g. Ctrl-C doesn't stop
the running application.

See here for details on why this is needed in Docker:
https://docs.docker.com/engine/reference/builder/#exec-form-entrypoint-example