### PR TITLE
Define addJava in ash-template

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -27,6 +27,17 @@ realpath () {
 )
 }
 
+# Allow user and template_declares (see below) to add java options.
+addJava () {
+  java_opts="$java_opts $1"
+}
+
+# Allow user to specify java options. These get listed first per bash-template.
+if [ -n "$JAVA_OPTS" ]
+then
+  addJava "$JAVA_OPTS"
+fi
+
 # Loads a configuration file full of default command line options for this script.
 loadConfigFile() {
   cat "$1" | sed '/^\#/d' | sed 's/^-J-X/-X/' | tr '\r\n' ' '
@@ -44,4 +55,4 @@ ${{template_declares}}
 # If a configuration file exist, read the contents to $opts
 [ -f "$script_conf_file" ] && opts=$(loadConfigFile "$script_conf_file")
 
-exec java -classpath $app_classpath $opts $app_mainclass $@
+exec java $java_opts -classpath $app_classpath $opts $app_mainclass $@

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
@@ -77,7 +77,8 @@ object AshScriptPlugin extends AutoPlugin {
 
   override def projectSettings = Seq(
     bashScriptTemplateLocation := (sourceDirectory.value / "templates" / ashTemplate),
-    bashScriptDefines := Defines((scriptClasspath in bashScriptDefines).value, bashScriptConfigLocation.value)
+    bashScriptDefines := Defines((scriptClasspath in bashScriptDefines).value, bashScriptConfigLocation.value),
+    bashScriptDefines ++= bashScriptExtraDefines.value
   )
 
   /**

--- a/src/sbt-test/ash/memory-settings/build.sbt
+++ b/src/sbt-test/ash/memory-settings/build.sbt
@@ -1,0 +1,24 @@
+enablePlugins(JavaAppPackaging, AshScriptPlugin)
+
+name := "simple-app"
+
+version := "0.1.0"
+
+bashScriptExtraDefines ++= Seq(
+  """addJava "-Xms64m"""",
+  """addJava "-Xmx64m""""
+)
+
+TaskKey[Unit]("script-check") := {
+  val startScript = (stagingDirectory in Universal).value / "bin" / executableScriptName.value
+  val options = IO.read(startScript)
+  assert(options contains """addJava "-Xms64m"""", "Script doesn't contain xmx setting:\n" + options)
+  assert(options contains """addJava "-Xmx64m"""", "Script doesn't contain xms setting:\n" + options)
+}
+
+TaskKey[Unit]("run-check") := {
+  val cwd = (stagingDirectory in Universal).value
+  val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath)
+  val memory = (Process(cmd, cwd).!!).replaceAll("\n", "")
+  assert(memory.toLong <= 64, "Runtime memory is bigger then 64m < " + memory + "m")
+}

--- a/src/sbt-test/ash/memory-settings/project/plugins.sbt
+++ b/src/sbt-test/ash/memory-settings/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/ash/memory-settings/src/main/scala/MainApp.scala
+++ b/src/sbt-test/ash/memory-settings/src/main/scala/MainApp.scala
@@ -1,0 +1,4 @@
+object MainApp extends App {
+  val memory = Runtime.getRuntime.maxMemory() / (1024L * 1024L)
+  print(memory)
+}

--- a/src/sbt-test/ash/memory-settings/test
+++ b/src/sbt-test/ash/memory-settings/test
@@ -1,0 +1,5 @@
+# Run the staging and check the script.
+> stage
+$ exists target/universal/stage/bin/simple-app
+> script-check
+> run-check


### PR DESCRIPTION
Added tests to the initial code from #942 and fixed a bug in the `bashScriptDefines`.


### Initial PR text

Previously, there was no addJava function defined in the ash-template.
This resulted in warnings when the ash script ran because template
declares expects the function to be defined.

Now, the addJava function is defined. It adds options to java_opts. As a
convenience, if JAVA_OPTS is set then it is added to java_opts. This
makes the ash script behave more like the bash script. The result is
then passed to java at the end of the script.