### PR TITLE
Use daemonUserUid to opt-out of numeric USER

### DIFF
--- a/src/sbt-test/docker/file-permission/build.sbt
+++ b/src/sbt-test/docker/file-permission/build.sbt
@@ -20,9 +20,10 @@ lazy val root = (project in file("."))
           |RUN ["chmod", "-R", "u=rX,g=rX", "/opt/docker"]
           |
           |FROM fabric8/java-centos-openjdk8-jdk
-          |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
+          |USER root
+          |RUN id -u demiourgos728 2> /dev/null || useradd --system --create-home --uid 1001 --gid 0 demiourgos728
           |WORKDIR /opt/docker
-          |COPY --from=stage0 --chown=daemon:root /opt/docker /opt/docker
+          |COPY --from=stage0 --chown=demiourgos728:root /opt/docker /opt/docker
           |USER 1001
           |ENTRYPOINT ["/opt/docker/bin/file-permission-test"]
           |CMD []""".stripMargin.linesIterator.toList)
@@ -33,7 +34,8 @@ lazy val root = (project in file("."))
       val lines = dockerfile.linesIterator.toList
       assertEquals(lines,
         """FROM fabric8/java-centos-openjdk8-jdk
-          |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
+          |USER root
+          |RUN id -u demiourgos728 2> /dev/null || useradd --system --create-home --uid 1001 --gid 0 demiourgos728
           |WORKDIR /opt/docker
           |COPY opt /opt
           |USER 1001
@@ -46,7 +48,8 @@ lazy val root = (project in file("."))
       val lines = dockerfile.linesIterator.toList
       assertEquals(lines,
         """FROM openjdk:8
-          |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
+          |USER root
+          |RUN id -u demiourgos728 2> /dev/null || useradd --system --create-home --uid 1001 --gid 0 demiourgos728
           |WORKDIR /opt/docker
           |COPY opt /opt
           |RUN ["chmod", "-R", "u=rX,g=rX", "/opt/docker"]
@@ -60,10 +63,9 @@ lazy val root = (project in file("."))
       val lines = dockerfile.linesIterator.toList
       assertEquals(lines,
         """FROM fabric8/java-centos-openjdk8-jdk
-          |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
           |WORKDIR /opt/docker
           |COPY --chown=daemon:root opt /opt
-          |USER 1001
+          |USER daemon
           |ENTRYPOINT ["/opt/docker/bin/file-permission-test"]
           |CMD []""".stripMargin.linesIterator.toList)
     },
@@ -79,9 +81,10 @@ lazy val root = (project in file("."))
           |RUN ["chmod", "-R", "u=rwX,g=rwX", "/opt/docker"]
           |
           |FROM fabric8/java-centos-openjdk8-jdk
-          |RUN id -u daemon || useradd --system --create-home --uid 1001 --gid 0 daemon
+          |USER root
+          |RUN id -u demiourgos728 2> /dev/null || useradd --system --create-home --uid 1001 --gid 0 demiourgos728
           |WORKDIR /opt/docker
-          |COPY --from=stage0 --chown=daemon:root /opt/docker /opt/docker
+          |COPY --from=stage0 --chown=demiourgos728:root /opt/docker /opt/docker
           |USER 1001
           |ENTRYPOINT ["/opt/docker/bin/file-permission-test"]
           |CMD []""".stripMargin.linesIterator.toList)

--- a/src/sbt-test/docker/file-permission/changes/strategy-copychown.sbt
+++ b/src/sbt-test/docker/file-permission/changes/strategy-copychown.sbt
@@ -2,3 +2,7 @@ import com.typesafe.sbt.packager.docker._
 
 dockerPermissionStrategy := DockerPermissionStrategy.CopyChown
 dockerBaseImage          := "fabric8/java-centos-openjdk8-jdk"
+
+// opt-out of numeric USER
+daemonUserUid in Docker  := None
+daemonUser in Docker     := "daemon"

--- a/src/sbt-test/docker/volumes/test
+++ b/src/sbt-test/docker/volumes/test
@@ -1,5 +1,5 @@
 # Stage the distribution and ensure files show up.
 > docker:stage
 $ exec grep -q -F 'VOLUME ["/opt/docker/logs", "/opt/docker/config"]' target/docker/stage/Dockerfile
-$ exec grep -q -F 'RUN ["chown", "-R", "daemon:root", "/opt/docker/logs", "/opt/docker/config"]' target/docker/stage/Dockerfile
+$ exec grep -q -F 'RUN ["chown", "-R", "demiourgos728:root", "/opt/docker/logs", "/opt/docker/config"]' target/docker/stage/Dockerfile
 $ exec grep -q -F 'RUN ["mkdir", "-p", "/opt/docker/logs", "/opt/docker/config"]' target/docker/stage/Dockerfile

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -246,6 +246,17 @@ The files from ``mappings in Docker`` are extracted underneath this directory.
 
   defaultLinuxInstallLocation in Docker := "/opt/docker"
 
+Daemon User
+~~~~~~~~~~~
+By default, sbt Native Packager will create a daemon user named ``demiourgos728``
+whose UID is set to ``1001``, and and emit ``USER 1001`` since running as non-root is considered the best practice.
+
+The following can be used to emit ``USER daemon`` instead:
+
+.. code-block:: scala
+
+    daemonUserUid in Docker := None
+    daemonUser in Docker    := "daemon"
 
 File Permission
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fixes #1198

Numeric USER directive is now controlled using `daemonUserUid in Docker`, which defaults to `Some("1001")`.

To get back to previous behavior the following can be used:

```scala
daemonUserUid in Docker := None
daemonUser in Docker    := "daemon"
```
