### PR TITLE
Replace deprecated java Docker image with openjdk

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -72,7 +72,7 @@ object DockerPlugin extends AutoPlugin {
   override def projectConfigurations: Seq[Configuration] = Seq(Docker)
 
   override lazy val projectSettings = Seq(
-    dockerBaseImage := "java:latest",
+    dockerBaseImage := "openjdk:latest",
     dockerExposedPorts := Seq(),
     dockerExposedVolumes := Seq(),
     dockerRepository := None,

--- a/src/sbt-test/docker/override-commands/build.sbt
+++ b/src/sbt-test/docker/override-commands/build.sbt
@@ -9,7 +9,7 @@ version := "0.1.0"
 maintainer := "Gary Coady <gary@lyranthe.org>"
 
 dockerCommands := Seq(
-  Cmd("FROM", "dockerfile/java:latest"),
+  Cmd("FROM", "dockerfile/openjdk:latest"),
   Cmd("MAINTAINER", maintainer.value),
   ExecCmd("CMD", "echo", "Hello, World from Docker")
 )

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -166,7 +166,7 @@ Docker Base Image
 
 .. code-block:: scala
 
-    dockerBaseImage := "dockerfile/java"
+    dockerBaseImage := "dockerfile/openjdk"
 
 Docker Repository
 ~~~~~~~~~~~~~~~~~
@@ -210,7 +210,7 @@ In your sbt console type
 .. code-block:: bash
 
     > show dockerCommands
-    [info] List(Cmd(FROM,dockerfile/java:latest), Cmd(MAINTAINER,Your Name <y.n@yourcompany.com>), ...)
+    [info] List(Cmd(FROM,dockerfile/openjdk:latest), Cmd(MAINTAINER,Your Name <y.n@yourcompany.com>), ...)
 
 
 
@@ -278,7 +278,7 @@ Now let's start adding some Docker commands.
   import com.typesafe.sbt.packager.docker._
 
   dockerCommands := Seq(
-    Cmd("FROM", "dockerfile/java:latest"),
+    Cmd("FROM", "dockerfile/openjdk:latest"),
     Cmd("MAINTAINER", maintainer.value),
     ExecCmd("CMD", "echo", "Hello, World from Docker")
   )


### PR DESCRIPTION
As per https://hub.docker.com/_/java/ the default `java` images have been deprecated in favor of `openjdk` (https://hub.docker.com/_/openjdk/) and will no longer receive updates after this year.

This change is replacing the references to `java:latest` with `openjdk:latest` both in code and documentation.