### PR TITLE
FIX #981 Documentation incorrect -- Docker v1.10 or higher required

### DIFF
--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -16,7 +16,7 @@ sbt-native-packager focuses on creating a Docker image which can "just run" the 
 Requirements
 ------------
 
-You need the version 1.3 or higher of the docker console client installed.
+You need the version 1.10 or higher of the docker console client installed.
 SBT Native Packager doesn't use the REST API, but instead uses the CLI directly.
 
 It is currently not possible to provide authentication for Docker repositories from within the build.


### PR DESCRIPTION
Requiring docker 1.10 or higher.