### PR TITLE
Add Setting for Docker User

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -79,9 +79,10 @@ object DockerPlugin extends AutoPlugin {
       dockerExposedVolumes := Seq(),
       dockerLabels := Map(),
       dockerRepository := None,
+      dockerUsername := None,
       dockerAlias := DockerAlias(
         dockerRepository.value,
-        None,
+        dockerUsername.value,
         (packageName in Docker).value,
         Some((version in Docker).value)
       ),

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -18,6 +18,7 @@ trait DockerKeys {
   val dockerExposedUdpPorts = SettingKey[Seq[Int]]("dockerExposedUdpPorts", "UDP Ports exposed by Docker image")
   val dockerExposedVolumes = SettingKey[Seq[String]]("dockerExposedVolumes", "Volumes exposed by Docker image")
   val dockerRepository = SettingKey[Option[String]]("dockerRepository", "Repository for published Docker image")
+  val dockerUsername = SettingKey[Option[String]]("dockerUsername", "Username for published Docker image")
   val dockerAlias =
     SettingKey[DockerAlias]("dockerAlias", "Docker alias for the built image")
   val dockerUpdateLatest =

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -118,7 +118,10 @@ Publishing Settings
 ~~~~~~~~~~~~~~~~~~~
 
   ``dockerRepository``
-    The repository to which the image is pushed when the ``docker:publish`` task is run. This should be of the form ``[username]`` (assumes use of the ``index.docker.io`` repository) or ``[repository.host]/[username]``.
+    The repository to which the image is pushed when the ``docker:publish`` task is run. This should be of the form  ``[repository.host[:repository.port]]`` (assumes use of the ``index.docker.io`` repository) or ``[repository.host[:repository.port]][/username]`` (discouraged, but available for backwards compatibilty.).
+
+  ``dockerUsername``
+    The username or orgranization to which the image is pushed when the ``docker:publish`` task is run. This should be of the form ``[username]`` or ``[organization]``.
 
   ``dockerUpdateLatest``
     The flag to automatic update the latest tag when the ``docker:publish`` task is run. Default value is ``FALSE``.  In order to use this setting, the minimum docker console version required is 1.10. See https://github.com/sbt/sbt-native-packager/issues/871 for a detailed explanation.
@@ -126,7 +129,7 @@ Publishing Settings
   ``dockerAlias``
     The alias to be used for tagging the resulting image of the Docker build.
     The type of the setting key is ``DockerAlias``.
-    Defaults to ``[dockerRepository/][name]:[version]``.
+    Defaults to ``[dockerRepository/][dockerUsername/][packageName]:[version]``.
 
   ``dockerBuildOptions``
     Overrides the default Docker build options.


### PR DESCRIPTION
Currently, there is no way to set the organizaiton or user for a docker
image. The documented practice is to misuse the dockerRepository setting
to set the username or organization. However, there is already
functionality in place for the DockerAlias class to support a separate
username.

This commit adds a dockerUsername setting which ties into the existing
DockerAlias username functionality.