### PR TITLE
[rpm] Fixes #894. Symlinks only removed during uninstall, not during update of RPM.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmMetadata.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmMetadata.scala
@@ -312,13 +312,14 @@ case class RpmSpec(meta: RpmMetadata,
     if (symlinks.isEmpty)
       None
     else {
+      val checkUninstall = "if [ $1 -eq 0 ] ;\nthen"
       val sourceAppConfig =
-        s"""[ -e /etc/sysconfig/$appName ] && . /etc/sysconfig/$appName"""
+        s"""  [ -e /etc/sysconfig/$appName ] && . /etc/sysconfig/$appName"""
       val cleanupLinks = symlinks.map { symlink =>
-        s"""rm -rf $$(relocateLink ${symlink.link} $installDir $appName $$PACKAGE_PREFIX)"""
+        s"""  rm -rf $$(relocateLink ${symlink.link} $installDir $appName $$PACKAGE_PREFIX)"""
       }.mkString("\n")
 
-      Some(relocateLinkFunction + "\n" + sourceAppConfig + "\n" + cleanupLinks)
+      Some(relocateLinkFunction + "\n" + checkUninstall + "\n" + sourceAppConfig + "\n" + cleanupLinks + "\nfi")
     }
 
   private def relocateLinkFunction: String =

--- a/src/sbt-test/rpm/scriptlets-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriptlets-rpm/build.sbt
@@ -73,8 +73,11 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
       |    echo "$1"
       |  fi
       |}
-      |[ -e /etc/sysconfig/rpm-test ] && . /etc/sysconfig/rpm-test
-      |rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $PACKAGE_PREFIX)
+      |if [ $1 -eq 0 ] ;
+      |then
+      |  [ -e /etc/sysconfig/rpm-test ] && . /etc/sysconfig/rpm-test
+      |  rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $PACKAGE_PREFIX)
+      |fi
       |""".stripMargin,
     "%postun scriptlet does not contain relocate link"
   )


### PR DESCRIPTION
The removal of the symlinks in `%preun` now is only triggered during an uninstall. Before an update of an package removed the symlinks and left the package in a non-functioning state.