### PR TITLE
Improve comments in etc-default files

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-systemd-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-systemd-template
@@ -2,6 +2,10 @@
 # ##### Environment Configuration #####
 # #####################################
 
+# To use your own template create
+#   src/templates/etc-default-systemv
+# see http://www.scala-sbt.org/sbt-native-packager/archetypes/cheatsheet.html#server-app-config-src-templates-etc-default-systemv-systemd
+
 # This file is parsed by systemd. You can modify it to specify environment
 # variables for your application.
 #
@@ -9,16 +13,21 @@
 # `EnvironmentFile`.
 
 # Available replacements
-# ------------------------------------------------
-# ${{author}}           debian author
-# ${{descr}}            debian package description
-# ${{exec}}             startup script name
-# ${{chdir}}            app directory
-# ${{retries}}          retries for startup
-# ${{retryTimeout}}     retry timeout
-# ${{app_name}}         normalized app name
-# ${{daemon_user}}      daemon user
-# -------------------------------------------------
+# see http://www.scala-sbt.org/sbt-native-packager/archetypes/systemloaders.html#override-start-script
+# --------------------------------------------------------------------
+# Name                   Contains                     Current value
+# (remove space)
+# $ {{author}}           debian author                ${{author}}
+# $ {{descr}}            debian package description   ${{descr}}
+# $ {{exec}}             startup script name          ${{exec}}
+# $ {{chdir}}            app directory                ${{chdir}}
+# $ {{retries}}          retries for startup          ${{retries}}
+# $ {{retryTimeout}}     retry timeout                ${{retryTimeout}}
+# $ {{app_name}}         normalized app name          ${{app_name}}
+# $ {{app_main_class}}   main class/entry point       ${{app_main_class}}
+# $ {{daemon_user}}      daemon user                  ${{daemon_user}}
+# $ {{daemon_group}}     daemon group                 ${{daemon_group}}
+# --------------------------------------------------------------------
 
 # Setting JAVA_OPTS
 # -----------------

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/etc-default-template
@@ -2,21 +2,30 @@
 # ##### Environment Configuration #####
 # #####################################
 
+# To use your own template create
+#   src/templates/etc-default-systemv
+# see http://www.scala-sbt.org/sbt-native-packager/archetypes/cheatsheet.html#server-app-config-src-templates-etc-default-systemv-systemd
+
 # This file gets sourced before the actual startscript
 # gets executed. You can use this file to provide
 # environment variables
 
-# Available replacements 
-# ------------------------------------------------
-# ${{author}}           debian author
-# ${{descr}}            debian package description
-# ${{exec}}             startup script name
-# ${{chdir}}            app directory
-# ${{retries}}          retries for startup
-# ${{retryTimeout}}     retry timeout
-# ${{app_name}}         normalized app name
-# ${{daemon_user}}      daemon user
-# -------------------------------------------------
+# Available replacements
+# see http://www.scala-sbt.org/sbt-native-packager/archetypes/systemloaders.html#override-start-script
+# --------------------------------------------------------------------
+# Name                   Contains                     Current value
+# (remove space)
+# $ {{author}}           debian author                ${{author}}
+# $ {{descr}}            debian package description   ${{descr}}
+# $ {{exec}}             startup script name          ${{exec}}
+# $ {{chdir}}            app directory                ${{chdir}}
+# $ {{retries}}          retries for startup          ${{retries}}
+# $ {{retryTimeout}}     retry timeout                ${{retryTimeout}}
+# $ {{app_name}}         normalized app name          ${{app_name}}
+# $ {{app_main_class}}   main class/entry point       ${{app_main_class}}
+# $ {{daemon_user}}      daemon user                  ${{daemon_user}}
+# $ {{daemon_group}}     daemon group                 ${{daemon_group}}
+# --------------------------------------------------------------------
 
 # Setting JAVA_OPTS
 # -----------------


### PR DESCRIPTION
It took me a while to find out how to configure my service startup.
I propose to
* Add extra space so that variables meant as documentation don't get replaced
* Add links into documentation