### PR TITLE
Add ability to expose UDP ports

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -74,6 +74,7 @@ object DockerPlugin extends AutoPlugin {
   override lazy val projectSettings = Seq(
     dockerBaseImage := "openjdk:latest",
     dockerExposedPorts := Seq(),
+    dockerExposedUdpPorts := Seq(),
     dockerExposedVolumes := Seq(),
     dockerRepository := None,
     dockerAlias := DockerAlias(dockerRepository.value, None, packageName.value, Some(version.value)),
@@ -99,7 +100,7 @@ object DockerPlugin extends AutoPlugin {
         makeAdd(dockerBaseDirectory),
         makeChown(user, group, "." :: Nil)
       ) ++
-        makeExposePorts(dockerExposedPorts.value) ++
+        makeExposePorts(dockerExposedPorts.value, dockerExposedUdpPorts.value) ++
         makeVolumes(dockerExposedVolumes.value, user, group) ++
         Seq(
           makeUser(user),
@@ -207,8 +208,8 @@ object DockerPlugin extends AutoPlugin {
    * @param exposedPorts
    * @return if ports are exposed the EXPOSE command
    */
-  private final def makeExposePorts(exposedPorts: Seq[Int]): Option[CmdLike] = {
-    if (exposedPorts.isEmpty) None else Some(Cmd("EXPOSE", exposedPorts mkString " "))
+  private final def makeExposePorts(exposedPorts: Seq[Int], exposedUdpPorts: Seq[Int]): Option[CmdLike] = {
+    if (exposedPorts.isEmpty) None else Some(Cmd("EXPOSE", (exposedPorts.map(_.toString) ++ exposedUdpPorts.map(_.toString).map(_ + "/udp")) mkString " "))
   }
 
   /**

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -12,7 +12,8 @@ trait DockerKeys {
   val dockerPackageMappings = TaskKey[Seq[(File, String)]]("docker-package-mappings", "Generates location mappings for Docker build.")
 
   val dockerBaseImage = SettingKey[String]("dockerBaseImage", "Base image for Dockerfile.")
-  val dockerExposedPorts = SettingKey[Seq[Int]]("dockerExposedPorts", "Ports exposed by Docker image")
+  val dockerExposedPorts = SettingKey[Seq[Int]]("dockerExposedPorts", "TCP Ports exposed by Docker image")
+  val dockerExposedUdpPorts = SettingKey[Seq[Int]]("dockerExposedUdpPorts", "UDP Ports exposed by Docker image")
   val dockerExposedVolumes = SettingKey[Seq[String]]("dockerExposedVolumes", "Volumes exposed by Docker image")
   val dockerRepository = SettingKey[Option[String]]("dockerRepository", "Repository for published Docker image")
   val dockerAlias = SettingKey[DockerAlias]("dockerAlias", "Docker alias for the built image")

--- a/src/sbt-test/docker/ports/build.sbt
+++ b/src/sbt-test/docker/ports/build.sbt
@@ -4,4 +4,5 @@ name := "simple-test"
 
 version := "0.1.0"
 
-dockerExposedPorts := Seq(9000)
+dockerExposedPorts := Seq(9000, 9001)
+dockerExposedUdpPorts := Seq(10000, 10001)

--- a/src/sbt-test/docker/ports/test
+++ b/src/sbt-test/docker/ports/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
 > docker:stage
-$ exec grep -q -F 'EXPOSE 9000' target/docker/Dockerfile
+$ exec grep -q -F 'EXPOSE 9000 9001 10000/udp 10001/udp' target/docker/Dockerfile

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -99,7 +99,10 @@ Environment Settings
     The user to use when executing the application. Files below the install path also have their ownership set to this user.
 
   ``dockerExposedPorts``
-    A list of ports to expose from the Docker image.
+    A list of TCP ports to expose from the Docker image.
+
+  ``dockerExposedUdpPorts``
+    A list of UDP ports to expose from the Docker image.
 
   ``dockerExposedVolumes in Docker``
     A list of data volumes to make available in the Docker image.


### PR DESCRIPTION
Add `dockerExposedUdpPorts` similar to the existing `dockerExposedPorts`.

Note that this depends on #880 for the tests to pass.

Fixed #843