### PR TITLE
Windows batch script improvements

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -79,50 +79,7 @@ rem "-J" is stripped, "-D" is left as is, and everything is appended to JAVA_OPT
 set _JAVA_PARAMS=
 set _APP_ARGS=
 
-:param_loop
-call set _PARAM1=%%1
-set "_TEST_PARAM=%~1"
-
-if ["!_PARAM1!"]==[""] goto param_afterloop
-
-
-rem ignore arguments that do not start with '-'
-if "%_TEST_PARAM:~0,1%"=="-" goto param_java_check
-set _APP_ARGS=!_APP_ARGS! !_PARAM1!
-shift
-goto param_loop
-
-:param_java_check
-if "!_TEST_PARAM:~0,2!"=="-J" (
-  rem strip -J prefix
-  set _JAVA_PARAMS=!_JAVA_PARAMS! !_TEST_PARAM:~2!
-  shift
-  goto param_loop
-)
-
-if "!_TEST_PARAM:~0,2!"=="-D" (
-  rem test if this was double-quoted property "-Dprop=42"
-  for /F "delims== tokens=1,*" %%G in ("!_TEST_PARAM!") DO (
-    if not ["%%H"] == [""] (
-      set _JAVA_PARAMS=!_JAVA_PARAMS! !_PARAM1!
-    ) else if [%2] neq [] (
-      rem it was a normal property: -Dprop=42 or -Drop="42"
-      call set _PARAM1=%%1=%%2
-      set _JAVA_PARAMS=!_JAVA_PARAMS! !_PARAM1!
-      shift
-    )
-  )
-) else (
-  if "!_TEST_PARAM!"=="-main" (
-    call set CUSTOM_MAIN_CLASS=%%2
-    shift
-  ) else (
-    set _APP_ARGS=!_APP_ARGS! !_PARAM1!
-  )
-)
-shift
-goto param_loop
-:param_afterloop
+call :process_args %*
 
 set _JAVA_OPTS=!_JAVA_OPTS! !_JAVA_PARAMS!
 :run
@@ -144,3 +101,63 @@ rem Call the application and pass all arguments unchanged.
 :end
 
 exit /B %ERRORLEVEL%
+
+
+:add_java
+  set _JAVA_PARAMS=!_JAVA_PARAMS! %1
+exit /B 0
+
+
+:add_app
+  set _APP_ARGS=!_APP_ARGS! %1
+exit /B 0
+
+
+rem Processes incoming arguments and places them in appropriate global variables
+:process_args
+  :param_loop
+  call set _PARAM1=%%1
+  set "_TEST_PARAM=%~1"
+
+  if ["!_PARAM1!"]==[""] goto param_afterloop
+
+
+  rem ignore arguments that do not start with '-'
+  if "%_TEST_PARAM:~0,1%"=="-" goto param_java_check
+  call :add_app "!_PARAM1!"
+  shift
+  goto param_loop
+
+  :param_java_check
+  if "!_TEST_PARAM:~0,2!"=="-J" (
+    rem strip -J prefix
+    call :add_java "!_TEST_PARAM:~2!"
+    shift
+    goto param_loop
+  )
+
+  if "!_TEST_PARAM:~0,2!"=="-D" (
+    rem test if this was double-quoted property "-Dprop=42"
+    for /F "delims== tokens=1,*" %%G in ("!_TEST_PARAM!") DO (
+      if not ["%%H"] == [""] (
+        call :add_java "!_PARAM1!"
+      ) else if [%2] neq [] (
+        rem it was a normal property: -Dprop=42 or -Drop="42"
+        call set _PARAM1=%%1=%%2
+        call :add_java "!_PARAM1!"
+        shift
+      )
+    )
+  ) else (
+    if "!_TEST_PARAM!"=="-main" (
+      call set CUSTOM_MAIN_CLASS=%%2
+      shift
+    ) else (
+      call :add_app "!_PARAM1!"
+    )
+  )
+  shift
+  goto param_loop
+  :param_afterloop
+
+exit /B 0

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -9,16 +9,21 @@
 
 @echo off
 
-if "%@@APP_ENV_NAME@@_HOME%"=="" set "@@APP_ENV_NAME@@_HOME=%~dp0\\.."
 
