### PR TITLE
Support prefixing Docker build and push commands with 'sudo'.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -12,6 +12,7 @@ trait DockerKeys {
   val dockerPackageMappings =
     TaskKey[Seq[(File, String)]]("docker-package-mappings", "Generates location mappings for Docker build.")
 
+  val dockerUseSudo = SettingKey[Boolean]("dockerUseSudo", "Prefix all docker commands with 'sudo'")
   val dockerBaseImage =
     SettingKey[String]("dockerBaseImage", "Base image for Dockerfile.")
   val dockerExposedPorts = SettingKey[Seq[Int]]("dockerExposedPorts", "TCP Ports exposed by Docker image")

--- a/src/sbt-test/docker/override-commands/test
+++ b/src/sbt-test/docker/override-commands/test
@@ -1,3 +1,3 @@
 # Generate the Docker image locally
 > docker:publishLocal
-$ exec bash -c 'docker run docker-test:latest | grep -q "Hello world"'
+$ exec bash -c 'docker run docker-commands:latest | grep -q "Hello world"'

--- a/src/sbt-test/docker/sudo-docker/build.sbt
+++ b/src/sbt-test/docker/sudo-docker/build.sbt
@@ -1,0 +1,9 @@
+enablePlugins(JavaAppPackaging)
+
+name := "docker-sudo-test"
+
+version := "0.1.0"
+
+maintainer := "G. Richard Bellamy <rbellamy@terradatum.com>"
+
+dockerUseSudo := true

--- a/src/sbt-test/docker/sudo-docker/project/plugins.sbt
+++ b/src/sbt-test/docker/sudo-docker/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/sudo-docker/src/main/scala/Main.scala
+++ b/src/sbt-test/docker/sudo-docker/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}

--- a/src/sbt-test/docker/sudo-docker/test
+++ b/src/sbt-test/docker/sudo-docker/test
@@ -1,0 +1,3 @@
+# Generate the Docker image locally
+> docker:publishLocal
+$ exec bash -c 'docker run docker-sudo-test:0.1.0 | grep -q "Hello world"'

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -74,10 +74,15 @@ Settings and Tasks inherited from parent plugins can be scoped with ``Docker``.
 Settings
 --------
 
+Invocation Settings
+-------------------
+
+  ``dockerUseSudo``
+    Prefix all docker command line invocations with 'sudo'. When building on CentOS, Fedory or RHEL, this may be necessary
+    for security purposes. See http://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/
 
 Informational Settings
 ~~~~~~~~~~~~~~~~~~~~~~
-
 
   ``packageName in Docker``
     The name of the package for Docker (if different from general name).


### PR DESCRIPTION
When building docker images on CentOS, Fedora or RHEL, the permissions on /var/run/docker.socket have restricted access, preventing Docker build and push commands from executing without severely compromising the system.

See http://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/

Therefore, I've added a new setting which supports prefixing both the Docker build and push commands with 'sudo', which is the recommended method for executing Docker on CentOS, Fedora and RHEL.