### PR TITLE
Treat symlinks as normal files in spec file

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -48,6 +48,15 @@ object RpmHelper {
       if file.exists && !file.isDirectory()
       target = buildroot / dest
     } copyWithZip(file, target, mapping.zipped)
+
+    for (LinuxSymlink(link, dest) <- spec.symlinks) {
+      val linkPath = file(link).toPath
+      val relativeLink = if (linkPath.isAbsolute) linkPath.getRoot.relativize(linkPath) else linkPath
+      val relocatedLink = buildroot / relativeLink.toString
+      val linkDir = if (relocatedLink.isDirectory) relocatedLink else file(relocatedLink.getParent)
+      IO.createDirectory(linkDir)
+      s"ln -s $dest $relocatedLink".!
+    }
   }
 
   private[this] def writeSpecFile(spec: RpmSpec, workArea: File, log: sbt.Logger): File = {

--- a/src/sbt-test/rpm/scriptlets-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriptlets-rpm/build.sbt
@@ -34,50 +34,16 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
   val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
   assert(spec contains "%pre\necho \"pre-install\"", "Spec doesn't contain %pre scriptlet")
   assert(spec contains "%post\necho \"post-install\"", "Spec doesn't contain %post scriptlet")
-  assert(spec contains
-    """
-      |%post
-      |echo "post-install"
-      |
-      |relocateLink() {
-      |  if [ -n "$4" ] ;
-      |  then
-      |    RELOCATED_INSTALL_DIR="$4/$3"
-      |    echo "${1/$2/$RELOCATED_INSTALL_DIR}"
-      |  else
-      |    echo "$1"
-      |  fi
-      |}
-      |rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX) && ln -s $(relocateLink /usr/share/rpm-test/conf /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX) $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX)
-      |""".stripMargin, "%post scriptlet does not contain relocateLink")
-
   assert(spec contains "%pretrans\necho \"pretrans\"", "Spec doesn't contain %pretrans scriptlet")
   assert(spec contains "%posttrans\necho \"posttrans\"", "Spec doesn't contain %posttrans scriptlet")
   assert(spec contains "%preun\necho \"pre-uninstall\"", "Spec doesn't contain %preun scriptlet")
   assert(spec contains "%postun\necho \"post-uninstall\"", "Spec doesn't contain %postun scriptlet")
-  assert(spec contains
-    """
-      |%postun
-      |echo "post-uninstall"
-      |
-      |relocateLink() {
-      |  if [ -n "$4" ] ;
-      |  then
-      |    RELOCATED_INSTALL_DIR="$4/$3"
-      |    echo "${1/$2/$RELOCATED_INSTALL_DIR}"
-      |  else
-      |    echo "$1"
-      |  fi
-      |}
-      |[ -e /etc/sysconfig/rpm-test ] && . /etc/sysconfig/rpm-test
-      |rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $PACKAGE_PREFIX)
-      |""".stripMargin, "%postun scriptlet does not contain relocate link")
   out.log.success("Successfully tested rpm test file")
   ()
 }
 
 TaskKey[Unit]("check-rpm-version") <<= (target, streams) map { (target, out) =>
-  val fullRpmVersion = Process("rpm", Seq("--version")) !! 
+  val fullRpmVersion = Process("rpm", Seq("--version")) !!
   val firstDigit = fullRpmVersion indexWhere Character.isDigit
   val rpmVersion = fullRpmVersion substring firstDigit
   out.log.info("Found rpmVersion: " + rpmVersion)
@@ -89,4 +55,3 @@ TaskKey[Unit]("check-rpm-version") <<= (target, streams) map { (target, out) =>
   assert(major >= 4, "RPM version must be greater than than 4.x.x. Is " + fullRpmVersion)
   ()
 }
-

--- a/src/sbt-test/rpm/symlink-rpm/build.sbt
+++ b/src/sbt-test/rpm/symlink-rpm/build.sbt
@@ -1,0 +1,32 @@
+import com.typesafe.sbt.packager.linux.{LinuxPackageMapping, LinuxSymlink}
+
+enablePlugins(JavaAppPackaging)
+
+name := "rpm-test"
+version := "0.1.0"
+maintainer := "David Pennell <dpennell@good-cloud.com>"
+
+packageSummary := "Test rpm package"
+packageName in Linux := "rpm-package"
+packageDescription := """A fun package description of our software,
+  with multiple lines."""
+
+rpmRelease := "1"
+rpmVendor := "typesafe"
+rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
+rpmLicense := Some("BSD")
+
+linuxPackageSymlinks := {
+  val helloSymlink = LinuxSymlink(((file(defaultLinuxInstallLocation.value) / (packageName in Linux).value / "lib") / "hello.link").toString, "/fake/hello.txt")
+  Seq(helloSymlink)
+}
+
+TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
+  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-package.spec")
+  out.log.success(spec)
+  assert(spec contains "%attr(0644,root,root) /usr/share/rpm-package/lib/rpm-test.rpm-test-0.1.0.jar", "Wrong installation path\n" + spec)
+  assert(spec contains "/usr/share/rpm-package/lib/hello.link", "Missing or incorrect symbolic link\n" + spec)
+  out.log.success("Successfully tested rpm-package file")
+  ()
+}
+

--- a/src/sbt-test/rpm/symlink-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/symlink-rpm/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/symlink-rpm/test
+++ b/src/sbt-test/rpm/symlink-rpm/test
@@ -1,0 +1,7 @@
+# Run the debian packaging.
+> rpm:package-bin
+$ exists target/rpm/RPMS/noarch/rpm-package-0.1.0-1.noarch.rpm
+$ exists target/rpm/SPECS/rpm-package.spec
+
+# Check files for defaults
+> check-spec-file


### PR DESCRIPTION
Symlinks are now treated like normal files in the spec.  All of the special handling in the scriptlets has been removed.  Symlinks are now handled properly by upgrades.
