### PR TITLE
Add support for -X JVM options

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -194,7 +194,7 @@ process_args () {
 
      -java-home) require_arg path "$1" "$2" && jre=`eval echo $2` && java_cmd="$jre/bin/java" && shift 2 ;;
 
- -D*|-agentlib*) addJava "$1" && shift ;;
+ -D*|-X*|-agentlib*) addJava "$1" && shift ;;
             -J*) addJava "${1:2}" && shift ;;
               *) addResidual "$1" && shift ;;
     esac


### PR DESCRIPTION
If you specify JVM options starting with "-X" in `javaOptions in Universal`, such as

    -Xbootclasspath/p:/usr/share/appname/lib/org.mortbay.jetty.alpn.alpn-boot-8.1.11.v20170118.jar

Then the bash script will append the option too late in the java command, and it won't work. This commit fixes it. Similar to https://github.com/sbt/sbt-native-packager/pull/431.