### PR TITLE
Use stage  task instead of debianExplodedPackage

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianMetadata.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianMetadata.scala
@@ -1,6 +1,4 @@
-package com.typesafe.sbt
-package packager
-package debian
+package com.typesafe.sbt.packager.debian
 
 case class PackageInfo(name: String, version: String, maintainer: String, summary: String, description: String)
 
@@ -33,7 +31,7 @@ case class PackageMetaData(info: PackageInfo,
       sb append ("Conflicts: %s\n" format (conflicts mkString ", "))
     sb append ("Maintainer: %s\n" format info.maintainer)
     sb append ("Description: %s\n %s\n" format (info.summary, info.description))
-    sb toString
+    sb.toString
   }
 
   def makeSourceControl(): String = {
@@ -56,7 +54,7 @@ case class PackageMetaData(info: PackageInfo,
     if (conflicts.nonEmpty)
       sb append ("Conflicts: %s\n" format (conflicts mkString ", "))
     sb append ("Description: %s\n %s\n" format (info.summary, info.description))
-    sb toString
+    sb.toString
   }
 }
 

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -226,7 +226,8 @@ object DebianPlugin extends AutoPlugin with DebianNativePackaging {
     } yield file.length).sum / 1024
 
   private[this] def createConfFile(meta: PackageMetaData, size: Long, targetDir: File): File = {
-    if (meta.info.description == null || meta.info.description.isEmpty) {
+    val description = Option(meta.info.description).filterNot(_.isEmpty)
+    if (description.isEmpty) {
       sys.error("""packageDescription in Debian cannot be empty. Use
                  packageDescription in Debian := "My package Description"""")
     }

--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -41,6 +41,8 @@ trait DebianKeys {
     TaskKey[Seq[LinuxPackageMapping]]("debian-zipped-mappings", "Files that need to be gzipped when they hit debian.")
   val debianCombinedMappings =
     TaskKey[Seq[LinuxPackageMapping]]("debian-combined-mappings", "All the mappings of files for the final package.")
+
+  @deprecated("Use debian:stage instead", "1.2.0")
   val debianExplodedPackage = TaskKey[File]("debian-exploded-package", "makes an exploded debian package")
   val lintian = TaskKey[Unit]("lintian", "runs the debian lintian tool on the current package.")
   val debianSign = TaskKey[File]("debian-sign", "runs the dpkg-sig command to sign the generated deb file.")

--- a/src/main/scala/com/typesafe/sbt/packager/debian/NativePackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/NativePackaging.scala
@@ -1,15 +1,10 @@
-package com.typesafe.sbt
-package packager
-package debian
+package com.typesafe.sbt.packager.debian
 
+import com.typesafe.sbt.SbtNativePackager.Debian
+import com.typesafe.sbt.packager.Keys._
+import com.typesafe.sbt.packager.linux.LinuxFileMetaData
+import sbt.Keys._
 import sbt._
-import sbt.Keys.{name, packageBin, streams, target, version}
-import packager.Hashing
-import packager.archetypes.TemplateWriter
-import linux.{LinuxFileMetaData, LinuxPackageMapping, LinuxSymlink}
-import linux.LinuxPlugin.autoImport.packageArchitecture
-
-import DebianPlugin.autoImport._
 
 /**
   * == Native Packaging ==
@@ -34,9 +29,7 @@ import DebianPlugin.autoImport._
   */
 trait DebianNativePackaging extends DebianPluginLike {
 
-  import com.typesafe.sbt.packager.universal.Archives
   import DebianPlugin.Names
-  import linux.LinuxPlugin.Users
 
   /**
     * Using the native installed dpkg-build tools to build the debian
@@ -46,34 +39,12 @@ trait DebianNativePackaging extends DebianPluginLike {
     inConfig(Debian)(
       Seq(
         debianNativeBuildOptions += "-Znone", // packages are largely JARs, which are already compressed
-        genChanges <<= (packageBin, target, debianChangelog, name, version, debianPackageMetadata) map {
-          (pkg, tdir, changelog, name, version, data) =>
-            changelog match {
-              case None =>
-                sys.error("Cannot generate .changes file without a changelog")
-              case Some(chlog) => {
-                // dpkg-genchanges needs a debian "source" directory, different from the DEBIAN "binary" directory
-                val debSrc = tdir / "../tmp" / Names.DebianSource
-                debSrc.mkdirs()
-                copyAndFixPerms(chlog, debSrc / Names.Changelog, LinuxFileMetaData("0644"))
-                IO.writeLines(debSrc / Names.Files, List(pkg.getName + " " + data.section + " " + data.priority))
-                // dpkg-genchanges needs a "source" control file, located in a "debian" directory
-                IO.writeLines(debSrc / Names.Control, List(data.makeSourceControl()))
-                val changesFileName = name + "_" + version + "_" + data.architecture + ".changes"
-                val changesFile: File = tdir / ".." / changesFileName
-                try {
-                  val changes = Process(Seq("dpkg-genchanges", "-b"), Some(tdir / "../tmp")) !!
-                  val allChanges = List(changes)
-                  IO.writeLines(changesFile, allChanges)
-                } catch {
-                  case e: Exception =>
-                    sys.error("Failure generating changes file." + e.getStackTraceString)
-                }
-                changesFile
-              }
-            }
-
-        },
+        genChanges := dpgkGenChanges(
+          packageBin.value,
+          debianChangelog.value,
+          debianPackageMetadata.value,
+          target.value
+        ),
         debianSign <<= (packageBin, debianSignRole, streams) map { (deb, role, s) =>
           Process(Seq("dpkg-sig", "-s", role, deb.getAbsolutePath), Some(deb.getParentFile())) ! s.log match {
             case 0 => ()
@@ -86,31 +57,64 @@ trait DebianNativePackaging extends DebianPluginLike {
           Process(Seq("lintian", "-c", "-v", file.getName), Some(file.getParentFile)).!
         },
         /** Implementation of the actual packaging  */
-        packageBin <<= (debianExplodedPackage,
-                        debianMD5sumsFile,
-                        debianSection,
-                        debianPriority,
-                        name,
-                        version,
-                        packageArchitecture,
-                        debianNativeBuildOptions,
-                        target,
-                        streams) map { (pkgdir, _, section, priority, name, version, arch, options, tdir, s) =>
-          s.log.info("Building debian package with native implementation")
-          // Make the package.  We put this in fakeroot, so we can build the package with root owning files.
-          val archive = archiveFilename(name, version, arch)
-          Process(
-            Seq("fakeroot", "--", "dpkg-deb", "--build") ++ options ++ Seq(pkgdir.getAbsolutePath, "../" + archive),
-            Some(tdir)
-          ) ! s.log match {
-            case 0 => ()
-            case x =>
-              sys.error("Failure packaging debian file.  Exit code: " + x)
-          }
-          tdir / ".." / archive
-        }
+        packageBin := buildPackage(
+          name.value,
+          version.value,
+          packageArchitecture.value,
+          stage.value,
+          debianNativeBuildOptions.value,
+          streams.value.log
+        )
       )
     )
+
+  private[this] def dpgkGenChanges(debFile: File, changelog: Option[File], data: PackageMetaData, targetDir: File) = {
+    println(s"Changelog: $changelog")
+    changelog match {
+      case None =>
+        sys.error("Cannot generate .changes file without a changelog")
+      case Some(chlog) => {
+        // dpkg-genchanges needs a debian "source" directory, different from the DEBIAN "binary" directory
+        val debSrc = targetDir / "../tmp" / Names.DebianSource
+        debSrc.mkdirs()
+        copyAndFixPerms(chlog, debSrc / Names.Changelog, LinuxFileMetaData("0644"))
+        IO.writeLines(debSrc / Names.Files, List(debFile.getName + " " + data.section + " " + data.priority))
+        // dpkg-genchanges needs a "source" control file, located in a "debian" directory
+        IO.writeLines(debSrc / Names.Control, List(data.makeSourceControl()))
+        val changesFileName = debFile.getName.replaceAll("deb$", "changes")
+        val changesFile: File = targetDir / ".." / changesFileName
+        try {
+          val changes = Process(Seq("dpkg-genchanges", "-b"), Some(targetDir / "../tmp")).!!
+          val allChanges = List(changes)
+          IO.writeLines(changesFile, allChanges)
+        } catch {
+          case e: Exception =>
+            sys.error("Failure generating changes file." + e.getStackTraceString)
+        }
+        changesFile
+      }
+    }
+  }
+
+  private[this] def buildPackage(name: String,
+                                 version: String,
+                                 arch: String,
+                                 stageDir: File,
+                                 buildOptions: Seq[String],
+                                 log: Logger) = {
+    log.info("Building debian package with native implementation")
+    // Make the package.  We put this in fakeroot, so we can build the package with root owning files.
+    val archive = archiveFilename(name, version, arch)
+    Process(
+      Seq("fakeroot", "--", "dpkg-deb", "--build") ++ buildOptions ++ Seq(stageDir.getAbsolutePath, "../" + archive),
+      Some(stageDir)
+    ) ! log match {
+      case 0 => ()
+      case x =>
+        sys.error("Failure packaging debian file.  Exit code: " + x)
+    }
+    stageDir / ".." / archive
+  }
 
 }
 


### PR DESCRIPTION
The `DebianPlugin` now uses the `stage` task to generate a staged folder where the `dpkg` build process is executed.

- Deprecated `debianExplodePackage`
- Replaced deprecated symbolic operators
- Fixed IntelliJ warnings