### PR TITLE
Rename dockerTarget to dockerTag

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -64,7 +64,7 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
 
   def publishLocalDocker = Def.task {
     val context = stage.value
-    val tag = dockerTarget.value
+    val tag = dockerTag.value
     val latest = dockerUpdateLatest.value
     val log = streams.value.log
 

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -10,12 +10,12 @@ import sbt._
 trait DockerKeys {
   val dockerGenerateConfig = TaskKey[File]("docker-generate-config", "Generates configuration file for Docker.")
   val dockerPackageMappings = TaskKey[Seq[(File, String)]]("docker-package-mappings", "Generates location mappings for Docker build.")
-  val dockerTarget = TaskKey[String]("docker-target", "Defines target used when building and publishing Docker image")
 
   val dockerBaseImage = SettingKey[String]("dockerBaseImage", "Base image for Dockerfile.")
   val dockerExposedPorts = SettingKey[Seq[Int]]("dockerExposedPorts", "Ports exposed by Docker image")
   val dockerExposedVolumes = SettingKey[Seq[String]]("dockerExposedVolumes", "Volumes exposed by Docker image")
   val dockerRepository = SettingKey[Option[String]]("dockerRepository", "Repository for published Docker image")
+  val dockerTag = SettingKey[String]("dockerTag", "Docker tag for the built image")
   val dockerUpdateLatest = SettingKey[Boolean]("dockerUpdateLatest", "Set to update latest tag")
   val dockerEntrypoint = SettingKey[Seq[String]]("dockerEntrypoint", "Entrypoint arguments passed in exec form")
   val dockerCmd = SettingKey[Seq[String]]("dockerCmd", "Docker CMD. Used together with dockerEntrypoint. Arguments passed in exec form")

--- a/src/sbt-test/docker/tag/build.sbt
+++ b/src/sbt-test/docker/tag/build.sbt
@@ -1,0 +1,7 @@
+enablePlugins(JavaAppPackaging)
+
+name := "docker-tag-test"
+
+version := "0.1.0"
+
+dockerTag := "docker-tag-test:0.1.0"

--- a/src/sbt-test/docker/tag/project/plugins.sbt
+++ b/src/sbt-test/docker/tag/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/tag/src/main/scala/Main.scala
+++ b/src/sbt-test/docker/tag/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}

--- a/src/sbt-test/docker/tag/test
+++ b/src/sbt-test/docker/tag/test
@@ -1,0 +1,3 @@
+# Stage the distribution and ensure files show up.
+> docker:publishLocal
+$ exec bash -c 'docker run docker-tag-test:0.1.0 | grep -q "Hello world"'

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -115,6 +115,10 @@ Publishing Settings
   ``dockerUpdateLatest``
     The flag to automatic update the latest tag when the ``docker:publish`` task is run. Default value is ``FALSE``.
 
+  ``dockerTag``
+    The tag to be used during build for the resulting image.
+    Defaults to ``[dockerRepository]/[name]:[version]``.
+
 Tasks
 -----
 The Docker support provides the following commands:


### PR DESCRIPTION
Using `SettingKey` instead of `TaskKey` for the `dockerTag` setting.

The `dockerTarget` configuration is used as Docker tag and was not documented yet. Renaming it to a more applicable name.