### PR TITLE
Allow specifying classifier for default package in deployment settings

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/SettingsHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/SettingsHelper.scala
@@ -25,7 +25,10 @@ object SettingsHelper {
       )
     )
 
-  def makeDeploymentSettings(config: Configuration, packageTask: TaskKey[File], extension: String): Seq[Setting[_]] =
+  def makeDeploymentSettings(config: Configuration,
+                             packageTask: TaskKey[File],
+                             extension: String,
+                             classifier: Option[String] = None): Seq[Setting[_]] =
     inConfig(config)(Classpaths.publishSettings) ++ inConfig(config)(
       Seq(
         artifacts := Seq.empty,
@@ -55,5 +58,5 @@ object SettingsHelper {
           overwrite = isSnapshot.value
         )
       )
-    ) ++ addPackage(config, packageTask, extension)
+    ) ++ addPackage(config, packageTask, extension, classifier)
 }


### PR DESCRIPTION
Hi there

This PR introduce the ability to provide an artifact classifier for default packages when calling `makeDeploymentSettings`. 

We need this feature in our build process and I see no other workaround that to produce second artifacts with `addPackage` call.

