### PR TITLE
Refresh PR: Treat symlinks as normal files in spec file

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager.rpm
 
 import sbt._
 import com.typesafe.sbt.packager.Compat._
+import com.typesafe.sbt.packager.linux.LinuxSymlink
 
 object RpmHelper {
 
@@ -65,6 +66,8 @@ object RpmHelper {
       if file.exists && !file.isDirectory()
       target = buildroot / dest
     } copyWithZip(file, target, mapping.zipped)
+
+    LinuxSymlink.makeSymLinks(spec.symlinks, buildroot, relativeLinks = false)
   }
 
   private[this] def writeSpecFile(spec: RpmSpec, workArea: File, log: sbt.Logger): File = {

--- a/src/sbt-test/rpm/scriptlets-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriptlets-rpm/build.sbt
@@ -36,53 +36,10 @@ TaskKey[Unit]("checkSpecFile") := {
   val spec = IO.read(target.value / "rpm" / "SPECS" / "rpm-test.spec")
   assert(spec contains "%pre\necho \"pre-install\"", "Spec doesn't contain %pre scriptlet")
   assert(spec contains "%post\necho \"post-install\"", "Spec doesn't contain %post scriptlet")
-  assert(
-    spec contains
-      """
-      |%post
-      |echo "post-install"
-      |
-      |relocateLink() {
-      |  if [ -n "$4" ] ;
-      |  then
-      |    RELOCATED_INSTALL_DIR="$4/$3"
-      |    echo "${1/$2/$RELOCATED_INSTALL_DIR}"
-      |  else
-      |    echo "$1"
-      |  fi
-      |}
-      |rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX) && ln -s $(relocateLink /usr/share/rpm-test/conf /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX) $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $RPM_INSTALL_PREFIX)
-      |""".stripMargin,
-    "%post scriptlet does not contain relocateLink"
-  )
-
   assert(spec contains "%pretrans\necho \"pretrans\"", "Spec doesn't contain %pretrans scriptlet")
   assert(spec contains "%posttrans\necho \"posttrans\"", "Spec doesn't contain %posttrans scriptlet")
   assert(spec contains "%preun\necho \"pre-uninstall\"", "Spec doesn't contain %preun scriptlet")
   assert(spec contains "%postun\necho \"post-uninstall\"", "Spec doesn't contain %postun scriptlet")
-  assert(
-    spec contains
-      """
-      |%postun
-      |echo "post-uninstall"
-      |
-      |relocateLink() {
-      |  if [ -n "$4" ] ;
-      |  then
-      |    RELOCATED_INSTALL_DIR="$4/$3"
-      |    echo "${1/$2/$RELOCATED_INSTALL_DIR}"
-      |  else
-      |    echo "$1"
-      |  fi
-      |}
-      |if [ $1 -eq 0 ] ;
-      |then
-      |  [ -e /etc/sysconfig/rpm-test ] && . /etc/sysconfig/rpm-test
-      |  rm -rf $(relocateLink /etc/rpm-test /usr/share/rpm-test rpm-test $PACKAGE_PREFIX)
-      |fi
-      |""".stripMargin,
-    "%postun scriptlet does not contain relocate link"
-  )
   streams.value.log.success("Successfully tested rpm test file")
   ()
 }

--- a/src/sbt-test/rpm/simple-rpm/build.sbt
+++ b/src/sbt-test/rpm/simple-rpm/build.sbt
@@ -29,8 +29,6 @@ linuxPackageMappings in Rpm := {
   Seq(LinuxPackageMapping(Seq(mapping1, mapping2)))
 }
 
-linuxPackageSymlinks in Rpm := Seq(LinuxSymlink("/etc/link1", "destination1"), LinuxSymlink("link2", "destination2"))
-
 defaultLinuxInstallLocation in Rpm := "/opt/foo"
 
 TaskKey[Unit]("checkSpecFile") := {
@@ -54,18 +52,6 @@ TaskKey[Unit]("checkSpecFile") := {
     spec contains
       "%files\n%attr(755,root,root) /tmp/test\n%attr(755,root,root) /tmp/build.sbt",
     "Contains package mappings"
-  )
-
-  assert(
-    spec contains
-      "ln -s $(relocateLink destination1 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX) $(relocateLink /etc/link1 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX)",
-    "Contains package symlink link (1)"
-  )
-
-  assert(
-    spec contains
-      "ln -s $(relocateLink destination2 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX) $(relocateLink link2 /opt/foo/rpm-test rpm-test $RPM_INSTALL_PREFIX)",
-    "Contains package symlink link (2)"
   )
 
   streams.value.log.success("Successfully tested rpm test file")

--- a/src/sbt-test/rpm/symlink-rpm/build.sbt
+++ b/src/sbt-test/rpm/symlink-rpm/build.sbt
@@ -1,0 +1,31 @@
+import com.typesafe.sbt.packager.linux.{LinuxPackageMapping, LinuxSymlink}
+
+enablePlugins(JavaAppPackaging)
+
+name := "rpm-test"
+version := "0.1.0"
+maintainer := "David Pennell <dpennell@good-cloud.com>"
+packageSummary := "Test rpm package"
+packageName in Linux := "rpm-package"
+packageDescription :=
+  """A fun package description of our software,
+  with multiple lines."""
+
+rpmRelease := "1"
+rpmVendor := "typesafe"
+rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
+rpmLicense := Some("BSD")
+
+linuxPackageSymlinks := {
+  val helloSymlink = LinuxSymlink(((file(defaultLinuxInstallLocation.value) / (packageName in Linux).value / "lib") / "hello.link").toString, "/fake/hello.tx")
+  Seq(helloSymlink)
+}
+
+TaskKey[Unit]("check-spec-file") := {
+  val spec = IO.read(target.value / "rpm" / "SPECS" / "rpm-package.spec")
+  streams.value.log.success(spec)
+  assert(spec contains "%attr(0644,root,root) /usr/share/rpm-package/lib/rpm-test.rpm-test-0.1.0.jar", "Wrong installation path")
+  assert(spec contains "/usr/share/rpm-package/lib/hello.link", "Missing or incorrect symbolic link")
+  streams.value.log.success("Successfully tested rpm-package file")
+  ()
+}

--- a/src/sbt-test/rpm/symlink-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/symlink-rpm/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/rpm/symlink-rpm/test
+++ b/src/sbt-test/rpm/symlink-rpm/test
@@ -1,0 +1,4 @@
+> rpm:packageBin
+$ exists target/rpm/RPMS/noarch/rpm-package-0.1.0-1.noarch.rpm
+$ exists target/rpm/SPECS/rpm-package.spec
+> checkSpecFile


### PR DESCRIPTION
I'm trying to bring back to life a very old PR: https://github.com/sbt/sbt-native-packager/pull/916

Here I'm adding back the original test made by @dpennell and I'm reapplying his changes on top of the current master branch.

An interesting improvement is that by describing symbolic links as part of RPM's spec file, it can remove them during uninstall, leaving no empty folders behind. Previously, the links were removed in the `postun` hook, after RPM tried to rid of its managed folders, resulting in empty directories whenever there was a symbolic link inside them.

I've tested this with a project I'm working on using a CentOS VM.