### PR TITLE
Adding rpm override script tests

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemVPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemVPlugin.scala
@@ -65,7 +65,7 @@ object SystemVPlugin extends AutoPlugin {
       Seq(
         // set the template
         linuxStartScriptTemplate := linuxStartScriptUrl(
-          (sourceDirectory in Compile).value,
+          sourceDirectory.value,
           serverLoading.value,
           "start-rpm-template"
         )

--- a/src/sbt-test/rpm/override-start-script-systemd/build.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemd/build.sbt
@@ -1,0 +1,36 @@
+enablePlugins(JavaServerAppPackaging, SystemdPlugin)
+
+name := "rpm-test"
+
+version := "0.1.0"
+
+maintainer := "Mitch Seymour <mitchseymour@gmail.com>"
+
+packageSummary := "Test rpm package"
+
+executableScriptName := "rpm-exec"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+rpmRelease := "1"
+
+rpmVendor := "typesafe"
+
+rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
+
+rpmLicense := Some("BSD")
+
+rpmGroup := Some("test-group")
+
+TaskKey[Unit]("unzip") <<= (packageBin in Rpm, streams) map { (rpmFile, streams) =>
+  val rpmPath = Seq(rpmFile.getAbsolutePath)
+  Process("rpm2cpio", rpmPath) #| Process("cpio -i --make-directories") ! streams.log
+  ()
+}
+
+TaskKey[Unit]("checkStartupScript") <<= (target, streams) map { (target, out) =>
+  val script = IO.read(file("usr/lib/systemd/system/rpm-test.service"))
+  assert(script.startsWith("# right systemd template"), s"override script wasn't picked, script is\n$script")
+  ()
+}

--- a/src/sbt-test/rpm/override-start-script-systemd/project/plugins.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemd/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/override-start-script-systemd/src/templates/start
+++ b/src/sbt-test/rpm/override-start-script-systemd/src/templates/start
@@ -1,0 +1,2 @@
+# check that old start template isn't picked
+# wrong start template

--- a/src/sbt-test/rpm/override-start-script-systemd/src/templates/systemloader/systemd
+++ b/src/sbt-test/rpm/override-start-script-systemd/src/templates/systemloader/systemd
@@ -1,0 +1,1 @@
+# right systemd template

--- a/src/sbt-test/rpm/override-start-script-systemd/test
+++ b/src/sbt-test/rpm/override-start-script-systemd/test
@@ -1,0 +1,10 @@
+# Run the rpm packaging.
+> rpm:package-bin
+$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+
+> unzip
+# Bootscript != executable Script
+$ exists /usr/lib/systemd/system/rpm-test.service
+# $ exists usr/share/rpm-test/bin/rpm-exec
+
+> checkStartupScript

--- a/src/sbt-test/rpm/override-start-script-systemv/build.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemv/build.sbt
@@ -1,0 +1,36 @@
+enablePlugins(JavaServerAppPackaging, SystemVPlugin)
+
+name := "rpm-test"
+
+version := "0.1.0"
+
+maintainer := "Mitch Seymour <mitchseymour@gmail.com>"
+
+packageSummary := "Test rpm package"
+
+executableScriptName := "rpm-exec"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+rpmRelease := "1"
+
+rpmVendor := "typesafe"
+
+rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
+
+rpmLicense := Some("BSD")
+
+rpmGroup := Some("test-group")
+
+TaskKey[Unit]("unzip") <<= (packageBin in Rpm, streams) map { (rpmFile, streams) =>
+  val rpmPath = Seq(rpmFile.getAbsolutePath)
+  Process("rpm2cpio", rpmPath) #| Process("cpio -i --make-directories") ! streams.log
+  ()
+}
+
+TaskKey[Unit]("checkStartupScript") <<= (target, streams) map { (target, out) =>
+  val script = IO.read(file("etc/init.d/rpm-test"))
+  assert(script.startsWith("# right systemv template"), s"override script wasn't picked, script is\n$script")
+  ()
+}

--- a/src/sbt-test/rpm/override-start-script-systemv/project/plugins.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemv/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/override-start-script-systemv/src/templates/start
+++ b/src/sbt-test/rpm/override-start-script-systemv/src/templates/start
@@ -1,0 +1,2 @@
+# check that old start template isn't picked
+# wrong start template

--- a/src/sbt-test/rpm/override-start-script-systemv/src/templates/systemloader/systemv
+++ b/src/sbt-test/rpm/override-start-script-systemv/src/templates/systemloader/systemv
@@ -1,0 +1,1 @@
+# right systemv template

--- a/src/sbt-test/rpm/override-start-script-systemv/test
+++ b/src/sbt-test/rpm/override-start-script-systemv/test
@@ -1,0 +1,10 @@
+# Run the rpm packaging.
+> rpm:package-bin
+$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+
+> unzip
+# Bootscript != executable Script
+$ exists etc/init.d/rpm-test
+# $ exists usr/share/rpm-test/bin/rpm-exec
+
+> checkStartupScript

--- a/src/sbt-test/rpm/override-start-script-upstart/build.sbt
+++ b/src/sbt-test/rpm/override-start-script-upstart/build.sbt
@@ -1,0 +1,36 @@
+enablePlugins(JavaServerAppPackaging, UpstartPlugin)
+
+name := "rpm-test"
+
+version := "0.1.0"
+
+maintainer := "Mitch Seymour <mitchseymour@gmail.com>"
+
+packageSummary := "Test rpm package"
+
+executableScriptName := "rpm-exec"
+
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+rpmRelease := "1"
+
+rpmVendor := "typesafe"
+
+rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
+
+rpmLicense := Some("BSD")
+
+rpmGroup := Some("test-group")
+
+TaskKey[Unit]("unzip") <<= (packageBin in Rpm, streams) map { (rpmFile, streams) =>
+  val rpmPath = Seq(rpmFile.getAbsolutePath)
+  Process("rpm2cpio", rpmPath) #| Process("cpio -i --make-directories") ! streams.log
+  ()
+}
+
+TaskKey[Unit]("checkStartupScript") <<= (target, streams) map { (target, out) =>
+  val script = IO.read(file("etc/init/rpm-test.conf"))
+  assert(script.startsWith("# right upstart template"), s"override script wasn't picked, script is\n$script")
+  ()
+}

--- a/src/sbt-test/rpm/override-start-script-upstart/project/plugins.sbt
+++ b/src/sbt-test/rpm/override-start-script-upstart/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/override-start-script-upstart/src/templates/start
+++ b/src/sbt-test/rpm/override-start-script-upstart/src/templates/start
@@ -1,0 +1,2 @@
+# check that old start template isn't picked
+# wrong start template

--- a/src/sbt-test/rpm/override-start-script-upstart/src/templates/systemloader/upstart
+++ b/src/sbt-test/rpm/override-start-script-upstart/src/templates/systemloader/upstart
@@ -1,0 +1,1 @@
+# right upstart template

--- a/src/sbt-test/rpm/override-start-script-upstart/test
+++ b/src/sbt-test/rpm/override-start-script-upstart/test
@@ -1,0 +1,10 @@
+# Run the rpm packaging.
+> rpm:package-bin
+$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+
+> unzip
+# Bootscript != executable Script
+$ exists etc/init/rpm-test.conf
+# $ exists usr/share/rpm-test/bin/rpm-exec
+
+> checkStartupScript


### PR DESCRIPTION
I added some tests for checking the override behavior of upstart, systemd, and systemv start scripts for rpm packaging (will circle back around to debian when I have time). It seems that the start script template can only be overridden for the [UpstartPlugin](https://github.com/sbt/sbt-native-packager/blob/e4e6504c1f6a75fb346958f68d0f7c13fec26877/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/UpstartPlugin.scala) and [SystemdPlugin](https://github.com/sbt/sbt-native-packager/blob/e4e6504c1f6a75fb346958f68d0f7c13fec26877/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemdPlugin.scala). However, the [SystemVPlugin](https://github.com/sbt/sbt-native-packager/blob/e4e6504c1f6a75fb346958f68d0f7c13fec26877/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemVPlugin.scala) __does not__ seem to work (would like verification from someone more experienced with this plugin, who can run these new tests from their own machine).

```bash
$ cd /path/to/sbt-native-packager
$ sbt # interactive mode
> scripted rpm/override-start-script-upstart # works
> scripted rpm/override-start-script-systemd # works
> scripted rpm/override-start-script-systemv # does not work
```

Would someone please:

1) Verify the systemv overriding template issue
2) If possible, provide some guidance on a possible fix that I can include in this PR

Thanks in advance