### PR TITLE
Update scaladoc in contentOf to match method signature

### DIFF
--- a/src/main/scala-sbt-1.0/com/typesafe/sbt/packager/MappingsHelper.scala
+++ b/src/main/scala-sbt-1.0/com/typesafe/sbt/packager/MappingsHelper.scala
@@ -25,7 +25,7 @@ object MappingsHelper extends Mapper {
     *
     * @example
     * {{{
-    * mappings in Universal ++= sourceDir("extra")
+    * mappings in Universal ++= contentOf("extra")
     * }}}
     *
     * @param sourceDir as string representation


### PR DESCRIPTION
This PR updates the scaladoc for `contentOf` method to use the same signature as the code. 