### PR TITLE
add available main classes to the usage notes in bash script

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -319,6 +319,7 @@ Usage: $script_name [options]
 
 In the case of duplicated or conflicting options, basically the order above
 shows precedence: JAVA_OPTS lowest, command line options highest except "--".
+${{available_main_classes}}
 EOM
 }
 


### PR DESCRIPTION
Adds a note at the end of the bash usage message with the available main classes that can be used with the runner.

Example generated usage:
```
...
In the case of duplicated or conflicting options, basically the order above
shows precedence: JAVA_OPTS lowest, command line options highest except "--".

Available main classes:
  com.foo.Main
  com.bar.Main
```
