### PR TITLE
Change shebang in bash-forwarder-template to `#!/usr/bin/env bash`.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-forwarder-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-forwarder-template
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Absolute path to this script
 # OS X doesn't support "readlink -f"


### PR DESCRIPTION
This will make the template more portable. The regular bash-template uses the `env` version
therefore the forwarder should use it too.

This fixes #921 