### PR TITLE
Update documentation for multi-module builds

### DIFF
--- a/_sources/recipes/custom.rst.txt
+++ b/_sources/recipes/custom.rst.txt
@@ -124,8 +124,6 @@ you can specify everything in a single ``build.sbt``
 
 .. code-block:: scala
 
-    import NativePackagerKeys._
-
     name := "mukis-fullstack"
 
     // used like the groupId in maven
@@ -146,7 +144,7 @@ you can specify everything in a single ``build.sbt``
         id = "root",
         base = file("."),
         // configure your native packaging settings here
-        settings = packageArchetype.java_server++ Seq(
+        settings = Seq(
             maintainer := "John Smith <john.smith@example.com>",
             packageDescription := "Fullstack Application",
             packageSummary := "Fullstack Application",
@@ -155,7 +153,8 @@ you can specify everything in a single ``build.sbt``
         ),
         // always run all commands on each sub project
         aggregate = Seq(frontend, backend, api)
-    ) dependsOn(frontend, backend, api) // this does the actual aggregation
+    ).enablePlugins(JavaServerAppPackaging) // enable app packaging on this project
+     .dependsOn(frontend, backend, api) // this does the actual aggregation
 
     // --------- Project Frontend ------------------
     lazy val frontend = Project(
@@ -175,6 +174,8 @@ you can specify everything in a single ``build.sbt``
         id = "api",
         base = file("api")
     )
+    
+If you want to build multiple bundles from the a single .sbt build, rather than one bundle aggregating all projects, you'll need to call `.enablePlugins(JavaAppPackaging)` on each root that you want to bundle.
     
     
 Custom Packaging Format


### PR DESCRIPTION
The `packageArchetype.java_server` syntax is deprecated and broken.

Probably the [example](https://github.com/muuki88/sbt-native-packager-examples/tree/master/multi-module-build) should also be updated.