### PR TITLE
fix a bug in the ash-template

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/ash-template
@@ -16,7 +16,7 @@ realpath () {
       COUNT=$(($COUNT + 1))
   done
 
-  if [ "$TARGET_FILE" == "." -o "$TARGET_FILE" == ".." ]; then
+  if [ "$TARGET_FILE" = "." -o "$TARGET_FILE" = ".." ]; then
     cd "$TARGET_FILE"
     TARGET_FILEPATH=
   else


### PR DESCRIPTION
`[ "foo" == "bar" ]` is not valid posix. It should be a single =, or else you'll get "unexpected operator/operand" on a posix compliant shell:

    > posh
    $ [ "foo" = "foo" ] && echo yes 
    yes
    $ [ "foo" == "foo" ] && echo yes
    posh: [: ==: unexpected operator/operand

    > dash                                                                                                               ⏎
    $ [ "foo" = "foo" ] && echo yes 
    yes
    $ [ "foo" == "foo" ] && echo yes
    dash: 2: [: foo: unexpected operator
