### PR TITLE
Drop "in Docker" in some docker keys

### DIFF
--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -104,10 +104,10 @@ Environment Settings
   ``dockerExposedUdpPorts``
     A list of UDP ports to expose from the Docker image.
 
-  ``dockerExposedVolumes in Docker``
+  ``dockerExposedVolumes``
     A list of data volumes to make available in the Docker image.
 
-  ``dockerEntrypoint in Docker``
+  ``dockerEntrypoint``
     Overrides the default entrypoint for docker-specific service discovery tasks before running the application.
     Defaults to the bash executable script, available at ``bin/<script name>`` in the current ``WORKDIR`` of ``/opt/docker``.
 


### PR DESCRIPTION
Given how these are set by default: https://github.com/sbt/sbt-native-packager/blob/v1.2.0-M8/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala#L78-L82

and how they are tested: https://github.com/sbt/sbt-native-packager/blob/v1.2.0-M8/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala#L78-L82

I'm pretty sure the "in Docker" is wrong (i.e. won't have any effect).