### PR TITLE
DockerAlias should use dockerRepository and dockerUsername from Docker scope

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -74,8 +74,8 @@ object DockerPlugin extends AutoPlugin {
     dockerRepository := None,
     dockerUsername := None,
     dockerAlias := DockerAlias(
-      dockerRepository.value,
-      dockerUsername.value,
+      (dockerRepository in Docker).value,
+      (dockerUsername in Docker).value,
       (packageName in Docker).value,
       Some((version in Docker).value)
     ),


### PR DESCRIPTION
When originally introduced in 885541e8a603273423100c0694e09804ebe654d0 `dockerTarget` used `dockerRepository` and `dockerUsername` defined in the `Docker` scope.

Sometime in the process of `dockerTarget` being refactored and renamed to `dockerTag` and then `dockerAlias`, it was made to use the value from `dockerRepository` from the global scope instead of the docker scope. ie, defining 

```
dockerRepository in Docker := "my-custom-repository"
dockerUsername in Docker := "john"
```
used to work, but now has no effect, as shown by looking up the value of dockerAlias:

```
sbt:test-docker> docker:dockerAlias
[info] DockerAlias(None,None,test-docker,Some(0.0.0-SNAPSHOT))
```

Instead one must define them globally

```
dockerRepository := "my-custom-repository"
dockerUsername := "john"
```

```
sbt:test-docker> docker:dockerAlias
[info] DockerAlias(Some(my-custom-repository/john,None,test-docker,Some(0.0.0-SNAPSHOT))
```

I believe this was unintentional, and there's a [fair amount of code out there](https://github.com/search?l=Scala&q=%22dockerRepository+in+Docker%22&type=Code&utf8=%E2%9C%93) still using the `Docker` scope for `dockerRepository`. This change reverts back to using the `Docker` scope for `dockerRepository` and `dockerUsername` when determining the docker alias. This change should be backwards-compatible as defining dockerRepository or dockerUsername on the `Global` scope means it's also inherited by  the `Docker` scope.

Tested locally by defining `dockerRepository` both with no scope and with the `Docker` scope in a build file and examining the value of `docker:dockerAlias`. Happy to add a scripted test if required.