### PR TITLE
Fixes issue #789 where brpJavaRepack was negated

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
+++ b/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
@@ -1,6 +1,1 @@
-%define __os_install_post \
-%{_rpmconfigdir}/brp-compress \
-%{!?__debug_package:%{_rpmconfigdir}/brp-strip %{__strip}} \
-%{_rpmconfigdir}/brp-strip-static-archive %{__strip} \
-%{_rpmconfigdir}/brp-strip-comment-note %{__strip} %{__objdump} \
-%{nil}
+%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-java-repack-jars[[:space:]].*$!!g')

--- a/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
+++ b/src/main/resources/com/typesafe/sbt/packager/rpm/brpJavaRepackJar
@@ -1,1 +1,1 @@
-%global __os_install_post %(echo '%{__os_install_post}' | sed -e 's!/usr/lib[^[:space:]]*/brp-java-repack-jars[[:space:]].*$!!g')
+%define __jar_repack %nil

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -81,7 +81,7 @@ object RpmPlugin extends AutoPlugin {
     rpmConflicts := Seq.empty,
     rpmSetarch := None,
     rpmChangelogFile := None,
-    rpmBrpJavaRepackJars := true,
+    rpmBrpJavaRepackJars := false,
     rpmPretrans := None,
     rpmPre := None,
     rpmPost := None,

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -81,7 +81,7 @@ object RpmPlugin extends AutoPlugin {
     rpmConflicts := Seq.empty,
     rpmSetarch := None,
     rpmChangelogFile := None,
-    rpmBrpJavaRepackJars := false,
+    rpmBrpJavaRepackJars := true,
     rpmPretrans := None,
     rpmPre := None,
     rpmPost := None,
@@ -121,7 +121,7 @@ object RpmPlugin extends AutoPlugin {
       (rpmProvides, rpmRequirements, rpmPrerequisites, rpmObsoletes, rpmConflicts) apply RpmDependencies,
     maintainerScripts in Rpm := {
       val scripts = (maintainerScripts in Rpm).value
-      if (rpmBrpJavaRepackJars.value) {
+      if (!rpmBrpJavaRepackJars.value) {
         val pre = scripts.getOrElse(Names.Pre, Nil)
         val scriptBits = IO.readStream(RpmPlugin.osPostInstallMacro.openStream, Charset forName "UTF-8")
         scripts + (Names.Pre -> (pre :+ scriptBits))

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
@@ -13,7 +13,7 @@ packageDescription :=
   """A fun package description of our software,
   with multiple lines."""
 
-rpmRelease := "1"
+rpmRelease := "2"
 
 rpmVendor := "typesafe"
 

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
@@ -28,7 +28,7 @@ TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
   out.log.info(spec)
   assert(
     spec contains
-      """sed -e 's!/usr/lib[^[:space:]]*/brp-java-repack-jars[[:space:]].*$!!g'""",
+      """%define __jar_repack %nil""",
     "Missing java repack disabling in %pre")
   out.log.success("Successfully tested rpm test file")
   ()

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
@@ -1,7 +1,7 @@
 
 enablePlugins(JavaServerAppPackaging)
 
-name := "rpm-test"
+name := "rpm-test-no-repack"
 
 version := "0.1.0"
 

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
@@ -24,8 +24,8 @@ rpmLicense := Some("BSD")
 rpmBrpJavaRepackJars := false
 
 TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
-  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
-  assert(spec.contains("""%define __jar_repack %nil""", "Missing java repack disabling in %pre"))
+  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test-no-repack.spec")
+  assert(spec.contains("""%define __jar_repack %nil"""), "Missing java repack disabling in %pre")
   out.log.success("Successfully tested rpm test file")
   ()
 }

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/build.sbt
@@ -1,0 +1,35 @@
+
+enablePlugins(JavaServerAppPackaging)
+
+name := "rpm-test"
+
+version := "0.1.0"
+
+maintainer := "Josh Suereth <joshua.suereth@typesafe.com>"
+
+packageSummary := "Test rpm package"
+
+packageDescription :=
+  """A fun package description of our software,
+  with multiple lines."""
+
+rpmRelease := "1"
+
+rpmVendor := "typesafe"
+
+rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
+
+rpmLicense := Some("BSD")
+
+rpmBrpJavaRepackJars := false
+
+TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
+  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
+  out.log.info(spec)
+  assert(
+    spec contains
+      """sed -e 's!/usr/lib[^[:space:]]*/brp-java-repack-jars[[:space:]].*$!!g'""",
+    "Missing java repack disabling in %pre")
+  out.log.success("Successfully tested rpm test file")
+  ()
+}

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
@@ -3,7 +3,4 @@
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test.spec
 
-# Check files for defaults
-> check-spec-file
-> set NativePackagerKeys.rpmBrpJavaRepackJars := false
 > check-spec-file

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
@@ -1,6 +1,6 @@
-# Run the debian packaging.
+# Run the RPM packaging.
 > rpm:package-bin
-$ exists target/rpm/RPMS/noarch/rpm-test-no-repack-0.1.0-1.noarch.rpm
-$ exists target/rpm/SPECS/rpm-test.spec
+$ exists target/rpm/RPMS/noarch/rpm-test-no-repack-0.1.0-2.noarch.rpm
+$ exists target/rpm/SPECS/rpm-test-no-repack.spec
 
 > check-spec-file

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
@@ -1,6 +1,6 @@
 # Run the debian packaging.
 > rpm:package-bin
-$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+$ exists target/rpm/RPMS/noarch/rpm-test-no-repack-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test.spec
 
 > check-spec-file

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/build.sbt
@@ -1,7 +1,7 @@
 
 enablePlugins(JavaServerAppPackaging)
 
-name := "rpm-test"
+name := "rpm-test-with-repack"
 
 version := "0.1.0"
 

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/build.sbt
@@ -21,11 +21,11 @@ rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
 
 rpmLicense := Some("BSD")
 
-rpmBrpJavaRepackJars := false
+rpmBrpJavaRepackJars := true
 
 TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
   val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
-  assert(spec.contains("""%define __jar_repack %nil""", "Missing java repack disabling in %pre"))
+  assert(!spec.contains("""%define __jar_repack %nil""", "%pre should not contain jar repack when set to true"))
   out.log.success("Successfully tested rpm test file")
   ()
 }

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/build.sbt
@@ -13,7 +13,7 @@ packageDescription :=
   """A fun package description of our software,
   with multiple lines."""
 
-rpmRelease := "1"
+rpmRelease := "2"
 
 rpmVendor := "typesafe"
 
@@ -24,8 +24,8 @@ rpmLicense := Some("BSD")
 rpmBrpJavaRepackJars := true
 
 TaskKey[Unit]("check-spec-file") <<= (target, streams) map { (target, out) =>
-  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test.spec")
-  assert(!spec.contains("""%define __jar_repack %nil""", "%pre should not contain jar repack when set to true"))
+  val spec = IO.read(target / "rpm" / "SPECS" / "rpm-test-with-repack.spec")
+  assert(!spec.contains("""%define __jar_repack %nil"""), "%pre should not contain jar repack when set to true")
   out.log.success("Successfully tested rpm test file")
   ()
 }

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
@@ -1,6 +1,6 @@
 # Run the debian packaging.
 > rpm:package-bin
-$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+$ exists target/rpm/RPMS/noarch/rpm-test-with-repack-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test.spec
 
 > check-spec-file

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
@@ -1,6 +1,6 @@
-# Run the debian packaging.
+# Run the RPM packaging.
 > rpm:package-bin
-$ exists target/rpm/RPMS/noarch/rpm-test-with-repack-0.1.0-1.noarch.rpm
-$ exists target/rpm/SPECS/rpm-test.spec
+$ exists target/rpm/RPMS/noarch/rpm-test-with-repack-0.1.0-2.noarch.rpm
+$ exists target/rpm/SPECS/rpm-test-with-repack.spec
 
 > check-spec-file

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
@@ -1,0 +1,6 @@
+# Run the debian packaging.
+> rpm:package-bin
+$ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
+$ exists target/rpm/SPECS/rpm-test.spec
+
+> check-spec-file

--- a/src/sbt-test/rpm/scriptlets-override-build-rpm/test
+++ b/src/sbt-test/rpm/scriptlets-override-build-rpm/test
@@ -5,5 +5,5 @@ $ exists target/rpm/SPECS/rpm-test.spec
 
 # Check files for defaults
 > check-spec-file
-> set NativePackagerKeys.rpmBrpJavaRepackJars := true
+> set NativePackagerKeys.rpmBrpJavaRepackJars := false
 > check-spec-file

--- a/src/sbt-test/rpm/scriptlets-override-rpm/test
+++ b/src/sbt-test/rpm/scriptlets-override-rpm/test
@@ -20,7 +20,7 @@ $ exists var/run/rpm-test
 # TODO symlinks aren't checked
 
 > check-spec-file
-> set NativePackagerKeys.rpmBrpJavaRepackJars := true
+> set NativePackagerKeys.rpmBrpJavaRepackJars := false
 > check-spec-file
 
 > unique-scripts-in-spec-file

--- a/src/sbt-test/rpm/scriptlets-rpm/test
+++ b/src/sbt-test/rpm/scriptlets-rpm/test
@@ -6,5 +6,5 @@ $ exists target/rpm/SPECS/rpm-test.spec
 # Check files for defaults
 > check-spec-file
 > check-rpm-version
-> set NativePackagerKeys.rpmBrpJavaRepackJars := true
+> set NativePackagerKeys.rpmBrpJavaRepackJars := false
 > check-spec-file

--- a/src/sbt-test/rpm/sysvinit-rpm/test
+++ b/src/sbt-test/rpm/sysvinit-rpm/test
@@ -23,7 +23,7 @@ $ exists var/run/rpm-test
 
 # TODO symlinks aren't checked
 
-> set NativePackagerKeys.rpmBrpJavaRepackJars := true
+> set NativePackagerKeys.rpmBrpJavaRepackJars := false
 > check-spec-file
 > check-spec-autostart
 

--- a/src/sphinx/formats/rpm.rst
+++ b/src/sphinx/formats/rpm.rst
@@ -339,12 +339,12 @@ After
 Jar Repackaging
 ~~~~~~~~~~~~~~~
 
-rpm repackages jars by default (described in this `blog post`_) in order to optimize jars.
-This behaviour is turned off by default with this setting:
+RPM repackages jars by default in order to optimize jars.
+Repacking is turned off by default. In order to enable it, set:
 
 .. code-block:: scala
 
-    rpmBrpJavaRepackJars := false
+    rpmBrpJavaRepackJars := true
 
 Note that this *appends* content to your ``Pre`` definition, so make sure not to override it.
 For more information on this topic follow these links:
@@ -353,7 +353,6 @@ For more information on this topic follow these links:
 * `pullrequest #199`_
 * `OpenSuse issue`_
 
-  .. _blog post: http://swaeku.github.io/blog/2013/08/05/how-to-disable-brp-java-repack-jars-during-rpm-build
   .. _issue #195: https://github.com/sbt/sbt-native-packager/issues/195
   .. _pullrequest #199: https://github.com/sbt/sbt-native-packager/pull/199
   .. _OpenSuse issue: https://github.com/sbt/sbt-native-packager/issues/215


### PR DESCRIPTION
Fixes #789 where the value of `rpmBrpJavaRepackJars` was required to be set to `false` in order for repacking *not* to occur.

I've done three things:

1. Created a shorter pre script which utilizes `sed` in a single liner, since there are versions which don't support multi line macros (when running the test I kept getting errors about macro having an empty body, see [this](https://www.redhat.com/archives/fedora-packaging/2005-July/msg00113.html) for more). I also changed the macro prefix from %define to %global, as that's the recommended approach by Fedora.

2. Negated the default flag from `false` to `true`. My assumption was people might not want to disable repackaging out of the box, but feel free to tell me otherwise

3. Added a test to validate that the removal of brpRepack works when the flag is set to `false`.
