### PR TITLE
Add kill timeout to SystemD service as TimeoutStopSec

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemd/start-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/systemloader/systemd/start-template
@@ -11,6 +11,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=always
 RestartSec=${{retryTimeout}}
 SuccessExitStatus=${{SuccessExitStatus}}
+TimeoutStopSec=${{TimeoutStopSec}}
 User=${{daemon_user}}
 ExecStartPre=/bin/mkdir -p /run/${{app_name}}
 ExecStartPre=/bin/chown ${{daemon_user}}:${{daemon_group}} /run/${{app_name}}

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemdPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemdPlugin.scala
@@ -4,6 +4,7 @@ import sbt._
 import sbt.Keys.{sourceDirectory, target}
 import com.typesafe.sbt.packager.Keys.{
   defaultLinuxStartScriptLocation,
+  killTimeout,
   linuxMakeStartScript,
   linuxPackageMappings,
   linuxScriptReplacements,
@@ -58,7 +59,8 @@ object SystemdPlugin extends AutoPlugin {
       isConf = true
     ),
     // add additional system configurations to script replacements
-    linuxScriptReplacements += ("SuccessExitStatus" -> systemdSuccessExitStatus.value.mkString(" "))
+    linuxScriptReplacements += ("SuccessExitStatus" -> systemdSuccessExitStatus.value.mkString(" ")),
+    linuxScriptReplacements += ("TimeoutStopSec" -> killTimeout.value.toString)
   )
 
   def debianSettings: Seq[Setting[_]] = inConfig(Debian)(defaultLinuxStartScriptLocation := "/lib/systemd/system")


### PR DESCRIPTION
We noticed the `killTimeout` `SettingKey` wasn't being used by the SystemD template. We've added it in similarly to how `SuccessExitStatus` was added

Co-authored-by: Andrew Smitherim <andrew.smitherim@gmail.com>