### PR TITLE
Convert dockerVersion from a setting to a task

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -84,7 +84,7 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
     }
   }
 
-  def dockerServerVersion: Def.Initialize[Option[DockerVersion]] = Def.setting {
+  def dockerServerVersion: Def.Initialize[Task[Option[DockerVersion]]] = Def.task {
     val docker: DockerClient = DefaultDockerClient.fromEnv().build()
     DockerVersion.parse(docker.version().version())
   }

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -29,7 +29,7 @@ trait DockerKeys {
     "Docker CMD. Used together with dockerEntrypoint. Arguments passed in exec form"
   )
   val dockerExecCommand = SettingKey[Seq[String]]("dockerExecCommand", "The shell command used to exec Docker")
-  val dockerVersion = SettingKey[Option[DockerVersion]]("dockerVersion", "The docker server version")
+  val dockerVersion = TaskKey[Option[DockerVersion]]("dockerVersion", "The docker server version")
   val dockerBuildOptions = SettingKey[Seq[String]]("dockerBuildOptions", "Options used for the Docker build")
   val dockerBuildCommand = SettingKey[Seq[String]]("dockerBuildCommand", "Command for building the Docker image")
   val dockerLabels = SettingKey[Map[String, String]]("dockerLabels", "Labels applied to the Docker image")


### PR DESCRIPTION
I get errors when starting sbt when the machine can't connect to docker
```
An error occurred trying to connect: Get http://127.0.0.1:2375/v1.22/version: dial tcp 127.0.0.1:2375: connectex: No connection could be made because the target machine actively refused it.
```

Since fetching the docker version involves starting a process and/or making an HTTP request, it seems like it should be a task rather than a setting.