### PR TITLE
Change startup script name generation

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -109,7 +109,7 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
     ScriptUtils.createScriptNames(discoveredMainClasses).map {
       case (qualifiedClassName, scriptName) =>
         val bashConfig = config.copy(executableScriptName = scriptName)
-      MainScript(qualifiedClassName, bashConfig, targetDir, discoveredMainClasses) -> s"$scriptTargetFolder/${bashConfig.executableScriptName}"
+        MainScript(qualifiedClassName, bashConfig, targetDir, discoveredMainClasses) -> s"$scriptTargetFolder/${bashConfig.executableScriptName}"
     }
 
   /**

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -35,7 +35,7 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
   override protected[this] val scriptSuffix: String = ""
   override protected[this] val eol: String = "\n"
   override protected[this] val keySurround: String => String = TemplateWriter.bashFriendlyKeySurround
-  override protected[this] val makeScriptsExecutable: Boolean = true
+  override protected[this] val executableBitValue: Boolean = true
 
   override val requires = JavaAppPackaging
   override val trigger = AllRequirements

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
@@ -36,7 +36,7 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with
   override protected[this] val scriptSuffix = ".bat"
   override protected[this] val eol: String = "\r\n"
   override protected[this] val keySurround: String => String = TemplateWriter.batFriendlyKeySurround
-  override protected[this] val makeScriptsExecutable: Boolean = false
+  override protected[this] val executableBitValue: Boolean = false
 
   override val requires = JavaAppPackaging
   override val trigger = AllRequirements

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
@@ -201,7 +201,8 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
 
           val replacements = Seq("startScript" -> executableScriptName, "qualifiedClassName" -> qualifiedClassName)
           val scriptContent =
-            TemplateWriter.generateScript(forwarderTemplate, replacements, "\r\n", TemplateWriter.batFriendlyKeySurround)
+            TemplateWriter
+              .generateScript(forwarderTemplate, replacements, "\r\n", TemplateWriter.batFriendlyKeySurround)
 
           IO.write(file, scriptContent)
           file -> s"bin/$scriptName"

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
@@ -1,7 +1,6 @@
 package com.typesafe.sbt.packager.archetypes.scripts
 
 import java.io.File
-import java.net.URL
 
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys._
@@ -17,7 +16,7 @@ import sbt._
   * [[com.typesafe.sbt.packager.archetypes.JavaAppPackaging]].
   *
   */
-object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
+object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with CommonStartScriptGenerator {
 
   /**
     * Name of the bat template if user wants to provide custom one
@@ -27,19 +26,17 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
   /**
     * Name of the bat forwarder template if user wants to provide custom one
     */
-  val batForwarderTemplate = "bat-forwarder-template"
-
-  /**
-    * Script destination in final package
-    */
-  val scriptTargetFolder = "bin"
+  override protected[this] val forwarderTemplateName = "bat-forwarder-template"
 
   /**
     * Location for the application.ini file used by the bat script to load initialization parameters for jvm and app
     */
   val appIniLocation = "%APP_HOME%\\conf\\application.ini"
 
-  val scriptSuffix = ".bat"
+  override protected[this] val scriptSuffix = ".bat"
+  override protected[this] val eol: String = "\r\n"
+  override protected[this] val keySurround: String => String = TemplateWriter.batFriendlyKeySurround
+  override protected[this] val makeScriptsExecutable: Boolean = false
 
   override val requires = JavaAppPackaging
   override val trigger = AllRequirements
@@ -47,12 +44,17 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
   object autoImport extends BatStartScriptKeys
   import autoImport._
 
-  private[this] case class BatScriptConfig(executableScriptName: String,
-                                           scriptClasspath: Seq[String],
-                                           configLocation: Option[String],
-                                           extraDefines: Seq[String],
-                                           replacements: Seq[(String, String)],
-                                           batScriptTemplateLocation: File)
+  protected[this] case class BatScriptConfig(override val executableScriptName: String,
+                                             override val scriptClasspath: Seq[String],
+                                             configLocation: Option[String],
+                                             extraDefines: Seq[String],
+                                             override val replacements: Seq[(String, String)],
+                                             override val templateLocation: File)
+      extends ScriptConfig {
+    override def withScriptName(scriptName: String): BatScriptConfig = copy(executableScriptName = scriptName)
+  }
+
+  override protected[this] type SpecializedScriptConfig = BatScriptConfig
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     batScriptTemplateLocation := (sourceDirectory.value / "templates" / batTemplate),
@@ -69,12 +71,12 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
     ),
     makeBatScripts := generateStartScripts(
       BatScriptConfig(
-        executableScriptName = s"${executableScriptName.value}.bat",
+        executableScriptName = executableScriptName.value,
         scriptClasspath = (scriptClasspath in batScriptReplacements).value,
         configLocation = batScriptConfigLocation.value,
         extraDefines = batScriptExtraDefines.value,
         replacements = batScriptReplacements.value,
-        batScriptTemplateLocation = batScriptTemplateLocation.value
+        templateLocation = batScriptTemplateLocation.value
       ),
       (mainClass in (Compile, batScriptReplacements)).value,
       (discoveredMainClasses in Compile).value,
@@ -83,33 +85,6 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
     ),
     mappings in Universal ++= makeBatScripts.value
   )
