### PR TITLE
Stop JavaAppPackaging from auto enabling the DockerPlugin

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaApp.scala
@@ -39,7 +39,7 @@ object JavaAppPackaging extends AutoPlugin {
   import JavaAppPackaging.autoImport._
 
   override def requires =
-    debian.DebianPlugin && rpm.RpmPlugin && docker.DockerPlugin && windows.WindowsPlugin
+    debian.DebianPlugin && rpm.RpmPlugin && windows.WindowsPlugin
 
   // format: off
   override def projectSettings = Seq(


### PR DESCRIPTION
When enabling the JavaAppPackaging, the DockerPlugin is automatically enabled.
It causes issue in our case and I don't think it makes generally sense.
It feels the user should knowlingly enable it if he needs it.
What do you think ?