### PR TITLE
Add docker:clean task

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -31,6 +31,8 @@ trait DockerKeys {
   val dockerBuildOptions = SettingKey[Seq[String]]("dockerBuildOptions", "Options used for the Docker build")
   val dockerBuildCommand = SettingKey[Seq[String]]("dockerBuildCommand", "Command for building the Docker image")
   val dockerLabels = SettingKey[Map[String, String]]("dockerLabels", "Labels applied to the Docker image")
+  val dockerRmiCommand =
+    SettingKey[Seq[String]]("dockerRmiCommand", "Command for removing the Docker image from the local registry")
 
   val dockerCommands = TaskKey[Seq[CmdLike]]("dockerCommands", "List of docker commands that form the Dockerfile")
 }

--- a/src/sbt-test/docker/rmi/build.sbt
+++ b/src/sbt-test/docker/rmi/build.sbt
@@ -1,0 +1,8 @@
+enablePlugins(DockerPlugin)
+enablePlugins(JavaAppPackaging)
+
+name := "rmi"
+
+version := "0.1.0"
+
+maintainer := "Tim Steinbach <steinbach.tim@gmail.com>"

--- a/src/sbt-test/docker/rmi/project/plugins.sbt
+++ b/src/sbt-test/docker/rmi/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/rmi/src/main/scala/Main.scala
+++ b/src/sbt-test/docker/rmi/src/main/scala/Main.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("Hello world")
+}

--- a/src/sbt-test/docker/rmi/test
+++ b/src/sbt-test/docker/rmi/test
@@ -1,0 +1,5 @@
+# Generate the Docker image locally
+> docker:publishLocal
+$ exec bash -c 'docker images | grep rmi'
+> docker:clean
+$ exec bash -c '[[ $(docker images) != *"rmi"* ]]'

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -140,6 +140,10 @@ Publishing Settings
     Overrides the default Docker build command. The reason for this is that many systems restrict docker execution to root, and while the accepted guidance is to alias the docker command ``alias docker='/usr/bin/docker'``, neither Java nor Scala support passing aliases to sub-processes, and most build systems run builds using a non-login, non-interactive shell, which also have limited support for aliases, which means that the only viable option is to use ``sudo docker`` directly.
     Defaults to ``Seq("[dockerExecCommand]", "build", "[dockerBuildOptions]", ".")``.
 
+  ``dockerRmiCommand``
+    Overrides the default Docker rmi command. This may be used if force flags or other options need to be passed to the command ``docker rmi``.
+    Defaults to ``Seq("[dockerExecCommand]", "rmi")`` and will be directly appended with the image name and tag.
+
 Tasks
 -----
 The Docker plugin provides the following commands:
@@ -152,6 +156,9 @@ The Docker plugin provides the following commands:
 
   ``docker:publish``
     Builds an image using the local Docker server, and pushes it to the configured remote repository.
+
+  ``docker:clean``
+    Removes the built image from the local Docker server.
 
 
 Customize


### PR DESCRIPTION
This task will call `docker rmi` by default.
The command can be controlled using the dockerRmiCommand key.

Fixes #501 

- Added a test that tests for the images' existence before and after
- Reused `clean` as it is familiar
- Command override provided as key
- Documentation