-set "APP_LIB_DIR=%@@APP_ENV_NAME@@_HOME%\lib\"
+if "%@@APP_ENV_NAME@@_HOME%"=="" (
+  set "APP_HOME=%~dp0\\.."
+) else (
+  set "APP_HOME=%@@APP_ENV_NAME@@_HOME%"
+)
+
+set "APP_LIB_DIR=%APP_HOME%\lib\"
 
 rem Detect if we were double clicked, although theoretically A user could
 rem manually run cmd /c
 for %%x in (!cmdcmdline!) do if %%~x==/c set DOUBLECLICKED=1
 
 rem FIRST we load the config file of extra options.
-set "CFG_FILE=%@@APP_ENV_NAME@@_HOME%\@@APP_ENV_NAME@@_config.txt"
+set "CFG_FILE=%APP_HOME%\@@APP_ENV_NAME@@_config.txt"
 set CFG_OPTS=
 call :parse_config "%CFG_FILE%" CFG_OPTS
 

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -77,11 +77,14 @@ rem "-J" is stripped, "-D" is left as is, and everything is appended to JAVA_OPT
 set _JAVA_PARAMS=
 set _APP_ARGS=
 
-call :process_args %*
+@@APP_DEFINES@@
+
+rem if configuration files exist, prepend their contents to the script arguments so it can be processed by this runner
+call :parse_config "%SCRIPT_CONF_FILE%" SCRIPT_CONF_ARGS
+
+call :process_args %SCRIPT_CONF_ARGS% %*
 
 set _JAVA_OPTS=!_JAVA_OPTS! !_JAVA_PARAMS!
-
-@@APP_DEFINES@@
 
 if defined CUSTOM_MAIN_CLASS (
     set MAIN_CLASS=!CUSTOM_MAIN_CLASS!

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -82,7 +82,7 @@ set _APP_ARGS=
 rem if configuration files exist, prepend their contents to the script arguments so it can be processed by this runner
 call :parse_config "%SCRIPT_CONF_FILE%" SCRIPT_CONF_ARGS
 
-call :process_args %SCRIPT_CONF_ARGS% %*
+call :process_args %SCRIPT_CONF_ARGS% %%*
 
 set _JAVA_OPTS=!_JAVA_OPTS! !_JAVA_PARAMS!
 
@@ -116,12 +116,12 @@ exit /B 0
 
 
 :add_java
-  set _JAVA_PARAMS=!_JAVA_PARAMS! %1
+  set _JAVA_PARAMS=!_JAVA_PARAMS! %*
 exit /B 0
 
 
 :add_app
-  set _APP_ARGS=!_APP_ARGS! %1
+  set _APP_ARGS=!_APP_ARGS! %*
 exit /B 0
 
 
@@ -136,14 +136,14 @@ rem Processes incoming arguments and places them in appropriate global variables
 
   rem ignore arguments that do not start with '-'
   if "%_TEST_PARAM:~0,1%"=="-" goto param_java_check
-  call :add_app "!_PARAM1!"
+  set _APP_ARGS=!_APP_ARGS! !_PARAM1!
   shift
   goto param_loop
 
   :param_java_check
   if "!_TEST_PARAM:~0,2!"=="-J" (
     rem strip -J prefix
-    call :add_java "!_TEST_PARAM:~2!"
+    set _JAVA_PARAMS=!_JAVA_PARAMS! !_TEST_PARAM:~2!
     shift
     goto param_loop
   )
@@ -152,11 +152,11 @@ rem Processes incoming arguments and places them in appropriate global variables
     rem test if this was double-quoted property "-Dprop=42"
     for /F "delims== tokens=1,*" %%G in ("!_TEST_PARAM!") DO (
       if not ["%%H"] == [""] (
-        call :add_java "!_PARAM1!"
+        set _JAVA_PARAMS=!_JAVA_PARAMS! !_PARAM1!
       ) else if [%2] neq [] (
         rem it was a normal property: -Dprop=42 or -Drop="42"
         call set _PARAM1=%%1=%%2
-        call :add_java "!_PARAM1!"
+        set _JAVA_PARAMS=!_JAVA_PARAMS! !_PARAM1!
         shift
       )
     )
@@ -165,7 +165,7 @@ rem Processes incoming arguments and places them in appropriate global variables
       call set CUSTOM_MAIN_CLASS=%%2
       shift
     ) else (
-      call :add_app "!_PARAM1!"
+      set _APP_ARGS=!_APP_ARGS! !_PARAM1!
     )
   )
   shift

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -20,14 +20,7 @@ for %%x in (!cmdcmdline!) do if %%~x==/c set DOUBLECLICKED=1
 rem FIRST we load the config file of extra options.
 set "CFG_FILE=%@@APP_ENV_NAME@@_HOME%\@@APP_ENV_NAME@@_config.txt"
 set CFG_OPTS=
