### PR TITLE
Fix docker server version parsing

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerVersion.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerVersion.scala
@@ -5,7 +5,7 @@ import scala.util.matching.Regex
 case class DockerVersion(major: Int, minor: Int, patch: Int, release: Option[String])
 
 object DockerVersion {
-  private val DockerVersionPattern: Regex = "^'?([0-9]+).([0-9]+).([0-9]+)-?([-a-z]+)?'?$".r
+  private val DockerVersionPattern: Regex = "^'?([0-9]+).([0-9]+).([0-9]+)-?([-a-z0-9]+)?'?$".r
 
   def parse(version: String): Option[DockerVersion] =
     Option(version).collect {


### PR DESCRIPTION
Add support for numbers in the release version. This allows version
detection to parse server version of the form '18.03.0-ce-rc3'.