### PR TITLE
Give an absolute path to the entrypoint

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -80,7 +80,7 @@ object DockerPlugin extends AutoPlugin {
       Some((version in Docker).value)
     ),
     dockerUpdateLatest := false,
-    dockerEntrypoint := Seq("bin/%s" format executableScriptName.value),
+    dockerEntrypoint := Seq(s"${(defaultLinuxInstallLocation in Docker).value}/bin/${executableScriptName.value}"),
     dockerCmd := Seq(),
     dockerExecCommand := Seq("docker"),
     dockerVersion := Try(Process(dockerExecCommand.value ++ Seq("version", "--format", "'{{.Server.Version}}'")).!!).toOption

--- a/src/sbt-test/docker/test-executableScriptName/build.sbt
+++ b/src/sbt-test/docker/test-executableScriptName/build.sbt
@@ -13,8 +13,8 @@ maintainer := "Gary Coady <gary@lyranthe.org>"
 TaskKey[Unit]("checkDockerfile") := {
   val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
   assert(
-    dockerfile.contains("ENTRYPOINT [\"bin/docker-exec\"]\n"),
-    "dockerfile doesn't contain ENTRYPOINT [\"docker-exec\"]\n" + dockerfile
+    dockerfile.contains("ENTRYPOINT [\"/opt/docker/bin/docker-exec\"]\n"),
+    "dockerfile doesn't contain ENTRYPOINT [\"/opt/docker/bin/docker-test\"]\n" + dockerfile
   )
   streams.value.log.success("Successfully tested control script")
   ()

--- a/src/sbt-test/docker/test-packageName-universal/build.sbt
+++ b/src/sbt-test/docker/test-packageName-universal/build.sbt
@@ -11,8 +11,8 @@ maintainer := "Gary Coady <gary@lyranthe.org>"
 TaskKey[Unit]("checkDockerfile") := {
   val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
   assert(
-    dockerfile.contains("ENTRYPOINT [\"bin/docker-test\"]\n"),
-    "dockerfile doesn't contain ENTRYPOINT [\"docker-test\"]\n" + dockerfile
+    dockerfile.contains("ENTRYPOINT [\"/opt/docker/bin/docker-test\"]\n"),
+    "dockerfile doesn't contain ENTRYPOINT [\"/opt/docker/bin/docker-test\"]\n" + dockerfile
   )
   streams.value.log.success("Successfully tested control script")
   ()

--- a/src/sbt-test/docker/test-packageName/build.sbt
+++ b/src/sbt-test/docker/test-packageName/build.sbt
@@ -12,8 +12,8 @@ maintainer := "Gary Coady <gary@lyranthe.org>"
 TaskKey[Unit]("checkDockerfile") := {
   val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
   assert(
-    dockerfile.contains("ENTRYPOINT [\"bin/docker-test\"]\n"),
-    "dockerfile doesn't contain ENTRYPOINT [\"docker-test\"]\n" + dockerfile
+    dockerfile.contains("ENTRYPOINT [\"/opt/docker/bin/docker-test\"]\n"),
+    "dockerfile doesn't contain ENTRYPOINT [\"/opt/docker/bin/docker-test\"]\n" + dockerfile
   )
   streams.value.log.success("Successfully tested control script")
   ()


### PR DESCRIPTION
We sometimes need to change the the WORKDIR, and when we do the ENTRYPOINT becomes invalid.
In general it's good to use absolute paths unless things are sementicaly tied to each other, which is not the case of ENTRYPOINT regarding WORKDIR