-
-  private[this] def generateStartScripts(config: BatScriptConfig,
-                                         mainClass: Option[String],
-                                         discoveredMainClasses: Seq[String],
-                                         targetDir: File,
-                                         log: Logger): Seq[(File, String)] =
-    StartScriptMainClassConfig.from(mainClass, discoveredMainClasses) match {
-      case NoMain =>
-        log.warn("You have no main class in your project. No start script will be generated.")
-        Seq.empty
-      case SingleMain(main) =>
-        Seq(MainScript(main, config, targetDir) -> s"$scriptTargetFolder/${config.executableScriptName}")
-      case MultipleMains(mains) =>
-        generateMainScripts(discoveredMainClasses, config, targetDir)
-      case ExplicitMainWithAdditional(main, additional) =>
-        (MainScript(main, config, targetDir) -> s"$scriptTargetFolder/${config.executableScriptName}") +:
-          ForwarderScripts(config.executableScriptName, additional, targetDir)
-    }
-
-  private[this] def generateMainScripts(discoveredMainClasses: Seq[String],
-                                        config: BatScriptConfig,
-                                        targetDir: File): Seq[(File, String)] =
-    ScriptUtils.createScriptNames(discoveredMainClasses).map {
-      case (qualifiedClassName, scriptName) =>
-        val batConfig = config.copy(executableScriptName = scriptName + scriptSuffix)
-        MainScript(qualifiedClassName, batConfig, targetDir) -> s"$scriptTargetFolder/${batConfig.executableScriptName}"
-    }
 
   /**
     * @param path that could be relative to APP_HOME
@@ -165,49 +140,11 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
       }
   }
 
-  object MainScript {
+  override protected[this] def createReplacementsForMainScript(
+    mainClass: String,
+    mainClasses: Seq[String],
+    config: SpecializedScriptConfig
+  ): Seq[(String, String)] =
+    config.replacements :+ Replacements.appDefines(mainClass, config, config.replacements)
 
-    /**
-      *
-      * @param mainClass - Main class added to the java command
-      * @param config - Config data for this script
-      * @param targetDir - Target directory for this script
-      * @return File pointing to the created main script
-      */
-    def apply(mainClass: String, config: BatScriptConfig, targetDir: File): File = {
-      val template = resolveTemplate(config.batScriptTemplateLocation)
-      val replacements = config.replacements :+ Replacements.appDefines(mainClass, config, config.replacements)
-      val scriptContent =
-        TemplateWriter.generateScript(template, replacements, "\r\n", TemplateWriter.batFriendlyKeySurround)
-      val script = targetDir / "scripts" / config.executableScriptName
-      IO.write(script, scriptContent)
-      script
-    }
-
-    private[this] def resolveTemplate(defaultTemplateLocation: File): URL =
-      if (defaultTemplateLocation.exists) defaultTemplateLocation.toURI.toURL
-      else getClass.getResource(defaultTemplateLocation.getName)
-
-  }
-
-  object ForwarderScripts {
-    def apply(executableScriptName: String, discoveredMainClasses: Seq[String], targetDir: File): Seq[(File, String)] = {
-      val tmp = targetDir / "scripts"
-      val forwarderTemplate = getClass.getResource(batForwarderTemplate)
-      ScriptUtils.createScriptNames(discoveredMainClasses).map {
-        case (qualifiedClassName, scriptNameWithoutSuffix) =>
-          val scriptName = scriptNameWithoutSuffix + scriptSuffix
-          val file = tmp / scriptName
-
-          val replacements = Seq("startScript" -> executableScriptName, "qualifiedClassName" -> qualifiedClassName)
-          val scriptContent =
-            TemplateWriter
-              .generateScript(forwarderTemplate, replacements, "\r\n", TemplateWriter.batFriendlyKeySurround)
-
-          IO.write(file, scriptContent)
-          file -> s"bin/$scriptName"
-      }
-    }
-
-  }
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
@@ -33,7 +33,11 @@ trait CommonStartScriptGenerator {
     */
   protected[this] val keySurround: String => String
 
-  protected[this] val makeScriptsExecutable: Boolean
+  /**
+    * Set executable bit of the generated scripts to this value
+    * @todo Does it work when building archives on hosts that do not support such permission?
+    */
+  protected[this] val executableBitValue: Boolean
 
   protected[this] def createReplacementsForMainScript(mainClass: String,
                                                       mainClasses: Seq[String],
@@ -48,6 +52,11 @@ trait CommonStartScriptGenerator {
     def withScriptName(scriptName: String): SpecializedScriptConfig
   }
 
+  /**
+    * The type of specialized ScriptConfig.
+    * This enables callback methods of the concrete plugin implementations
+    * to use fields of config that only exist in their ScriptConfig specialization.
+    */
   protected[this] type SpecializedScriptConfig <: ScriptConfig
 
   protected[this] def generateStartScripts(config: SpecializedScriptConfig,
@@ -100,10 +109,10 @@ trait CommonStartScriptGenerator {
     val scriptContent = TemplateWriter.generateScript(template, replacements, eol, keySurround)
     val scriptNameWithSuffix = mainScriptName(config)
     val script = targetDir / scriptTargetFolder / scriptNameWithSuffix
+
     IO.write(script, scriptContent)
     // TODO - Better control over this!
-    if (makeScriptsExecutable)
-      script.setExecutable(true)
+    script.setExecutable(executableBitValue)
     script -> s"$scriptTargetFolder/$scriptNameWithSuffix"
   }
 
@@ -129,8 +138,7 @@ trait CommonStartScriptGenerator {
         val scriptContent = TemplateWriter.generateScript(forwarderTemplate, replacements, eol, keySurround)
 
         IO.write(file, scriptContent)
-        if (makeScriptsExecutable)
-          file.setExecutable(true)
+        file.setExecutable(executableBitValue)
         file -> s"$scriptTargetFolder/$scriptName"
     }
   }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
@@ -1,0 +1,126 @@
+package com.typesafe.sbt.packager.archetypes.scripts
+
+import java.io.File
+import java.net.URL
+
+import com.typesafe.sbt.packager.archetypes.TemplateWriter
+import sbt._
+
+trait CommonStartScriptGenerator {
+
+  /**
+    * Script destination in final package
+    */
+  protected[this] val scriptTargetFolder: String = "bin"
+
+  /**
+    * Suffix to append to the generated script name (such as ".bat")
+    */
+  protected[this] val scriptSuffix: String
+
+  /**
+    * Name of the forwarder template if user wants to provide custom one
+    */
+  protected[this] val forwarderTemplateName: String
+
+  /**
+    * Line separator for generated scripts
+    */
+  protected[this] val eol: String
+
+  /**
+    * keySurround for TemplateWriter.generateScript()
+    */
+  protected[this] val keySurround: String => String
+
+  protected[this] val makeScriptsExecutable: Boolean
+
+  protected[this] def createReplacementsForMainScript(mainClass: String,
+                                                      mainClasses: Seq[String],
+                                                      config: SpecializedScriptConfig): Seq[(String, String)]
+
+  protected[this] trait ScriptConfig {
+    val executableScriptName: String
+    val scriptClasspath: Seq[String]
+    val replacements: Seq[(String, String)]
+    val templateLocation: File
+
+    def withScriptName(scriptName: String): SpecializedScriptConfig
+  }
+
+  protected[this] type SpecializedScriptConfig <: ScriptConfig
+
+  protected[this] def generateStartScripts(config: SpecializedScriptConfig,
+                                           mainClass: Option[String],
+                                           discoveredMainClasses: Seq[String],
+                                           targetDir: File,
+                                           log: sbt.Logger): Seq[(File, String)] =
+    StartScriptMainClassConfig.from(mainClass, discoveredMainClasses) match {
+      case NoMain =>
+        log.warn("You have no main class in your project. No start script will be generated.")
+        Seq.empty
+      case SingleMain(main) =>
+        Seq(createMainScript(main, config, targetDir, Seq(main)))
+      case MultipleMains(mains) =>
+        generateMainScripts(mains, config, targetDir)
+      case ExplicitMainWithAdditional(main, additional) =>
+        createMainScript(main, config, targetDir, discoveredMainClasses) +:
+          createForwarderScripts(config.executableScriptName, additional, targetDir)
+    }
+
+  private[this] def generateMainScripts(discoveredMainClasses: Seq[String],
+                                        config: SpecializedScriptConfig,
+                                        targetDir: File): Seq[(File, String)] =
+    ScriptUtils.createScriptNames(discoveredMainClasses).map {
+      case (qualifiedClassName, scriptName) =>
+        val newConfig = config.withScriptName(scriptName)
+        createMainScript(qualifiedClassName, newConfig, targetDir, discoveredMainClasses)
+    }
+
+  /**
+    *
+    * @param mainClass - Main class added to the java command
+    * @param config - Config data for this script
+    * @param targetDir - Target directory for this script
+    * @return File pointing to the created main script
+    */
+  private[this] def createMainScript(mainClass: String,
+                                     config: SpecializedScriptConfig,
+                                     targetDir: File,
+                                     mainClasses: Seq[String]): (File, String) = {
+    val template = resolveTemplate(config.templateLocation)
+    val replacements = createReplacementsForMainScript(mainClass, mainClasses, config)
+    val scriptContent = TemplateWriter.generateScript(template, replacements, eol, keySurround)
+    val scriptNameWithSuffix = config.executableScriptName + scriptSuffix
+    val script = targetDir / scriptTargetFolder / scriptNameWithSuffix
+    IO.write(script, scriptContent)
+    // TODO - Better control over this!
+    if (makeScriptsExecutable)
+      script.setExecutable(true)
+    script -> s"$scriptTargetFolder/$scriptNameWithSuffix"
+  }
+
+  private[this] def resolveTemplate(defaultTemplateLocation: File): URL =
+    if (defaultTemplateLocation.exists) defaultTemplateLocation.toURI.toURL
+    else getClass.getResource(defaultTemplateLocation.getName)
+
+  private[this] def createForwarderScripts(executableScriptName: String,
+                                           discoveredMainClasses: Seq[String],
+                                           targetDir: File): Seq[(File, String)] = {
+    val tmp = targetDir / scriptTargetFolder
+    val forwarderTemplate = getClass.getResource(forwarderTemplateName)
+    ScriptUtils.createScriptNames(discoveredMainClasses).map {
+      case (qualifiedClassName, scriptNameWithoutSuffix) =>
+        val scriptName = scriptNameWithoutSuffix + scriptSuffix
+        val file = tmp / scriptName
+
+        val replacements = Seq("startScript" -> executableScriptName, "qualifiedClassName" -> qualifiedClassName)
+        val scriptContent = TemplateWriter.generateScript(forwarderTemplate, replacements, eol, keySurround)
+
+        IO.write(file, scriptContent)
+        if (makeScriptsExecutable)
+          file.setExecutable(true)
+        file -> s"$scriptTargetFolder/$scriptName"
+    }
+  }
+}

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtils.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtils.scala
@@ -54,7 +54,7 @@ object ScriptUtils {
       val parts = lowerCased.split("\\.")
       MainClass(qualifiedClassName, parts)
     }
-    val commonPrefixLength = mainClasses.map(_.parts.toList).reduce(commonPrefix).size
+    val commonPrefixLength = mainClasses.map(_.parts.init.toList).reduce(commonPrefix).size
 
     disambiguateNames(
       mainClasses.map {

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtils.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtils.scala
@@ -2,6 +2,72 @@ package com.typesafe.sbt.packager.archetypes.scripts
 
 object ScriptUtils {
 
+  private[this] def commonPrefix(list1: List[String], list2: List[String]): List[String] = (list1, list2) match {
+    case (Nil, _) => Nil
+    case (_, Nil) => Nil
+    case (x::xs, y::ys) =>
+      if (x == y)
+        x :: commonPrefix(xs, ys)
+      else
+        Nil
+  }
+
+  /**
+    * Recursive function that disambiguates classes with equal short names
+    * according to their packages.
+    * @param classesAndPrefixParts sequence of tuples
+    *     (qualified class name, not yet processed suffix of packages in which this class resides)
+    * @param shortName short class name to append at the end of generate name
+    * @param accumulatedPrefixes prefix parts accumulated above on the call stack
+    * @return sequence of tuples (passed in class name, disambiguated name)
+    */
+  private[this] def disambiguateNames(
+                      classesAndPrefixParts: Seq[(String, List[String])],
+                      shortName: String,
+                      accumulatedPrefixes: Seq[String] = Seq()
+                                  ): Seq[(String, String)] = {
+
+    if (classesAndPrefixParts.size <= 1) {
+      classesAndPrefixParts.map {
+        case (clazz, _) => (
+          clazz,
+          (accumulatedPrefixes :+ shortName)
+            .filter { str => str.nonEmpty }
+            .mkString("_")
+        )
+      }
+    } else {
+      val commonPrefixLength = classesAndPrefixParts
+        .map {
+          case (_, candidatePrefixes) => candidatePrefixes
+        }
+        .reduce(commonPrefix)
+        .size
+
+      classesAndPrefixParts
+        .map {
+          case (clazz, candidatePrefixes) =>
+            (clazz, candidatePrefixes.drop(commonPrefixLength))
+        }
+        .groupBy {
+          case (_, prefixes) => prefixes.headOption.getOrElse("")
+        }
+        .toSeq
+        .flatMap {
+          case (nextPrefix, nextConflictingNames) =>
+            disambiguateNames(
+              nextConflictingNames
+                .map {
+                  case (clazz, Nil) => (clazz, Nil)
+                  case (clazz, _ :: otherPrefixes) => (clazz, otherPrefixes)
+                },
+              shortName,
+              accumulatedPrefixes :+ nextPrefix
+            )
+        }
+    }
+  }
+
   /**
     * Generates launcher script names for the specified main class names.
     * Tries to make script names readable and unique.
@@ -11,21 +77,23 @@ object ScriptUtils {
   def createScriptNames(discoveredMainClasses: Seq[String]): Seq[(String, String)] = {
     val names = discoveredMainClasses.map { qualifiedClassName =>
       val lowerCased = toLowerCase(qualifiedClassName)
-      (qualifiedClassName, lowerCased.replace('.', '-'), lowerCased.split("\\.").last)
+      val parts = lowerCased.split("\\.")
+      (qualifiedClassName, parts.init.toList, parts.last)
     }
 
-    names.groupBy(_._3).toSeq.flatMap {
-      case (shortName, Seq((clazz, _, _))) => Seq((clazz, shortName))
-      case (_, conflictingNames) =>
-        conflictingNames.groupBy(_._2).toSeq.flatMap {
-          case (longerName, Seq((clazz, _, _))) => Seq((clazz, longerName))
-          case (longerName, veryConflictingNames) =>
-            veryConflictingNames.zipWithIndex.map {
-              case ((clazz, _, _), index) =>
-                // ... and hope it will not conflict with previously accepted names...
-                (clazz, s"$longerName-${index + 1}")
-            }
-        }
+    names
+      .groupBy {
+        case (_, _, shortName) => shortName
+      }
+      .toSeq
+      .flatMap {
+        case (shortName, conflictingNames) =>
+          disambiguateNames(
+            conflictingNames.map {
+              case (clazz, prefixes, _) => (clazz, prefixes)
+            },
+            shortName
+          )
     }
   }
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtils.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtils.scala
@@ -1,0 +1,68 @@
+package com.typesafe.sbt.packager.archetypes.scripts
+
+object ScriptUtils {
+
+  /**
+    * Generates launcher script names for the specified main class names.
+    * Tries to make script names readable and unique.
+    * @param discoveredMainClasses discovered qualified main class names
+    * @return sequence of tuples: (passed in class name) -> (generated script name)
+    */
+  def createScriptNames(discoveredMainClasses: Seq[String]): Seq[(String, String)] = {
+    val names = discoveredMainClasses.map { qualifiedClassName =>
+      val lowerCased = toLowerCase(qualifiedClassName)
+      (qualifiedClassName, lowerCased.replace('.', '-'), lowerCased.split("\\.").last)
+    }
+
+    names.groupBy(_._3).toSeq.flatMap {
+      case (shortName, Seq((clazz, _, _))) => Seq((clazz, shortName))
+      case (_, conflictingNames) =>
+        conflictingNames.groupBy(_._2).toSeq.flatMap {
+          case (longerName, Seq((clazz, _, _))) => Seq((clazz, longerName))
+          case (longerName, veryConflictingNames) =>
+            veryConflictingNames.zipWithIndex.map {
+              case ((clazz, _, _), index) =>
+                // ... and hope it will not conflict with previously accepted names...
+                (clazz, s"$longerName-${index + 1}")
+            }
+        }
+    }
+  }
+
+  /**
+    * Converts class name to lower case, applying some heuristics
+    * to guess the word splitting.
+    * @param qualifiedClassName a class name
+    * @return lower cased name with '-' between words. Dots ('.') are left as is.
+    */
+  def toLowerCase(qualifiedClassName: String): String = {
+    // suppose list is not very huge, so no need in tail recursion
+    def split(chars: List[Char]): List[Char] = chars match {
+      case c1 :: c2 :: cs if c1.isLower && c2.isUpper =>
+        //  aClass   ->  a-Class
+        // anUITest  -> an-UITest
+        //  ^
+        c1 :: '-' :: split(c2 :: cs)
+      case c1 :: c2 :: c3 :: cs if c1.isUpper && c2.isUpper && c3.isLower =>
+        // UITest -> UI-Test
+        //  ^
+        c1 :: '-' :: split(c2 :: c3 :: cs)
+      case c1 :: c2 :: cs if c1.isLetter && c2.isDigit =>
+        // Test1 -> Test-1
+        //    ^
+        c1 :: '-' :: split(c2 :: cs)
+      case c1 :: c2 :: cs if c1.isDigit && c2.isLetter =>
+        // Test1Class -> Test-1-Class
+        //     ^              ^
+        // _not_ pkg1.Test
+        //          ^
+        c1 :: '-' :: split(c2 :: cs)
+      case c :: cs =>
+        c :: split(cs)
+      case Nil => Nil
+    }
+    val sb = new StringBuilder
+    sb ++= split(qualifiedClassName.toList).map(_.toLower)
+    sb.result()
+  }
+}

--- a/src/sphinx/archetypes/java_app/index.rst
+++ b/src/sphinx/archetypes/java_app/index.rst
@@ -248,10 +248,10 @@ When this plugin generates script names from main class names, it tries to gener
 
 2. Resulted lower-cased names are grouped by the simple class name.
 
-    - Names from single-element groups are reduced to their lower-cased simple names.
+   - Names from single-element groups are reduced to their lower-cased simple names.
 
-    - Names that would otherwise collide by their simple names are used as is (that is, full names)
-      with dots replaced by underscores
+   - Names that would otherwise collide by their simple names are used as is (that is, full names)
+     with dots replaced by underscores
 
    So the final names will be:
 

--- a/src/sphinx/archetypes/java_app/index.rst
+++ b/src/sphinx/archetypes/java_app/index.rst
@@ -223,6 +223,48 @@ For two main classes ``com.example.FooMain`` and ``com.example.BarMain`` ``sbt s
 
 Now you can package your application as usual, but with multiple start scripts.
 
+A note on script names
+----------------------
+
+When this plugin generates script names from main class names, it tries to generate readable and unique names:
+
+1. An heuristic is used to split the fully qualified class names into words:
+
+   .. code-block:: none
+
+      pkg1.TestClass
+      pkg2.AnUIMainClass
+      pkg2.SomeXMLLoader
+      pkg3.TestClass
+
+   becomes
+
+   .. code-block:: none
+
+      pkg-1.test-class
+      pkg-2.an-ui-main-class
+      pkg-2.some-xml-loader
+      pkg-3.test-class
+
+2. Resulted lower-cased names are grouped by the simple class name.
+
+    - Names from single-element groups are reduced to their lower-cased simple names.
+
+    - Names that would otherwise collide by their simple names are used as is (that is, full names)
+      with dots replaced by underscores
+
+   So the final names will be:
+
+   .. code-block:: none
+
+      pkg-1_test-class
+      an-ui-main-class
+      some-xml-loader
+      pkg-3_test-class
+
+Please note that in some corner cases this may result in multiple scripts with the same name
+in the resulting archive, but it is not expected to happen in normal circumstances.
+
 Customize
 =========
 

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -18,15 +18,14 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
   }
 
   it should "convert names with numbers" in {
-    ScriptUtils.toLowerCase("package.Test1")  should be("package.test-1")
+    ScriptUtils.toLowerCase("package.Test1") should be("package.test-1")
     ScriptUtils.toLowerCase("package.Test11") should be("package.test-11")
-    ScriptUtils.toLowerCase("package.Test1Class")  should be("package.test-1-class")
+    ScriptUtils.toLowerCase("package.Test1Class") should be("package.test-1-class")
     ScriptUtils.toLowerCase("package.Test11Class") should be("package.test-11-class")
   }
 
-  private[this] def testMapping(testCase: (String, String)*): Unit = {
+  private[this] def testMapping(testCase: (String, String)*): Unit =
     ScriptUtils.createScriptNames(testCase.map(_._1)) should contain theSameElementsAs testCase
-  }
 
   "createScriptNames()" should "generate short names when no conflicts" in {
     testMapping(
@@ -46,8 +45,6 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
   }
 
   it should "handle single main class" in {
-    testMapping(
-      "pkg1.Test" -> "test"
-    )
+    testMapping("pkg1.Test" -> "test")
   }
 }

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -47,4 +47,14 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
   it should "handle single main class" in {
     testMapping("pkg1.Test" -> "test")
   }
+
+  it should "be consistent with the docs" in {
+    // see src/sphinx/archetypes/java_app/index.rst
+    testMapping(
+      "pkg1.TestClass" -> "pkg-1_test-class",
+      "pkg2.AnUIMainClass" -> "an-ui-main-class",
+      "pkg2.SomeXMLLoader" -> "some-xml-loader",
+      "pkg3.TestClass" -> "pkg-3_test-class"
+    )
+  }
 }

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -56,4 +56,9 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
       "pkg1.ui.Test" -> "ui_test"
     )
   }
