### PR TITLE
Don't write RPM standard output as error

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -105,7 +105,8 @@ object RpmHelper {
         else Seq.empty
       ) ++ Seq(spec.meta.name + ".spec")
       log.debug("Executing rpmbuild with: " + args.mkString(" "))
-      (sys.process.Process(args, Some(specsDir)) ! log) match {
+      (sys.process.Process(args, Some(specsDir)) ! sys.process
+        .ProcessLogger(o => log.info(o), e => log.error(e))) match {
         case 0 => ()
         case code =>
           sys.error("Unable to run rpmbuild, check output for details. Errorcode " + code)


### PR DESCRIPTION
Currently stdout for building an RPM gets output at error level. 

```
[error] + umask 022
[error] + cd /home/david/test/target/rpm/BUILD
[error] + /bin/rm -rf /home/david/test/target/rpm/buildroot
[error] + exit 0
```