### PR TITLE
Fix a bug which cause upgrade failing because of no restartService

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemloaderPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemloaderPlugin.scala
@@ -121,6 +121,7 @@ object SystemloaderPlugin extends AutoPlugin {
                                  |fi
                                  |""".stripMargin,
           RpmConstants.Postun -> s"""|# ${getOrUnsupported(serverLoading.value)} support
+                                   |$${{loader-functions}}
                                    |if [ $$1 -ge 1 ] ;
                                    |then
                                    |  restartService $${{app_name}} || echo "Failed to try-restart $${{app_name}}"


### PR DESCRIPTION
I got the following error when upgrading:
```
/var/tmp/rpm-tmp.zpTtMD: line 4: restartService: command not found
```
