### PR TITLE
"" value for default docker label values

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -172,7 +172,11 @@ object DockerPlugin extends AutoPlugin {
     */
   private final def makeLabel(label: (String, String)): CmdLike = {
     val (variable, value) = label
-    Cmd("LABEL", variable + "=\"" + value.toString + "\"")
+    val valueString = Option(value) match {
+      case Some(v) => v.toString
+      case None => ""
+    }
+    Cmd("LABEL", variable + "=\"" + valueString + "\"")
   }
 
   /**


### PR DESCRIPTION
If docker label's value is null, `NullPointerException` is thrown currently.
To prevent that, this pr will put `""` as default value for label values.
`""` for empty label values seems ok according to [value guidelines in official docker doc](https://docs.docker.com/engine/userguide/labels-custom-metadata/#manage-labels-on-objects)