### PR TITLE
Do not ignore template name in serviceManager script overloading

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/package.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/package.scala
@@ -71,5 +71,5 @@ package object systemloader {
     loader.toString + "/" + name
 
   private def overrideFromFile(sourceDirectory: File, loader: ServerLoader, name: String): Option[URL] =
-    Option(sourceDirectory / "templates" / "systemloader" / loader.toString).filter(_.exists).map(_.toURI.toURL)
+    Option(sourceDirectory / "templates" / "systemloader" / loader.toString / name).filter(_.exists).map(_.toURI.toURL)
 }


### PR DESCRIPTION
According to the [documentation](http://www.scala-sbt.org/sbt-native-packager/archetypes/cheatsheet.html#overriding-templates ), user must be able to override service manager templates.

But creating a file in src/templates/systemloader/$loader overrides both start-template and loader-functions, used in %post and %preun RPM sections.

This pull requst appends specific template name to common path, thus allowing independnt overriding