### PR TITLE
Fix logging for SystemV packages

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemv/start-debian-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemv/start-debian-template
@@ -46,9 +46,9 @@ start_daemon() {
   fi
 
   if [ "$create_pidfile" = true ]; then
-    start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS ${stdout_redirect}
+    start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --make-pidfile --pidfile "$PIDFILE" --startas /bin/sh --start -- -c "exec $RUN_CMD $RUN_OPTS ${stdout_redirect}"
   else
-    start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --pidfile "$PIDFILE" --startas "$RUN_CMD" --start -- $RUN_OPTS ${stdout_redirect}
+    start-stop-daemon --background --chdir ${{chdir}} --chuid "$DAEMON_USER" --pidfile "$PIDFILE" --startas /bin/sh --start -- -c "exec $RUN_CMD $RUN_OPTS ${stdout_redirect}"
   fi
   log_end_msg $?
 }


### PR DESCRIPTION
The current implementation has no effect; nothing is logged. '>>' seems
to be passed to the process as a parameter and not something that is
interpretted by the shell.

This approach is in line with the accepted solution suggested at
https://stackoverflow.com/a/21029952/183863

Fixes #1021