+  it should "not strip the class name as well as packages for single main class" in {
+    testMapping(
+      "pkg1.Test" -> "test"
+    )
+  }
 }

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -57,4 +57,17 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
       "pkg3.TestClass" -> "pkg-3_test-class"
     )
   }
+
+  "duplicated script name detector" should "work" in {
+    ScriptUtils.describeDuplicates(
+      Seq(
+        "Test11" -> "dup1",
+        "Test12" -> "dup1",
+        "Test21" -> "dup2",
+        "Test22" -> "dup2",
+        "Test23" -> "dup2",
+        "Test3" -> "nodup"
+      )
+    ) should contain theSameElementsAs Seq("dup1 (Test11, Test12)", "dup2 (Test21, Test22, Test23)")
+  }
 }

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -39,24 +39,13 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
   it should "generate long names only when necessary" in {
     testMapping(
       "pkg1.TestClass" -> "pkg-1_test-class",
+      "pkg1.ui.TestClass" -> "pkg-1_ui_test-class",
       "pkg1.AnotherTestClass" -> "another-test-class",
       "pkg2.TestClass" -> "pkg-2_test-class"
     )
   }
 
-  it should "properly strip common packages when disambiguating names" in {
-    testMapping(
-      "com.company.feature1.Test" -> "feature-1_test",
-      "com.company.feature1.AnotherTest" -> "another-test",
-      "com.company.feature2.subpkg.core.Test" -> "feature-2_subpkg_core_test",
-      "com.company.feature2.subpkg.ui.Test"   -> "feature-2_subpkg_ui_test"
-    )
-    testMapping(
-      "pkg1.Test" -> "test",
-      "pkg1.ui.Test" -> "ui_test"
-    )
-  }
-  it should "not strip the class name as well as packages for single main class" in {
+  it should "handle single main class" in {
     testMapping(
       "pkg1.Test" -> "test"
     )

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -38,9 +38,22 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
 
   it should "generate long names only when necessary" in {
     testMapping(
-      "pkg1.TestClass" -> "pkg-1-test-class",
+      "pkg1.TestClass" -> "pkg-1_test-class",
       "pkg1.AnotherTestClass" -> "another-test-class",
-      "pkg2.TestClass" -> "pkg-2-test-class"
+      "pkg2.TestClass" -> "pkg-2_test-class"
+    )
+  }
+
+  it should "properly strip common packages when disambiguating names" in {
+    testMapping(
+      "com.company.feature1.Test" -> "feature-1_test",
+      "com.company.feature1.AnotherTest" -> "another-test",
+      "com.company.feature2.subpkg.core.Test" -> "feature-2_core_test",
+      "com.company.feature2.subpkg.ui.Test" -> "feature-2_ui_test"
+    )
+    testMapping(
+      "pkg1.Test" -> "test",
+      "pkg1.ui.Test" -> "ui_test"
     )
   }
 }

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -1,0 +1,46 @@
+package com.typesafe.sbt.packager.archetypes.scripts
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class ScriptUtilsTest extends FlatSpec with Matchers {
+  "toLowerCase()" should "convert regular names" in {
+    ScriptUtils.toLowerCase("package.TestClass") should be("package.test-class")
+  }
+
+  it should "convert regular names with single-lettered words" in {
+    ScriptUtils.toLowerCase("package.ATestClass") should be("package.a-test-class")
+    ScriptUtils.toLowerCase("package.FindAClass") should be("package.find-a-class")
+  }
+
+  it should "convert names with abbreviations" in {
+    ScriptUtils.toLowerCase("package.XMLParser") should be("package.xml-parser")
+    ScriptUtils.toLowerCase("package.AnXMLParser") should be("package.an-xml-parser")
+  }
+
+  it should "convert names with numbers" in {
+    ScriptUtils.toLowerCase("package.Test1")  should be("package.test-1")
+    ScriptUtils.toLowerCase("package.Test11") should be("package.test-11")
+    ScriptUtils.toLowerCase("package.Test1Class")  should be("package.test-1-class")
+    ScriptUtils.toLowerCase("package.Test11Class") should be("package.test-11-class")
+  }
+
+  private[this] def testMapping(testCase: (String, String)*): Unit = {
+    ScriptUtils.createScriptNames(testCase.map(_._1)) should contain theSameElementsAs testCase
+  }
+
+  "createScriptNames()" should "generate short names when no conflicts" in {
+    testMapping(
+      "pkg1.TestClass" -> "test-class",
+      "pkg1.AnotherTestClass" -> "another-test-class",
+      "pkg2.ThirdTestClass" -> "third-test-class"
+    )
+  }
+
+  it should "generate long names only when necessary" in {
+    testMapping(
+      "pkg1.TestClass" -> "pkg-1-test-class",
+      "pkg1.AnotherTestClass" -> "another-test-class",
+      "pkg2.TestClass" -> "pkg-2-test-class"
+    )
+  }
+}

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/scripts/ScriptUtilsTest.scala
@@ -48,8 +48,8 @@ class ScriptUtilsTest extends FlatSpec with Matchers {
     testMapping(
       "com.company.feature1.Test" -> "feature-1_test",
       "com.company.feature1.AnotherTest" -> "another-test",
-      "com.company.feature2.subpkg.core.Test" -> "feature-2_core_test",
-      "com.company.feature2.subpkg.ui.Test" -> "feature-2_ui_test"
+      "com.company.feature2.subpkg.core.Test" -> "feature-2_subpkg_core_test",
+      "com.company.feature2.subpkg.ui.Test"   -> "feature-2_subpkg_ui_test"
     )
     testMapping(
       "pkg1.Test" -> "test",


### PR DESCRIPTION
This PR tries to lower the chance of generation of multiple scripts
with equal names in one archive. Fixes #1016.

Additionally, an attempt was made to improve the word splitting
for the script names, so, for example `UITest` becomes `ui-test`
and not `u-i-test`.

I had to edit `ForwarderScripts.apply(...)` as well but I'm not sure I did it the right way.