### PR TITLE
Run stage0 as root during Docker build

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -124,8 +124,8 @@ object DockerPlugin extends AutoPlugin {
           Seq(
             makeFromAs(base, stage0name),
             makeWorkdir(dockerBaseDirectory),
-            makeUserAdd(user, uid, gid),
             makeCopy(dockerBaseDirectory),
+            makeUser("root"),
             makeChmod(dockerChmodType.value, Seq(dockerBaseDirectory)),
             DockerStageBreak
           )
@@ -336,6 +336,13 @@ object DockerPlugin extends AutoPlugin {
       groupId.toString,
       daemonUser
     )
+
+  /**
+    * @param daemonUser
+    * @return USER docker command
+    */
+  private final def makeUser(daemonUser: String): CmdLike =
+    Cmd("USER", daemonUser)
 
   /**
     * @param userId userId of the daemon user

--- a/src/sbt-test/docker/file-permission/build.sbt
+++ b/src/sbt-test/docker/file-permission/build.sbt
@@ -13,13 +13,13 @@ lazy val root = (project in file("."))
       val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
       val lines = dockerfile.linesIterator.toList
       assertEquals(lines,
-        """FROM openjdk:8 as stage0
+        """FROM fabric8/java-centos-openjdk8-jdk as stage0
           |WORKDIR /opt/docker
-          |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
           |COPY opt /opt
+          |USER root
           |RUN ["chmod", "-R", "u=rX,g=rX", "/opt/docker"]
           |
-          |FROM openjdk:8
+          |FROM fabric8/java-centos-openjdk8-jdk
           |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
           |WORKDIR /opt/docker
           |COPY --from=stage0 --chown=daemon:root /opt/docker /opt/docker
@@ -32,7 +32,7 @@ lazy val root = (project in file("."))
       val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
       val lines = dockerfile.linesIterator.toList
       assertEquals(lines,
-        """FROM openjdk:8
+        """FROM fabric8/java-centos-openjdk8-jdk
           |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
           |WORKDIR /opt/docker
           |COPY opt /opt
@@ -59,7 +59,7 @@ lazy val root = (project in file("."))
       val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
       val lines = dockerfile.linesIterator.toList
       assertEquals(lines,
-        """FROM openjdk:8
+        """FROM fabric8/java-centos-openjdk8-jdk
           |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
           |WORKDIR /opt/docker
           |COPY --chown=daemon:root opt /opt
@@ -72,13 +72,13 @@ lazy val root = (project in file("."))
       val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
       val lines = dockerfile.linesIterator.toList
       assertEquals(lines,
-        """FROM openjdk:8 as stage0
+        """FROM fabric8/java-centos-openjdk8-jdk as stage0
           |WORKDIR /opt/docker
-          |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
           |COPY opt /opt
+          |USER root
           |RUN ["chmod", "-R", "u=rwX,g=rwX", "/opt/docker"]
           |
-          |FROM openjdk:8
+          |FROM fabric8/java-centos-openjdk8-jdk
           |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
           |WORKDIR /opt/docker
           |COPY --from=stage0 --chown=daemon:root /opt/docker /opt/docker

--- a/src/sbt-test/docker/file-permission/change.sbt
+++ b/src/sbt-test/docker/file-permission/change.sbt
@@ -1,0 +1,1 @@
+dockerBaseImage := "fabric8/java-centos-openjdk8-jdk"

--- a/src/sbt-test/docker/file-permission/changes/strategy-copychown.sbt
+++ b/src/sbt-test/docker/file-permission/changes/strategy-copychown.sbt
@@ -1,3 +1,4 @@
 import com.typesafe.sbt.packager.docker._
 
 dockerPermissionStrategy := DockerPermissionStrategy.CopyChown
+dockerBaseImage          := "fabric8/java-centos-openjdk8-jdk"

--- a/src/sbt-test/docker/file-permission/changes/strategy-none.sbt
+++ b/src/sbt-test/docker/file-permission/changes/strategy-none.sbt
@@ -1,3 +1,4 @@
 import com.typesafe.sbt.packager.docker._
 
 dockerPermissionStrategy := DockerPermissionStrategy.None
+dockerBaseImage          := "fabric8/java-centos-openjdk8-jdk"

--- a/src/sbt-test/docker/file-permission/changes/write-execute.sbt
+++ b/src/sbt-test/docker/file-permission/changes/write-execute.sbt
@@ -2,3 +2,4 @@ import com.typesafe.sbt.packager.docker._
 
 dockerPermissionStrategy := DockerPermissionStrategy.MultiStage
 dockerChmodType          := DockerChmodType.UserGroupWriteExecute
+dockerBaseImage          := "fabric8/java-centos-openjdk8-jdk"


### PR DESCRIPTION
Fixes #1195

Since the user of the fabric8 image is already non-root, stage0 fails with

```
chmod: changing permissions of '/opt/docker': Operation not permitted
```

This switches the stage0 user to root explicitly so we can run `chmod` in there. In the actual image the user is set back to 1001.