### PR TITLE
fixed Java version check in bash template

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -276,16 +276,22 @@ java_version_check() {
     echo Please go to http://www.java.com/getjava/ and download
     echo
     exit 1
-  elif [[ ! "$java_version" > "1.6" ]]; then
-    echo
-    echo The java installation you have is not up to date
-    echo $app_name requires at least version 1.6+, you have
-    echo version $java_version
-    echo
-    echo Please go to http://www.java.com/getjava/ and download
-    echo a valid Java Runtime and install before running $app_name.
-    echo
-    exit 1
+  else
+    local major=$(echo "$java_version" | cut -d'.' -f1)
+    if [[ "$major" -eq "1" ]]; then
+     local major=$(echo "$java_version" | cut -d'.' -f2)
+    fi
+    if [[ "$major" -lt "6" ]]; then
+      echo
+      echo The java installation you have is not up to date
+      echo $app_name requires at least version 1.6+, you have
+      echo version $java_version
+      echo
+      echo Please go to http://www.java.com/getjava/ and download
+      echo a valid Java Runtime and install before running $app_name.
+      echo
+      exit 1
+    fi
   fi
 }
 

--- a/src/sbt-test/docker/jdk-versions/build.sbt
+++ b/src/sbt-test/docker/jdk-versions/build.sbt
@@ -1,6 +1,6 @@
 val basename = "jdk-versions"
 
-scalacOptions in ThisBuild := Seq("-target:jvm-1.8")
+scalacOptions in ThisBuild in (Compile, compile) := Seq("-target:jvm-1.8")
 
 lazy val `jdk8` = project
   .in(file("jdk8"))

--- a/src/sbt-test/docker/jdk-versions/build.sbt
+++ b/src/sbt-test/docker/jdk-versions/build.sbt
@@ -1,0 +1,31 @@
+val basename = "jdk-versions"
+
+scalacOptions in ThisBuild := Seq("-target:jvm-1.8")
+
+lazy val `jdk8` = project
+  .in(file("jdk8"))
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := basename + "-8",
+    dockerBaseImage := "openjdk:8u162-jre",
+    dockerBuildOptions := dockerBuildOptions.value ++ Seq("-t", "jdk-versions:8")
+  )
+
+lazy val `jdk9` = project
+  .in(file("jdk9"))
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := basename + "-9",
+    dockerBaseImage := "openjdk:9.0.4-jre",
+    dockerBuildOptions := dockerBuildOptions.value ++ Seq("-t", "jdk-versions:9")
+  )
+
+lazy val `jdk10` = project
+  .in(file("jdk10"))
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := basename + "-10",
+    dockerBaseImage := "openjdk:10-jre",
+    dockerBuildOptions := dockerBuildOptions.value ++ Seq("-t", "jdk-versions:10")
+  )
+

--- a/src/sbt-test/docker/jdk-versions/jdk10/src/main/scala/Hello.scala
+++ b/src/sbt-test/docker/jdk-versions/jdk10/src/main/scala/Hello.scala
@@ -1,0 +1,3 @@
+object Hello extends App {
+  println("Hello JDK10!")
+}

--- a/src/sbt-test/docker/jdk-versions/jdk8/src/main/scala/Hello.scala
+++ b/src/sbt-test/docker/jdk-versions/jdk8/src/main/scala/Hello.scala
@@ -1,0 +1,3 @@
+object Hello extends App {
+  println("Hello JDK8!")
+}

--- a/src/sbt-test/docker/jdk-versions/jdk9/src/main/scala/Hello.scala
+++ b/src/sbt-test/docker/jdk-versions/jdk9/src/main/scala/Hello.scala
@@ -1,0 +1,3 @@
+object Hello extends App {
+  println("Hello JDK9!")
+}

--- a/src/sbt-test/docker/jdk-versions/project/plugins.sbt
+++ b/src/sbt-test/docker/jdk-versions/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+

--- a/src/sbt-test/docker/jdk-versions/test
+++ b/src/sbt-test/docker/jdk-versions/test
@@ -1,0 +1,9 @@
+> project jdk8
+> docker:publishLocal
+$ exec bash -c 'docker run --rm jdk-versions:8 | grep -q "Hello JDK8!"'
+> project jdk9
+> docker:publishLocal
+$ exec bash -c 'docker run --rm jdk-versions:9 | grep -q "Hello JDK9!"'
+> project jdk10
+> docker:publishLocal
+$ exec bash -c 'docker run --rm jdk-versions:10 | grep -q "Hello JDK10!"'


### PR DESCRIPTION
The current Java version check in 'bash-template' relies on a string comparison for numbers.
As far as I could investigate this check fails at least for bash 4.3.48 on a xenial/sid based docker images.

It fails for the latest JDK release 10, as "10" is not greater than "1.6" when compared as string in bash.
Later bash version seem to treat this check differently.

I changed the version check to compare numbers. For versions 1.x.y, the check extracts the minor version "x" and compares agains "6". If the major version is unequal to "1", the major version is compared against "6".

Using docker openjdk images I added scripted test.

Tested with bash 4.3.48 and 4.4.19, docker 17.12.0-ce.