### PR TITLE
Improve main class detection

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/StartScriptMainClassConfig.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/StartScriptMainClassConfig.scala
@@ -41,7 +41,7 @@ object StartScriptMainClassConfig {
     * @return A start script configuration
     */
   def from(mainClass: Option[String], discoveredMainClasses: Seq[String]): StartScriptMainClassConfig = {
-    val additionalMainClasses = discoveredMainClasses.filterNot(mainClass contains _)
+    val additionalMainClasses = discoveredMainClasses.filterNot(mainClass == Some(_))
     (mainClass, additionalMainClasses) match {
       // only one main - create the default script
       case (Some(main), Seq()) => SingleMain(main)

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/StartScriptMainClassConfig.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/StartScriptMainClassConfig.scala
@@ -40,16 +40,19 @@ object StartScriptMainClassConfig {
     * @param discoveredMainClasses all discovered main classes, e.g. from (discoveredMainClasses in Compile).value
     * @return A start script configuration
     */
-  def from(mainClass: Option[String], discoveredMainClasses: Seq[String]): StartScriptMainClassConfig =
-    mainClass match {
+  def from(mainClass: Option[String], discoveredMainClasses: Seq[String]): StartScriptMainClassConfig = {
+    val additionalMainClasses = discoveredMainClasses.filterNot(mainClass contains _)
+    (mainClass, additionalMainClasses) match {
       // only one main - create the default script
-      case Some(main) if discoveredMainClasses.size == 1 => SingleMain(main)
+      case (Some(main), Seq()) => SingleMain(main)
+      case (None, Seq(main)) => SingleMain(main)
       // main explicitly set and multiple discoveredMainClasses
-      case Some(main) => ExplicitMainWithAdditional(main, discoveredMainClasses.filterNot(_ == main))
+      case (Some(main), additional) => ExplicitMainWithAdditional(main, additional)
       // no main class at all
-      case None if discoveredMainClasses.isEmpty => NoMain
+      case (None, Seq()) => NoMain
       // multiple main classes and none explicitly set. Create start script for each class
-      case None => MultipleMains(discoveredMainClasses)
+      case (None, additional) => MultipleMains(additional)
     }
+  }
 
 }

--- a/src/test/scala/com/typesafe/sbt/packager/StartScriptMainClassConfigSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/StartScriptMainClassConfigSpec.scala
@@ -1,0 +1,47 @@
+package com.typesafe.sbt.packager
+
+import com.typesafe.sbt.packager.archetypes.scripts._
+import org.scalatest._
+
+class StartScriptMainClassConfigSpec extends WordSpec with Matchers {
+
+  "StartScriptMainClassConfig" should {
+
+    "handle a single explicit main class" when {
+
+      "main class is not discovered" in {
+        StartScriptMainClassConfig.from(Some("mainClass"), Nil) should === (SingleMain("mainClass"))
+      }
+
+      "main class is discovered" in {
+        StartScriptMainClassConfig.from(Some("mainClass"), Seq("mainClass")) should === (SingleMain("mainClass"))
+      }
+    }
+
+    "handle an explicit main class with alternatives" when {
+
+      "main class is not discovered" in {
+        StartScriptMainClassConfig.from(Some("mainClass"), Seq("alternate")) should === (ExplicitMainWithAdditional("mainClass", Seq("alternate")))
+      }
+
+      "main class is discovered" in {
+        StartScriptMainClassConfig.from(Some("mainClass"), Seq("mainClass", "alternate")) should === (ExplicitMainWithAdditional("mainClass", Seq("alternate")))
+      }
+    }
+
+    "handle discovered main classes" when {
+
+      "a single main class is discovered" in {
+        StartScriptMainClassConfig.from(None, Seq("mainClass")) should === (SingleMain("mainClass"))
+      }
+
+      "multiple main classes are discovered" in {
+        StartScriptMainClassConfig.from(None, Seq("mainClass", "alternate")) should === (MultipleMains(Seq("mainClass", "alternate")))
+      }
+    }
+
+    "handle no main classes" in {
+      StartScriptMainClassConfig.from(None, Seq.empty) should === (NoMain)
+    }
+  }
+}


### PR DESCRIPTION
Fixes an issue where the main class is not discovered because it's located in a different jar on the classpath. For example:
```sbt
> show mainClass
[info] Some(play.core.server.ProdServerStart)
> show discoveredMainClasses
[info] * com.acme.CustomMainClass
```

This matches the first case, and consequently the discovered main class is ignored
```
      case Some(main) if discoveredMainClasses.size == 1 => SingleMain(main)
```