### PR TITLE
Prevent empty double quotes in start daemon line.

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemv/start-debian-template
@@ -48,9 +48,9 @@ start_daemon() {
     fi
 
     if [ "$create_pidfile" = true ]; then
-        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS "$stdout_redirect"
+        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS ${stdout_redirect}
     else
-        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS "$stdout_redirect"
+        start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS ${stdout_redirect}
     fi
     log_end_msg $?
 }

--- a/src/sbt-test/debian/sysvinit-deb/build.sbt
+++ b/src/sbt-test/debian/sysvinit-deb/build.sbt
@@ -49,7 +49,7 @@ TaskKey[Unit]("check-startup-script") <<= (target, streams) map { (target, out) 
   )
   assert(
     script.contains(
-      """start-stop-daemon --background --chdir /usr/share/debian-test --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS "$stdout_redirect"""
+      """start-stop-daemon --background --chdir /usr/share/debian-test --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS ${stdout_redirect}"""
     ),
     "script has wrong startup line\n" + script
   )


### PR DESCRIPTION
The removal of the quotes should fix this if no `stdout_redirect` is set. Also the file had mixed indenting of 2 and 4 spaces, therefore I adjusted it to 2 spaces.

This should fix #955 . Travis is green on our fork: https://travis-ci.org/wegtam/sbt-native-packager/branches .