### PR TITLE
DockerAlias should have version scoped to Docker

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -78,7 +78,7 @@ object DockerPlugin extends AutoPlugin {
     dockerExposedUdpPorts := Seq(),
     dockerExposedVolumes := Seq(),
     dockerRepository := None,
-    dockerAlias := DockerAlias(dockerRepository.value, None, packageName.value, Some(version.value)),
+    dockerAlias := DockerAlias(dockerRepository.value, None, packageName.value, Some((version in Docker).value)),
     dockerUpdateLatest := false,
     dockerEntrypoint := Seq("bin/%s" format executableScriptName.value),
     dockerCmd := Seq(),


### PR DESCRIPTION
When the SBT project version follows semantic versioning, and includes build metadata (e.g. 1.0.0+abcdef1) the Docker tag and publish is broken. The most reasonable way to handle this is to modify the build.sbt to adjust the version in Docker scope.

Right now, the DockerAlias pulls the version from the project scope.

-- Modified build.sbt --
```
(version in Docker) := version.value.split('+')(0)
```
-- In SBT console --
```
[sample-server] $ show dockerAlias
[info] DockerAlias(Some(some.registry),None,aergo-server,Some(1.0.0+abcdef1))
[sample-server] $ show docker:version
[info] 1.0.0
```
-- In SBT console after fix --
```
[sample-server] $ show dockerAlias
[info] DockerAlias(Some(some.registry),None,aergo-server,Some(1.0.0))
[sample-server] $ show docker:version
[info] 1.0.0
```