### PR TITLE
Add dockerExecCommand setting

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -27,6 +27,7 @@ trait DockerKeys {
     "dockerCmd",
     "Docker CMD. Used together with dockerEntrypoint. Arguments passed in exec form"
   )
+  val dockerExecCommand = SettingKey[Seq[String]]("dockerExecCommand", "The shell command used to exec Docker")
   val dockerBuildOptions = SettingKey[Seq[String]]("dockerBuildOptions", "Options used for the Docker build")
   val dockerBuildCommand = SettingKey[Seq[String]]("dockerBuildCommand", "Command for building the Docker image")
 

--- a/src/sbt-test/docker/simple-docker/build.sbt
+++ b/src/sbt-test/docker/simple-docker/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(JavaAppPackaging)
 
-name := "docker-test"
+name := "simple-docker"
 
 version := "0.1.0"
 

--- a/src/sbt-test/docker/simple-docker/test
+++ b/src/sbt-test/docker/simple-docker/test
@@ -1,3 +1,3 @@
 # Generate the Docker image locally
 > docker:publishLocal
-$ exec bash -c 'docker run docker-test:0.1.0 | grep -q "Hello world"'
+$ exec bash -c 'docker run simple-docker:0.1.0 | grep -q "Hello world"'

--- a/src/sbt-test/docker/simple-sudo-docker/build.sbt
+++ b/src/sbt-test/docker/simple-sudo-docker/build.sbt
@@ -1,0 +1,9 @@
+enablePlugins(JavaAppPackaging)
+
+name := "simple-sudo-docker"
+
+version := "0.1.0"
+
+maintainer := "G. Richard Bellamy <rbellamy@terradatum.com>"
+
+dockerExecCommand := Seq("sudo", "docker")

--- a/src/sbt-test/docker/simple-sudo-docker/project/plugins.sbt
+++ b/src/sbt-test/docker/simple-sudo-docker/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/simple-sudo-docker/src/main/scala/Main.scala
+++ b/src/sbt-test/docker/simple-sudo-docker/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}

--- a/src/sbt-test/docker/simple-sudo-docker/test
+++ b/src/sbt-test/docker/simple-sudo-docker/test
@@ -1,0 +1,3 @@
+# Generate the Docker image locally
+> docker:publishLocal
+$ exec bash -c 'docker run simple-sudo-docker:0.1.0 | grep -q "Hello world"'

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -122,16 +122,20 @@ Publishing Settings
 
   ``dockerAlias``
     The alias to be used for tagging the resulting image of the Docker build.
-    The type of the setting key is ``DockerAlias`.
+    The type of the setting key is ``DockerAlias``.
     Defaults to ``[dockerRepository/][name]:[version]``.
 
   ``dockerBuildOptions``
     Overrides the default Docker build options.
     Defaults to ``Seq("--force-rm", "-t", "[dockerAlias]")``. This default is expanded if ``dockerUpdateLatest`` is set to true.
 
+  ``dockerExecCommand``
+    Overrides the default Docker exec command.
+    Defaults to ``Seq("docker")``
+
   ``dockerBuildCommand``
-    Overrides the default Docker build command.
-    Defaults to ``Seq("docker", "build", "[dockerBuildOptions]", ".")``.
+    Overrides the default Docker build command. The reason for this is that many systems restrict docker execution to root, and while the accepted guidance is to alias the docker command ``alias docker='/usr/bin/docker'``, neither Java nor Scala support passing aliases to sub-processes, and most build systems run builds using a non-login, non-interactive shell, which also have limited support for aliases, which means that the only viable option is to use ``sudo docker`` directly.
+    Defaults to ``Seq("[dockerExecCommand]", "build", "[dockerBuildOptions]", ".")``.
 
 Tasks
 -----


### PR DESCRIPTION
Per discussion in https://github.com/sbt/sbt-native-packager/pull/903

When building docker images on CentOS, Fedora or RHEL, the permissions on /var/run/docker.socket have restricted access, preventing Docker build and push commands as a normal user from executing without severely compromising the system.

See http://www.projectatomic.io/blog/2015/08/why-we-dont-let-non-root-users-run-docker-in-centos-fedora-or-rhel/

Therefore, I've added a new setting which supports replacing the default docker shell exec command so that I can instead use `sudo docker` (which is the recommended method for executing Docker on CentOS, Fedora and RHEL), or completely replace the `docker` command with a path to a shell script.

With this new setting and the regular `dockerBuildCommand` and `dockerBuildOptions`, you get the following basics:
```scala
dockerBuildCommand := dockerExecCommand.value ++ Seq("build") ++ dockerBuildOptions.value ++ Seq(".")
// default
dockerExecCommand := Seq("docker")
// custom
dockerExecCommand := Seq("sudo", "docker")
```

What I don't want to do is run SBT as root - this will cause the working directory, and the ivy cache to become polluted with artifacts that are owned by root. It's best to limit the use of escalated privileges to just those commands that require them to avoid this pollution.

So, to avoid:

```
sudo sbt docker:publishLocal
sbt clean <=== will fail because "target" is now owned by root
```