### PR TITLE
fix packageZipTarball defaults for UniversalDocs and UniversalSource

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
@@ -86,9 +86,9 @@ object UniversalPlugin extends AutoPlugin {
   private[this] def defaultUniversalArchiveOptions: Seq[Setting[_]] = Seq(
     universalArchiveOptions in (Universal, packageZipTarball) := Seq("-pcvf"),
     universalArchiveOptions in (Universal, packageXzTarball) := Seq("-pcvf"),
+    universalArchiveOptions in (UniversalDocs, packageZipTarball) := Seq("-pcvf"),
     universalArchiveOptions in (UniversalDocs, packageXzTarball) := Seq("-pcvf"),
-    universalArchiveOptions in (UniversalDocs, packageXzTarball) := Seq("-pcvf"),
-    universalArchiveOptions in (UniversalSrc, packageXzTarball) := Seq("-pcvf"),
+    universalArchiveOptions in (UniversalSrc, packageZipTarball) := Seq("-pcvf"),
     universalArchiveOptions in (UniversalSrc, packageXzTarball) := Seq("-pcvf")
   )
 


### PR DESCRIPTION
The implementation clearly fell short of the intention.

fixes #1019