### PR TITLE
Generate EXPOSE when only UDP ports are exposed

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -215,7 +215,7 @@ object DockerPlugin extends AutoPlugin {
     * @return if ports are exposed the EXPOSE command
     */
   private final def makeExposePorts(exposedPorts: Seq[Int], exposedUdpPorts: Seq[Int]): Option[CmdLike] =
-    if (exposedPorts.isEmpty) None
+    if (exposedPorts.isEmpty && exposedUdpPorts.isEmpty) None
     else
       Some(
         Cmd("EXPOSE", (exposedPorts.map(_.toString) ++ exposedUdpPorts.map(_.toString).map(_ + "/udp")) mkString " ")

--- a/src/sbt-test/docker/udp-only-ports/build.sbt
+++ b/src/sbt-test/docker/udp-only-ports/build.sbt
@@ -1,0 +1,8 @@
+enablePlugins(DockerPlugin)
+
+name := "simple-test"
+
+version := "0.1.0"
+
+dockerExposedPorts := Seq()
+dockerExposedUdpPorts := Seq(10000, 10001)

--- a/src/sbt-test/docker/udp-only-ports/project/plugins.sbt
+++ b/src/sbt-test/docker/udp-only-ports/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/udp-only-ports/test
+++ b/src/sbt-test/docker/udp-only-ports/test
@@ -1,0 +1,3 @@
+# Stage the distribution and ensure files show up.
+> docker:stage
+$ exec grep -q -F 'EXPOSE 10000/udp 10001/udp' target/docker/Dockerfile


### PR DESCRIPTION
Right now setting
```
dockerExposedPorts := Seq()
dockerExposedUdpPorts := Seq(10000, 10001)
```

would not generate EXPOSE section