### PR TITLE
Fix DebianDeployPlugin not publishing deb file

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -467,5 +467,5 @@ object DebianDeployPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] =
     SettingsHelper.makeDeploymentSettings(Debian, packageBin in Debian, "deb") ++
-      SettingsHelper.makeDeploymentSettings(Debian, genChanges in Debian, "changes")
+      SettingsHelper.addPackage(Debian, genChanges in Debian, "changes")
 }


### PR DESCRIPTION
Fixes #587

By calling `SettingsHelper.makeDeploymentSettings` twice DebianDeployPlugin only adds "changes" file, but not the "deb" file to the list of artifacts.