### PR TITLE
Included feature publishM2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,4 +70,5 @@ cache:
  apt: true
  directories:
  - $HOME/.sbt
+ - $HOME/.m2
  - $HOME/.ivy2

--- a/src/main/scala-sbt-0.13/com/typesafe/sbt/packager/SettingsHelper.scala
+++ b/src/main/scala-sbt-0.13/com/typesafe/sbt/packager/SettingsHelper.scala
@@ -55,7 +55,15 @@ object SettingsHelper {
           checksums = checksums.value,
           logging = UpdateLogging.DownloadOnly,
           overwrite = isSnapshot.value
-        )
+        ),
+        publishM2Configuration := new PublishConfiguration(
+          ivyFile = None,
+          resolverName = Resolver.mavenLocal.name,
+          artifacts = packagedArtifacts.value,
+          checksums = checksums.value,
+          logging = UpdateLogging.DownloadOnly,
+          overwrite = isSnapshot.value
+       )
       )
     ) ++ addPackage(config, packageTask, extension, classifier) ++ addResolver(config)
 

--- a/src/main/scala-sbt-1.0/com/typesafe/sbt/packager/SettingsHelper.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbt/packager/SettingsHelper.scala
@@ -62,6 +62,12 @@ object SettingsHelper {
           .withArtifacts(packagedArtifacts.value.toVector)
           .withChecksums(checksums.value.toVector)
           .withOverwrite(isSnapshot.value)
+          .withLogging(UpdateLogging.DownloadOnly),
+        publishM2Configuration := PublishConfiguration()
+          .withResolverName(Resolver.mavenLocal.name)
+          .withArtifacts(packagedArtifacts.value.toVector)
+          .withChecksums(checksums.value.toVector)
+          .withOverwrite(isSnapshot.value)
           .withLogging(UpdateLogging.DownloadOnly)
       )
     ) ++ addPackage(config, packageTask, extension, classifier) ++ addResolver(config)

--- a/src/sbt-test/universal/publish/build.sbt
+++ b/src/sbt-test/universal/publish/build.sbt
@@ -9,5 +9,6 @@ lazy val testResolver =
 
 // Workaround for ivy configuration bug
 resolvers += testResolver
+resolvers += Resolver.mavenLocal
 
 publishTo in Universal := Some(testResolver)

--- a/src/sbt-test/universal/publish/build.sbt
+++ b/src/sbt-test/universal/publish/build.sbt
@@ -11,4 +11,7 @@ lazy val testResolver =
 resolvers += testResolver
 resolvers += Resolver.mavenLocal
 
+// Workaround for overwriting packages at .m2 directory
+isSnapshot in ThisBuild := true
+
 publishTo in Universal := Some(testResolver)

--- a/src/sbt-test/universal/publish/test
+++ b/src/sbt-test/universal/publish/test
@@ -2,3 +2,5 @@
 > universal:publish
 # Ensure isSnpashot works correctly
 > universal:publish
+# Ensure we can publish to local maven repository.
+> universal:publishM2


### PR DESCRIPTION
# Feature request - publishM2

It's a small change including a publishM2 action. Currently the sbt-native-packages only supports`publish` and `publishLocal` actions. 

## Tested on

- **O.S.:** MacOSX, Darwin <host> 17.4.0 Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64 x86_64
- **bash:** GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin17)
- **sbt:** 1.1.1
- **scala:** Scala code runner version 2.12.5 -- Copyright 2002-2018, LAMP/EPFL and Lightbend, Inc
- **java jdk:** java version "1.8.0_162",Java(TM) SE Runtime Environment (build 1.8.0_162-b12), Java HotSpot(TM) 64-Bit Server VM (build 25.162-b12, mixed mode)