### PR TITLE
Change openjdk:latest to openjdk:8.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -66,7 +66,7 @@ object DockerPlugin extends AutoPlugin {
   override def projectConfigurations: Seq[Configuration] = Seq(Docker)
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    dockerBaseImage := "openjdk:latest",
+    dockerBaseImage := "openjdk:8",
     dockerExposedPorts := Seq(),
     dockerExposedUdpPorts := Seq(),
     dockerExposedVolumes := Seq(),

--- a/src/sbt-test/docker/override-commands/build.sbt
+++ b/src/sbt-test/docker/override-commands/build.sbt
@@ -9,7 +9,7 @@ maintainer := "Gary Coady <gary@lyranthe.org>"
 
 dockerUpdateLatest := true
 dockerCommands := Seq(
-  Cmd("FROM", "openjdk:latest"),
+  Cmd("FROM", "openjdk:8"),
   Cmd("LABEL", s"""MAINTAINER="${maintainer.value}""""),
   ExecCmd("CMD", "echo", "Hello, World from Docker")
 )

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -243,7 +243,7 @@ In your sbt console type
 .. code-block:: bash
 
     > show dockerCommands
-    [info] List(Cmd(FROM,openjdk:latest), Cmd(LABEL,MAINTAINER=Your Name <y.n@yourcompany.com>), ...)
+    [info] List(Cmd(FROM,openjdk:8), Cmd(LABEL,MAINTAINER=Your Name <y.n@yourcompany.com>), ...)
 
 
 
@@ -311,7 +311,7 @@ Now let's start adding some Docker commands.
   import com.typesafe.sbt.packager.docker._
 
   dockerCommands := Seq(
-    Cmd("FROM", "openjdk:latest"),
+    Cmd("FROM", "openjdk:8"),
     Cmd("LABEL", s"""MAINTAINER="${maintainer.value}""""),
     ExecCmd("CMD", "echo", "Hello, World from Docker")
   )


### PR DESCRIPTION
Because the latest version of openjdk has moved to Java 10, which is not fully compatible with Scala.

This resolves https://github.com/sbt/sbt-native-packager/issues/1146