### PR TITLE
Improve the GraalVM native-image documentation

### DIFF
--- a/src/sphinx/formats/graalvm-native-image.rst
+++ b/src/sphinx/formats/graalvm-native-image.rst
@@ -12,6 +12,17 @@ Requirements
 
 You must have ``native-image`` of GraalVM in your ``PATH``.
 
+Quick installation
+~~~~~~~~~~~~~~~~~~
+
+To get started quickly, eg make ``native-image`` available in your ``PATH``,
+you may reuse the script that is used for sbt-native-packager's continuous integration.
+To do so, run the following. It will install GraalVM 1.0.0-rc8.
+
+.. code-block:: bash
+
+  source <(curl -o - https://raw.githubusercontent.com/sbt/sbt-native-packager/6e1ee230350ce86c37b39c75f35718ac4a7f0a26/.travis/download-graalvm)
+
 Build
 -----
 

--- a/src/sphinx/formats/index.rst
+++ b/src/sphinx/formats/index.rst
@@ -10,12 +10,12 @@ existing functionality. Currently the autoplugin hierarchy looks like this ::
                   +
                   |
                   |
-    +-------+  Universal  +--------+-------------+
-    |             +                |             |
-    |             |                |             |
-    |             |                |             |
-    +             +                +             +
-  Docker    +-+ Linux +-+       Windows     JDKPackager
+    +-------+  Universal  +--------+-------------+----------------+
+    |             +                |             |                |
+    |             |                |             |                |
+    |             |                |             |                |
+    +             +                +             +                +
+  Docker    +-+ Linux +-+       Windows     JDKPackager   GraalVM native-image
             |           |
             |           |
             +           +
@@ -49,3 +49,4 @@ To learn more about a specific plugin, read the appropriate doc.
    docker.rst
    windows.rst
    jdkpackager.rst
+   graalvm-native-image.rst


### PR DESCRIPTION
1. I was unable to see the documentation in the table of contents
2. GraalVM native-image plugin should be in the diagram
3. Added quickstart steps for GraalVM by reusing our Travis installer.

May need to update the URL inside of it depending on whether there're changes in #1166 - best merged only after.