### PR TITLE
Fix USER switching in Docker

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -148,7 +148,7 @@ object DockerPlugin extends AutoPlugin {
         dockerEnvVars.value.map(makeEnvVar) ++
         makeExposePorts(dockerExposedPorts.value, dockerExposedUdpPorts.value) ++
         makeVolumes(dockerExposedVolumes.value, user, group) ++
-        Seq(makeUser(uid), makeEntrypoint(dockerEntrypoint.value), makeCmd(dockerCmd.value))
+        Seq(makeUser(user), makeEntrypoint(dockerEntrypoint.value), makeCmd(dockerCmd.value))
 
       stage0 ++ stage1
     }


### PR DESCRIPTION
Refers #1198.

In attempting to switch to the `daemonUser` we are instead switching to the hardcoded uid 1001. If the daemon user exists with a different uid then the docker container default user is incorrect. Correcting the `makeUser` function to switch to the username specified by `daemonUser` instead of the static uid.