### PR TITLE
Wrap docker labels with " character

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -169,7 +169,7 @@ object DockerPlugin extends AutoPlugin {
     */
   private final def makeLabel(label: (String, String)): CmdLike = {
     val (variable, value) = label
-    Cmd("LABEL", s"$variable=\"${value.toString}\"")
+    Cmd("LABEL", variable + "=\"" + value.toString + "\"")
   }
 
   /**

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -167,13 +167,9 @@ object DockerPlugin extends AutoPlugin {
     * @param label
     * @return LABEL command
     */
-  private final def makeLabel(label: (String, Any)): CmdLike = {
+  private final def makeLabel(label: (String, String)): CmdLike = {
     val (variable, value) = label
-    val valueString = value match {
-      case n: Number => n.toString
-      case _ => "\"" + value.toString + "\""
-    }
-    Cmd("LABEL", s"$variable=$valueString")
+    Cmd("LABEL", s"$variable=\"${value.toString}\"")
   }
 
   /**

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -167,9 +167,13 @@ object DockerPlugin extends AutoPlugin {
     * @param label
     * @return LABEL command
     */
-  private final def makeLabel(label: Tuple2[String, String]): CmdLike = {
+  private final def makeLabel(label: (String, Any)): CmdLike = {
     val (variable, value) = label
-    Cmd("LABEL", s"${variable}=${value}")
+    val valueString = value match {
+      case n: Number => n.toString
+      case _ => "\"" + value.toString + "\""
+    }
+    Cmd("LABEL", s"$variable=$valueString")
   }
 
   /**

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -31,7 +31,7 @@ trait DockerKeys {
   val dockerExecCommand = SettingKey[Seq[String]]("dockerExecCommand", "The shell command used to exec Docker")
   val dockerBuildOptions = SettingKey[Seq[String]]("dockerBuildOptions", "Options used for the Docker build")
   val dockerBuildCommand = SettingKey[Seq[String]]("dockerBuildCommand", "Command for building the Docker image")
-  val dockerLabels = SettingKey[Map[String, String]]("dockerLabels", "Labels applied to the Docker image")
+  val dockerLabels = SettingKey[Map[String, Any]]("dockerLabels", "Labels applied to the Docker image")
   val dockerRmiCommand =
     SettingKey[Seq[String]]("dockerRmiCommand", "Command for removing the Docker image from the local registry")
 

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -31,7 +31,7 @@ trait DockerKeys {
   val dockerExecCommand = SettingKey[Seq[String]]("dockerExecCommand", "The shell command used to exec Docker")
   val dockerBuildOptions = SettingKey[Seq[String]]("dockerBuildOptions", "Options used for the Docker build")
   val dockerBuildCommand = SettingKey[Seq[String]]("dockerBuildCommand", "Command for building the Docker image")
-  val dockerLabels = SettingKey[Map[String, Any]]("dockerLabels", "Labels applied to the Docker image")
+  val dockerLabels = SettingKey[Map[String, String]]("dockerLabels", "Labels applied to the Docker image")
   val dockerRmiCommand =
     SettingKey[Seq[String]]("dockerRmiCommand", "Command for removing the Docker image from the local registry")
 

--- a/src/sbt-test/docker/labels/build.sbt
+++ b/src/sbt-test/docker/labels/build.sbt
@@ -4,4 +4,4 @@ name := "simple-test"
 
 version := "0.1.0"
 
-dockerLabels := Map("foo" -> "bar", "Hello" -> "World")
+dockerLabels := Map("foo" -> "foo", "fooBar" -> "foo bar", "number" -> 123)

--- a/src/sbt-test/docker/labels/build.sbt
+++ b/src/sbt-test/docker/labels/build.sbt
@@ -4,4 +4,4 @@ name := "simple-test"
 
 version := "0.1.0"
 
-dockerLabels := Map("foo" -> "foo", "fooBar" -> "foo bar", "number" -> 123)
+dockerLabels := Map("foo" -> "foo", "fooBar" -> "foo bar", "number" -> "123")

--- a/src/sbt-test/docker/labels/test
+++ b/src/sbt-test/docker/labels/test
@@ -1,4 +1,5 @@
 # Stage the distribution and ensure files show up.
 > docker:stage
-$ exec grep -q -F 'LABEL foo=bar' target/docker/Dockerfile
-$ exec grep -q -F 'LABEL Hello=World' target/docker/Dockerfile
+$ exec grep -q -F 'LABEL foo="bar"' target/docker/Dockerfile
+$ exec grep -q -F 'LABEL fooBar="foo bar"' target/docker/Dockerfile
+$ exec grep -q -F 'LABEL number=123' target/docker/Dockerfile

--- a/src/sbt-test/docker/labels/test
+++ b/src/sbt-test/docker/labels/test
@@ -2,4 +2,4 @@
 > docker:stage
 $ exec grep -q -F 'LABEL foo="bar"' target/docker/Dockerfile
 $ exec grep -q -F 'LABEL fooBar="foo bar"' target/docker/Dockerfile
-$ exec grep -q -F 'LABEL number=123' target/docker/Dockerfile
+$ exec grep -q -F 'LABEL number="123"' target/docker/Dockerfile


### PR DESCRIPTION
## Issue
For now, `dockerLabels` doesn't generate labels with wrapping `"` character.
- build.sbt
```sbt
dockerLabels := Map("foo" -> "bar")
```
- Generated Dockerfile
```Dockerfile
LABEL foo=bar
```

This may have issue with string values with spaces
- build.sbt
```sbt
dockerLabels := Map("fooBar" -> "foo bar")
```
- Generated Dockerfile
```Dockerfile
LABEL fooBar=foo bar
```

## Fix
Fixed that to wrap with `"` character.
- build.sbt
```sbt
dockerLabels := Map("fooBar" -> "foo bar", "number" -> 123)
```
- Generated Dockerfile
```Dockerfile
LABEL fooBar="foo bar"
LABEL number=123
```
Also, `dockerLabels` will accept map containing any type of value and make them string automatically(for convenience).
Only `Number` typed values won't be wrapped with `"` character

- [Docker doc reference](https://docs.docker.com/engine/reference/builder/#label)