-if exist "%CFG_FILE%" (
-  FOR /F "tokens=* eol=# usebackq delims=" %%i IN ("%CFG_FILE%") DO (
-    set DO_NOT_REUSE_ME=%%i
-    rem ZOMG (Part #2) WE use !! here to delay the expansion of
-    rem CFG_OPTS, otherwise it remains "" for this loop.
-    set CFG_OPTS=!CFG_OPTS! !DO_NOT_REUSE_ME!
-  )
-)
+call :parse_config "%CFG_FILE%" CFG_OPTS
 
 rem We use the value of the JAVACMD environment variable if defined
 set _JAVACMD=%JAVACMD%
@@ -97,6 +90,21 @@ rem Call the application and pass all arguments unchanged.
 @endlocal
 
 exit /B %ERRORLEVEL%
+
+
+rem Loads a configuration file full of default command line options for this script.
+rem First argument is the path to the config file.
+rem Second argument is the name of the environment variable to write to.
+:parse_config
+  set _PARSE_FILE=%~1
+  set _PARSE_OUT=
+  if exist "%_PARSE_FILE%" (
+    FOR /F "tokens=* eol=# usebackq delims=" %%i IN ("%_PARSE_FILE%") DO (
+      set _PARSE_OUT=!_PARSE_OUT! %%i
+    )
+  )
+  set %2=!_PARSE_OUT!
+exit /B 0
 
 
 :add_java

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -12,6 +12,9 @@
 
 if "%@@APP_ENV_NAME@@_HOME%"=="" (
   set "APP_HOME=%~dp0\\.."
+
+  rem Also set the old env name for backwards compatibility
+  set "@@APP_ENV_NAME@@_HOME=%~dp0\\.."
 ) else (
   set "APP_HOME=%@@APP_ENV_NAME@@_HOME%"
 )

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -82,7 +82,6 @@ set _APP_ARGS=
 call :process_args %*
 
 set _JAVA_OPTS=!_JAVA_OPTS! !_JAVA_PARAMS!
-:run
 
 @@APP_DEFINES@@
 
@@ -96,9 +95,6 @@ rem Call the application and pass all arguments unchanged.
 "%_JAVACMD%" !_JAVA_OPTS! !@@APP_ENV_NAME@@_OPTS! -cp "%APP_CLASSPATH%" %MAIN_CLASS% !_APP_ARGS!
 
 @endlocal
-
-
-:end
 
 exit /B %ERRORLEVEL%
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ApplicationIniGenerator.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ApplicationIniGenerator.scala
@@ -5,6 +5,10 @@ import java.io.File
 import sbt._
 
 trait ApplicationIniGenerator {
+  /**
+    * @return the existing mappings plus a generated application.ini
+    *         if custom javaOptions are specified
+    */
   def generateApplicationIni(universalMappings: Seq[(File, String)],
                              javaOptions: Seq[String],
                              bashScriptConfigLocation: Option[String],

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ApplicationIniGenerator.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ApplicationIniGenerator.scala
@@ -1,0 +1,40 @@
+package com.typesafe.sbt.packager.archetypes.scripts
+
+import java.io.File
+
+import sbt._
+
+trait ApplicationIniGenerator {
+  def generateApplicationIni(universalMappings: Seq[(File, String)],
+                             javaOptions: Seq[String],
+                             bashScriptConfigLocation: Option[String],
+                             tmpDir: File,
+                             log: Logger): Seq[(File, String)] =
+    bashScriptConfigLocation
+      .collect {
+        case location if javaOptions.nonEmpty =>
+          val configFile = tmpDir / "tmp" / "conf" / "application.ini"
+          val pathMapping = cleanApplicationIniPath(location)
+          //Do not use writeLines here because of issue #637
+          IO.write(configFile, ("# options from build" +: javaOptions).mkString("\n"))
+          val hasConflict = universalMappings.exists {
+            case (file, path) => file != configFile && path == pathMapping
+          }
+          // Warn the user if he tries to specify options
+          if (hasConflict) {
+            log.warn("--------!!! JVM Options are defined twice !!!-----------")
+            log.warn(
+              "application.ini is already present in output package. Will be overridden by 'javaOptions in Universal'"
+            )
+          }
+          (configFile -> pathMapping) +: universalMappings
+
+      }
+      .getOrElse(universalMappings)
+
+  /**
+    * @param path that could be relative to app_home
+    * @return path relative to app_home
+    */
+  protected def cleanApplicationIniPath(path: String): String
+}

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -16,7 +16,7 @@ import sbt._
   * [[com.typesafe.sbt.packager.archetypes.JavaAppPackaging]].
   *
   */
-object BashStartScriptPlugin extends AutoPlugin {
+object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator {
 
   /**
     * Name of the bash template if user wants to provide custom one
@@ -85,32 +85,6 @@ object BashStartScriptPlugin extends AutoPlugin {
     Seq("template_declares" -> defineString)
   }
 
-  private[this] def generateApplicationIni(universalMappings: Seq[(File, String)],
-                                           javaOptions: Seq[String],
-                                           bashScriptConfigLocation: Option[String],
-                                           tmpDir: File,
-                                           log: Logger): Seq[(File, String)] =
-    bashScriptConfigLocation
-      .collect {
-        case location if javaOptions.nonEmpty =>
-          val configFile = tmpDir / "tmp" / "conf" / "application.ini"
-          //Do not use writeLines here because of issue #637
-          IO.write(configFile, ("# options from build" +: javaOptions).mkString("\n"))
-          val filteredMappings = universalMappings.filter {
-            case (file, path) => path != appIniLocation
-          }
-          // Warn the user if he tries to specify options
-          if (filteredMappings.size < universalMappings.size) {
-            log.warn("--------!!! JVM Options are defined twice !!!-----------")
-            log.warn(
-              "application.ini is already present in output package. Will be overridden by 'javaOptions in Universal'"
-            )
-          }
-          (configFile -> cleanApplicationIniPath(location)) +: filteredMappings
-
-      }
-      .getOrElse(universalMappings)
-
   private[this] def generateStartScripts(config: BashScriptConfig,
                                          mainClass: Option[String],
                                          discoveredMainClasses: Seq[String],
@@ -153,8 +127,7 @@ object BashStartScriptPlugin extends AutoPlugin {
     * @param path that could be relative to app_home
     * @return path relative to app_home
     */
-  private[this] def cleanApplicationIniPath(path: String): String =
-    path.replaceFirst("\\$\\{app_home\\}/../", "")
+  protected def cleanApplicationIniPath(path: String): String = path.stripPrefix("${app_home}/../")
 
   /**
     * Bash defines

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptKeys.scala
@@ -25,4 +25,8 @@ trait BatStartScriptKeys {
     "A list of extra definitions that should be written to the bat file template."
   )
 
+  val batScriptConfigLocation = TaskKey[Option[String]](
+    "batScriptConfigLocation",
+    "The location where the bat script will load default argument configuration from."
+  )
 }

--- a/src/sbt-test/windows/app-home-var-expansion/build.sbt
+++ b/src/sbt-test/windows/app-home-var-expansion/build.sbt
@@ -1,0 +1,16 @@
+import com.typesafe.sbt.packager.Compat._
+
+enablePlugins(JavaAppPackaging)
+
+name := "simple-app"
+
+version := "0.1.0"
+
+batScriptExtraDefines += """call :add_java "-Dconfig.file=%APP_HOME%\conf\production.conf""""
+
+TaskKey[Unit]("runCheck") := {
+  val cwd = (stagingDirectory in Universal).value
+  val cmd = Seq((cwd / "bin" / s"${packageName.value}.bat").getAbsolutePath)
+  val configFile = (sys.process.Process(cmd, cwd).!!).replaceAll("\r\n", "")
+  assert(configFile.contains("""stage\bin\\\..\conf\production.conf"""), "Output didn't contain config file path: " + configFile)
+}

--- a/src/sbt-test/windows/app-home-var-expansion/project/plugins.sbt
+++ b/src/sbt-test/windows/app-home-var-expansion/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/windows/app-home-var-expansion/src/main/scala/MainApp.scala
+++ b/src/sbt-test/windows/app-home-var-expansion/src/main/scala/MainApp.scala
@@ -1,0 +1,4 @@
+object MainApp extends App {
+  val config = sys.props("config.file") ensuring (_ ne null, "didn't pick up -Dconfig.file argument")
+  print(config)
+}

--- a/src/sbt-test/windows/app-home-var-expansion/test
+++ b/src/sbt-test/windows/app-home-var-expansion/test
@@ -1,0 +1,3 @@
+# Run the staging and check the script.
+> stage
+> runCheck

--- a/src/sbt-test/windows/dynamic-app-env-name/build.sbt
+++ b/src/sbt-test/windows/dynamic-app-env-name/build.sbt
@@ -1,0 +1,21 @@
+import com.typesafe.sbt.packager.Compat._
+
+enablePlugins(JavaAppPackaging)
+
+name := "example-cli"
+
+version := "0.1.0"
+
+/*
+ * Previous sbt-native-packager versions used a dynamic environment variable name %<APP_NAME>_HOME%
+ * Now it is always called %APP_HOME% and the old name can be used for backwards compatibility.
+ */
+
+batScriptExtraDefines += """set _JAVA_OPTS=%_JAVA_OPTS% -Dconfig.file=%EXAMPLE_CLI_HOME%\\conf\\app.config"""
+
+TaskKey[Unit]("runCheck") := {
+  val cwd = (stagingDirectory in Universal).value
+  val cmd = Seq((cwd / "bin" / s"${packageName.value}.bat").getAbsolutePath)
+  val configFile = (sys.process.Process(cmd, cwd).!!).replaceAll("\r\n", "")
+  assert(configFile.contains("""stage\bin\\\..\\conf\\app.config"""), "Output didn't contain config file path: " + configFile)
+}

--- a/src/sbt-test/windows/dynamic-app-env-name/project/plugins.sbt
+++ b/src/sbt-test/windows/dynamic-app-env-name/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/windows/dynamic-app-env-name/src/main/scala/MainApp.scala
+++ b/src/sbt-test/windows/dynamic-app-env-name/src/main/scala/MainApp.scala
@@ -1,0 +1,4 @@
+object MainApp extends App {
+  val config = sys.props("config.file") ensuring (_ ne null, "didn't pick up -Dconfig.file argument")
+  print(config)
+}

--- a/src/sbt-test/windows/dynamic-app-env-name/test
+++ b/src/sbt-test/windows/dynamic-app-env-name/test
@@ -1,0 +1,3 @@
+# Run the staging and check the script.
+> stage
+> runCheck

--- a/src/sbt-test/windows/memory-settings/build.sbt
+++ b/src/sbt-test/windows/memory-settings/build.sbt
@@ -1,0 +1,23 @@
+import com.typesafe.sbt.packager.Compat._
+
+enablePlugins(JavaAppPackaging)
+
+name := "simple-app"
+
+version := "0.1.0"
+
+javaOptions in Universal ++= Seq("-J-Xmx64m", "-J-Xms64m")
+
+TaskKey[Unit]("jvmoptsCheck") := {
+  val jvmopts = (stagingDirectory in Universal).value / "conf" / "application.ini"
+  val options = IO.read(jvmopts)
+  assert(options contains "-J-Xmx64m", "Options don't contain xmx setting:\n" + options)
+  assert(options contains "-J-Xms64m", "Options don't contain xms setting:\n" + options)
+}
+
+TaskKey[Unit]("runCheck") := {
+  val cwd = (stagingDirectory in Universal).value
+  val cmd = Seq((cwd / "bin" / s"${packageName.value}.bat").getAbsolutePath)
+  val memory = (sys.process.Process(cmd, cwd).!!).replaceAll("\r\n", "")
+  assert(memory.toLong <= 64, "Runtime memory is bigger then 64m < " + memory + "m")
+}

--- a/src/sbt-test/windows/memory-settings/project/plugins.sbt
+++ b/src/sbt-test/windows/memory-settings/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/windows/memory-settings/src/main/scala/MainApp.scala
+++ b/src/sbt-test/windows/memory-settings/src/main/scala/MainApp.scala
@@ -1,0 +1,4 @@
+object MainApp extends App {
+  val memory = Runtime.getRuntime.maxMemory() / (1024L * 1024L)
+  print(memory)
+}

--- a/src/sbt-test/windows/memory-settings/test
+++ b/src/sbt-test/windows/memory-settings/test
@@ -1,0 +1,5 @@
+# Run the staging and check the script.
+> stage
+$ exists target/universal/stage/conf/application.ini
+> jvmoptsCheck
+> runCheck

--- a/src/sphinx/archetypes/java_app/customize.rst
+++ b/src/sphinx/archetypes/java_app/customize.rst
@@ -92,7 +92,7 @@ bash commands here, but for configurations you have two methods to add jvm and a
    // add jvm parameter for typesafe config
    bashScriptExtraDefines += """addJava "-Dconfig.file=${app_home}/../conf/app.config""""
    // add application parameter
-   bashScriptExtraDefines += """addApp "--port=8080"""
+   bashScriptExtraDefines += """addApp "--port=8080""""
 
 **Syntax**
 
@@ -108,14 +108,15 @@ bash commands here, but for configurations you have two methods to add jvm and a
 BatScript defines
 ^^^^^^^^^^^^^^^^^
 
-First, while the BASH file allows you to configure where to load JVM options and default arguments, in
-windows we can only configure JVM options.
+The Windows batch script accepts extra commands in ``batScriptExtraDefines``. It offers
+two methods to add jvm and app parameters using similar syntax to the BASH script.
 
 .. code-block:: scala
 
    // add jvm parameter for typesafe config
-  batScriptExtraDefines += """set _JAVA_OPTS=%_JAVA_OPTS% -Dconfig.file=%EXAMPLE_CLI_HOME%\\conf\\app.config"""
-
+   batScriptExtraDefines += """call :add_java "-Dconfig.file=%APP_HOME%\conf\app.config""""
+   // add application parameter
+   batScriptExtraDefines += """call :add_app "--port=8080""""
 
 **Syntax**
 

--- a/src/sphinx/archetypes/java_app/customize.rst
+++ b/src/sphinx/archetypes/java_app/customize.rst
@@ -38,7 +38,6 @@ Via Application.ini
 ^^^^^^^^^^^^^^^^^^^
 
 The second option is to create ``src/universal/conf/application.ini`` with the following template
-(For Windows-user: Create ``src/universal/<APP_ENV_NAME>_config.txt`` instead of the application.ini, it is expected that way by the BAT-template. Inside the <App_ENV_NAME>_config.txt the jvm-options are expected like in the command-line  (e.g. -Xms2G -Xmx3G) without an leading ``J``)
 
 .. code-block:: bash
 


### PR DESCRIPTION
I added some functions to the batch script to mirror the bash script. This means you can set extra java args using similar syntax:
```sbt
batScriptExtraDefines += """call :add_java "-Dconfig.file=%APP_HOME%\conf\production.conf""""
bashScriptExtraDefines += """addJava "-Dconfig.file=${app_home}/../conf/production.conf""""
```

Previously the batch script used a dynamic environment variable name `<APP_NAME>_HOME`, which is difficult to use from the sbt build. Now it's called `APP_HOME` always.

The bat script will still read `<APP_NAME>_HOME` from the environment for backwards compatibility.

### application.ini

The bat script now supports `javaOptions in Universal` via a generated `application.ini` file. Fixes #688

The ini file uses the `-J` syntax, so you can use the same ini file for both bat and bash, or you can have different files by specifying `batScriptConfigLocation` and/or `bashScriptConfigLocation`.

The bat script will still read `<APP_NAME>_config.txt` for backwards compatibility.