### PR TITLE
Fix launcher jar paths not being quoted on Windows

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -196,7 +196,7 @@ object BashStartScriptPlugin extends AutoPlugin {
     def apply(mainClass: String, config: BashScriptConfig, targetDir: File, mainClasses: Seq[String]): File = {
       val template = resolveTemplate(config.bashScriptTemplateLocation)
       val replacements = Seq(
-        "app_mainclass" -> mainClassReplacement(mainClass),
+        "app_mainclass" -> mainClass,
         "available_main_classes" -> usageMainClassReplacement(mainClasses)
       ) ++ config.bashScriptReplacements
 
@@ -206,15 +206,6 @@ object BashStartScriptPlugin extends AutoPlugin {
       // TODO - Better control over this!
       script.setExecutable(true)
       script
-    }
-
-    private[this] def mainClassReplacement(mainClass: String): String = {
-      val jarPrefixed = """^\-jar (.*)""".r
-      val args = mainClass match {
-        case jarPrefixed(jarName) => Seq("-jar", jarName)
-        case className => Seq(className)
-      }
-      args.map(s => "\"" + s + "\"").mkString(" ")
     }
 
     private[this] def usageMainClassReplacement(mainClasses: Seq[String]): String =

--- a/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
@@ -39,11 +39,11 @@ object LauncherJarPlugin extends AutoPlugin {
         artifact.classifier.fold("")("-" + _) + "." + artifact.extension
     },
     mainClass in (Compile, bashScriptDefines) := {
-      Some("-jar $lib_dir/" + (artifactPath in packageJavaLauncherJar).value.getName)
+      Some(s"""-jar "$$lib_dir/${(artifactPath in packageJavaLauncherJar).value.getName}"""")
     },
     scriptClasspath in bashScriptDefines := Nil,
     mainClass in (Compile, batScriptReplacements) := {
-      Some("-jar %APP_LIB_DIR%\\" + (artifactPath in packageJavaLauncherJar).value.getName)
+      Some(s"""-jar "%APP_LIB_DIR%\\${(artifactPath in packageJavaLauncherJar).value.getName}"""")
     },
     scriptClasspath in batScriptReplacements := Nil,
     mappings in Universal += {

--- a/src/sbt-test/jar/launcher-jar with spaces/build.sbt
+++ b/src/sbt-test/jar/launcher-jar with spaces/build.sbt
@@ -12,13 +12,13 @@ TaskKey[Unit]("checkClasspath") := {
   val bat = IO.read(dir / "bin" / "launcher-jar-test.bat")
   assert(bat contains "set \"APP_CLASSPATH=\"", "bat should set APP_CLASSPATH:\n" + bat)
   assert(
-    bat contains "set \"APP_MAIN_CLASS=-jar %APP_LIB_DIR%\\launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\"",
+    bat contains "set \"APP_MAIN_CLASS=-jar \"%APP_LIB_DIR%\\launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\"\"",
     "bat should set APP_MAIN_CLASS:\n" + bat
   )
   val bash = IO.read(dir / "bin" / "launcher-jar-test")
   assert(bash contains "declare -r app_classpath=\"\"", "bash should declare app_classpath:\n" + bash)
   assert(
-    bash contains "declare -a app_mainclass=(\"-jar\" \"$lib_dir/launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\")",
+    bash contains "declare -a app_mainclass=(-jar \"$lib_dir/launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\")",
     "bash should declare app_mainclass:\n" + bash
   )
   val jar = new java.util.jar.JarFile(dir / "lib" / "launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar")

--- a/src/sbt-test/jar/launcher-jar/build.sbt
+++ b/src/sbt-test/jar/launcher-jar/build.sbt
@@ -14,13 +14,13 @@ TaskKey[Unit]("checkClasspath") := {
   val bat = IO.read(dir / "bin" / "launcher-jar-test.bat")
   assert(bat contains "set \"APP_CLASSPATH=\"", "bat should set APP_CLASSPATH:\n" + bat)
   assert(
-    bat contains "set \"APP_MAIN_CLASS=-jar %APP_LIB_DIR%\\launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\"",
+    bat contains "set \"APP_MAIN_CLASS=-jar \"%APP_LIB_DIR%\\launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\"\"",
     "bat should set APP_MAIN_CLASS:\n" + bat
   )
   val bash = IO.read(dir / "bin" / "launcher-jar-test")
   assert(bash contains "declare -r app_classpath=\"\"", "bash should declare app_classpath:\n" + bash)
   assert(
-    bash contains "declare -a app_mainclass=(\"-jar\" \"$lib_dir/launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\")",
+    bash contains "declare -a app_mainclass=(-jar \"$lib_dir/launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar\")",
     "bash should declare app_mainclass:\n" + bash
   )
   val jar = new java.util.jar.JarFile(dir / "lib" / "launcher-jar-test.launcher-jar-test-0.1.0-launcher.jar")


### PR DESCRIPTION
If you run the batch script from `C:\Program Files\my-app\bin\my-app.bat` you'll get an error like this:
> Error: Unable to access jarfile C:\Program

#581 fixed the path being quoted in the bash script, but it still wasn't quoted in the bat script.

Before:
```bat
set "APP_MAIN_CLASS=-jar %APP_LIB_DIR%\app-1.0-SNAPSHOT-launcher.jar"
```
After:
```bat
set "APP_MAIN_CLASS=-jar "%APP_LIB_DIR%\app-1.0-SNAPSHOT-launcher.jar""
```

Fixes #913 