### PR TITLE
Add a simple jlink wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,10 @@ jobs:
       if: type = pull_request OR (type = push AND branch = master)
       # docker configuration as described in
       # https://docs.travis-ci.com/user/docker/
+    - script: sbt "^validateJlink"
+      name: "scripted jlink tests"
+      jdk: oraclejdk11
+      if: type = pull_request OR (type = push AND branch = master)
     - script: sbt "^validateDocker"
       name: "scripted docker integration-tests"
       if: type = pull_request OR (type = push AND branch = master)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ different archetypes for common configurations, such as simple Java apps or serv
     * Systemv
     * Upstart
 * Java8 [jdkpackager][] wrapper
+* Java11 [jlink][] wrapper
 * Optional JDeb integration for cross-platform Debian builds
 * Optional Spotify docker client integration
 
@@ -134,6 +135,7 @@ or provide a richer API for a single packaging format.
 [Java server application]: http://www.scala-sbt.org/sbt-native-packager/archetypes/java_server/index.html
 [My First Packaged Server Project guide]: http://www.scala-sbt.org/sbt-native-packager/GettingStartedServers/MyFirstProject.html
 [jdkpackager]: http://www.scala-sbt.org/sbt-native-packager/formats/jdkpackager.html
+[jlink]: https://docs.oracle.com/en/java/javase/11/tools/jlink.html
 
 ## Maintainers ##
 

--- a/build.sbt
+++ b/build.sbt
@@ -125,4 +125,6 @@ addCommandAlias("validateOSX", "; validate ; validateUniversal")
 // TODO check the cygwin scripted tests and run them on appveyor
 addCommandAlias("validateWindows", "; testOnly * -- -n windows ; scripted universal/dist universal/stage windows/*")
 
+addCommandAlias("validateJlink", "scripted jlink/*")
+
 addCommandAlias("releaseFromTravis", "release with-defaults")

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -43,6 +43,17 @@ loadConfigFile() {
   cat "$1" | sed '/^\#/d;s/\r$//' | sed 's/^-J-X/-X/' | tr '\r\n' ' '
 }
 
+# Detect which JVM we should use.
+get_java_cmd() {
+  # High-priority override for Jlink images
+  if [ -n "$bundled_jvm" ];  then
+    echo "$bundled_jvm/bin/java"
+  elif [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/java" ];  then
+    echo "$JAVA_HOME/bin/java"
+  else
+    echo "java"
+  fi
+}
 
 real_script_path="$(realpath "$0")"
 app_home="$(realpath "$(dirname "$real_script_path")")"
@@ -52,7 +63,9 @@ app_mainclass=${{app_mainclass}}
 
 ${{template_declares}}
 
+declare -r java_cmd=$(get_java_cmd)
+
 # If a configuration file exist, read the contents to $opts
 [ -f "$script_conf_file" ] && opts=$(loadConfigFile "$script_conf_file")
 
-exec java $java_opts -classpath $app_classpath $opts $app_mainclass "$@"
+exec "$java_cmd" $java_opts -classpath $app_classpath $opts $app_mainclass "$@"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -63,7 +63,7 @@ app_mainclass=${{app_mainclass}}
 
 ${{template_declares}}
 
-declare -r java_cmd=$(get_java_cmd)
+java_cmd="$(get_java_cmd)"
 
 # If a configuration file exist, read the contents to $opts
 [ -f "$script_conf_file" ] && opts=$(loadConfigFile "$script_conf_file")

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -103,7 +103,10 @@ fix_classpath() {
 }
 # Detect if we should use JAVA_HOME or just try PATH.
 get_java_cmd() {
-  if [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
+  # High-priority override for Jlink images
+  if [[ -n "$bundled_jvm" ]];  then
+    echo "$bundled_jvm/bin/java"
+  elif [[ -n "$JAVA_HOME" ]] && [[ -x "$JAVA_HOME/bin/java" ]];  then
     echo "$JAVA_HOME/bin/java"
   else
     echo "java"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -6,6 +6,7 @@
 @REM Configuration:
 @REM @@APP_ENV_NAME@@_config.txt found in the @@APP_ENV_NAME@@_HOME.
 @setlocal enabledelayedexpansion
+@setlocal enableextensions
 
 @echo off
 
@@ -30,12 +31,27 @@ set "CFG_FILE=%APP_HOME%\@@APP_ENV_NAME@@_config.txt"
 set CFG_OPTS=
 call :parse_config "%CFG_FILE%" CFG_OPTS
 
-rem We use the value of the JAVACMD environment variable if defined
-set _JAVACMD=%JAVACMD%
+rem We use the value of the JAVA_OPTS environment variable if defined, rather than the config.
+set _JAVA_OPTS=%JAVA_OPTS%
+if "!_JAVA_OPTS!"=="" set _JAVA_OPTS=!CFG_OPTS!
 
-if "%_JAVACMD%"=="" (
-  if not "%JAVA_HOME%"=="" (
-    if exist "%JAVA_HOME%\bin\java.exe" set "_JAVACMD=%JAVA_HOME%\bin\java.exe"
+rem We keep in _JAVA_PARAMS all -J-prefixed and -D-prefixed arguments
+rem "-J" is stripped, "-D" is left as is, and everything is appended to JAVA_OPTS
+set _JAVA_PARAMS=
+set _APP_ARGS=
+
+@@APP_DEFINES@@
+
+rem Bundled JRE has priority over standard environment variables
+if defined BUNDLED_JVM (
+  set "_JAVACMD=%BUNDLED_JVM%\bin\java.exe"
+) else (
+  if "%JAVACMD%" neq "" (
+    set "_JAVACMD=%JAVACMD%"
+  ) else (
+    if "%JAVA_HOME%" neq "" (
+      if exist "%JAVA_HOME%\bin\java.exe" set "_JAVACMD=%JAVA_HOME%\bin\java.exe"
+    )
   )
 )
 
@@ -69,18 +85,6 @@ if "%JAVAOK%"=="false" (
   if defined DOUBLECLICKED pause
   exit /B 1
 )
-
-
-rem We use the value of the JAVA_OPTS environment variable if defined, rather than the config.
-set _JAVA_OPTS=%JAVA_OPTS%
-if "!_JAVA_OPTS!"=="" set _JAVA_OPTS=!CFG_OPTS!
-
-rem We keep in _JAVA_PARAMS all -J-prefixed and -D-prefixed arguments
-rem "-J" is stripped, "-D" is left as is, and everything is appended to JAVA_OPTS
-set _JAVA_PARAMS=
-set _APP_ARGS=
-
-@@APP_DEFINES@@
 
 rem if configuration files exist, prepend their contents to the script arguments so it can be processed by this runner
 call :parse_config "%SCRIPT_CONF_FILE%" SCRIPT_CONF_ARGS

--- a/src/main/scala/com/typesafe/sbt/packager/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Keys.scala
@@ -52,6 +52,7 @@ object Keys
     with rpm.RpmKeys
     with archetypes.JavaAppKeys
     with archetypes.JavaServerAppKeys
+    with archetypes.jlink.JlinkKeys
     with archetypes.systemloader.SystemloaderKeys
     with archetypes.scripts.BashStartScriptKeys
     with archetypes.scripts.BatStartScriptKeys

--- a/src/main/scala/com/typesafe/sbt/packager/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Keys.scala
@@ -51,6 +51,7 @@ object Keys
     with debian.DebianKeys
     with rpm.RpmKeys
     with archetypes.JavaAppKeys
+    with archetypes.JavaAppKeys2
     with archetypes.JavaServerAppKeys
     with archetypes.jlink.JlinkKeys
     with archetypes.systemloader.SystemloaderKeys

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
@@ -26,4 +26,6 @@ trait JavaAppKeys {
     "scriptClasspath",
     "A list of relative filenames (to the lib/ folder in the distribution) of what to include on the classpath."
   )
+  val bundledJvmLocation =
+    TaskKey[Option[String]]("bundledJvmLocation", "The location of the bundled JVM image")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
@@ -26,6 +26,4 @@ trait JavaAppKeys {
     "scriptClasspath",
     "A list of relative filenames (to the lib/ folder in the distribution) of what to include on the classpath."
   )
-  val bundledJvmLocation =
-    TaskKey[Option[String]]("bundledJvmLocation", "The location of the bundled JVM image")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys2.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys2.scala
@@ -1,0 +1,12 @@
+package com.typesafe.sbt.packager.archetypes
+
+import sbt._
+
+/**
+  * See [[JavaAppKeys]]. These are private to preserve binary compatibility.
+  */
+// TODO: merge with JavaAppKeys when we can break binary compatibility
+private[packager] trait JavaAppKeys2 {
+  val bundledJvmLocation =
+    TaskKey[Option[String]]("bundledJvmLocation", "The location of the bundled JVM image")
+}

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
@@ -34,7 +34,7 @@ object JavaAppPackaging extends AutoPlugin {
     */
   val batTemplate = "bat-template"
 
-  object autoImport extends JavaAppKeys with MaintainerScriptHelper
+  object autoImport extends JavaAppKeys with JavaAppKeys2 with MaintainerScriptHelper
 
   import JavaAppPackaging.autoImport._
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
@@ -71,7 +71,8 @@ object JavaAppPackaging extends AutoPlugin {
       val d = targetDir / installLocation
       d.mkdirs()
       LinuxPackageMapping(Seq(d -> (installLocation + "/" + name)), LinuxFileMetaData())
-    }
+    },
+    bundledJvmLocation := (bundledJvmLocation ?? None).value
   )
 
   private def makeRelativeClasspathNames(mappings: Seq[(File, String)]): Seq[String] =

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
@@ -3,12 +3,10 @@ package jlink
 
 import sbt._
 
-import com.typesafe.sbt.packager.archetypes.jlink._
-
 /**
   * Available settings/tasks for the [[com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin]].
   */
-trait JlinkKeys {
+private[packager] trait JlinkKeys {
 
   val jlinkBundledJvmLocation =
     TaskKey[String]("jlinkBundledJvmLocation", "The location of the resulting JVM image")

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
@@ -1,0 +1,21 @@
+package com.typesafe.sbt.packager.archetypes
+package jlink
+
+import sbt._
+
+import com.typesafe.sbt.packager.archetypes.jlink._
+
+/**
+  * Available settings/tasks for the [[com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin]].
+  */
+trait JlinkKeys {
+
+  val jlinkBundledJvmLocation =
+    TaskKey[String]("jlinkBundledJvmLocation", "The location of the resulting JVM image")
+
+  val jlinkOptions =
+    TaskKey[Seq[String]]("jlinkOptions", "Options for the jlink utility")
+
+  val jlinkBuildImage =
+    TaskKey[File]("jlinkBuildImage", "Runs jlink. Yields the directory with the runtime image")
+}

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -1,0 +1,106 @@
+package com.typesafe.sbt.packager.archetypes
+package jlink
+
+import scala.sys.process.{Process, ProcessBuilder}
+import sbt._
+import sbt.Keys._
+import com.typesafe.sbt.SbtNativePackager.{Debian, Universal}
+import com.typesafe.sbt.packager.Keys.{bundledJvmLocation, packageName}
+import com.typesafe.sbt.packager.Compat._
+import com.typesafe.sbt.packager.archetypes.jlink._
+import com.typesafe.sbt.packager.archetypes.scripts.BashStartScriptKeys
+import com.typesafe.sbt.packager.universal.UniversalPlugin
+
+/**
+  * == Jlink Application ==
+  *
+  * This class contains the default settings for creating and deploying an
+  * application as a runtime image using the standard `jlink` utility.
+  *
+  * == Configuration ==
+  *
+  * This plugin adds new settings to configure your packaged application.
+  * The keys are defined in [[com.typesafe.sbt.packager.archetypes.jlink.JlinkKeys]]
+  *
+  * @example Enable this plugin in your `build.sbt` with
+  *
+  * {{{
+  *  enablePlugins(JlinkPlugin)
+  * }}}
+  */
+object JlinkPlugin extends AutoPlugin {
+
+  object autoImport extends JlinkKeys
+
+  import autoImport._
+
+  override def requires = JavaAppPackaging
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    target in jlinkBuildImage := target.value / "jlink" / "output",
+    jlinkBundledJvmLocation := "jre",
+    bundledJvmLocation := Some(jlinkBundledJvmLocation.value),
+    jlinkOptions := (jlinkOptions ?? Nil).value,
+    jlinkOptions ++= {
+      val log = streams.value.log
+      val run = runJavaTool(javaHome.in(jlinkBuildImage).value, log) _
+
+      val paths = fullClasspath.in(Compile).value.map(_.data.toString)
+      val modules =
+        (run("jdeps", "-R" +: "--print-module-deps" +: paths) !! log).trim
+          .split(",")
+
+      JlinkOptions(addModules = modules, output = Some(target.in(jlinkBuildImage).value))
+    },
+    jlinkBuildImage := {
+      val log = streams.value.log
+      val run = runJavaTool(javaHome.in(jlinkBuildImage).value, log) _
+      val outDir = target.in(jlinkBuildImage).value
+
+      IO.delete(outDir)
+
+      run("jlink", jlinkOptions.value) !! log
+
+      outDir
+    },
+    mappings in jlinkBuildImage := {
+      val prefix = jlinkBundledJvmLocation.value
+      // make sure the prefix has a terminating slash
+      val prefix0 = if (prefix.isEmpty) prefix else (prefix + "/")
+
+      findFiles(jlinkBuildImage.value).map {
+        case (file, string) => (file, prefix0 + string)
+      }
+    },
+    mappings in Universal ++= mappings.in(jlinkBuildImage).value
+  )
+
+  // TODO: deduplicate with UniversalPlugin and DebianPlugin
+  /** Finds all files in a directory. */
+  private def findFiles(dir: File): Seq[(File, String)] =
+    ((PathFinder(dir) ** AllPassFilter) --- dir)
+      .pair(file => IO.relativize(dir, file))
+
+  private def runJavaTool(jvm: Option[File], log: Logger)(exeName: String, args: Seq[String]): ProcessBuilder = {
+    val exe = jvm match {
+      case None     => exeName
+      case Some(jh) => (jh / "bin" / exeName).getAbsolutePath
+    }
+
+    log.info("Running: " + (exe +: args).mkString(" "))
+
+    Process(exe, args)
+  }
+
+  private object JlinkOptions {
+    def apply(addModules: Seq[String] = Nil, output: Option[File] = None): Seq[String] =
+      option("--output", output) ++
+        list("--add-modules", addModules)
+
+    private def option[A](arg: String, value: Option[A]): Seq[String] =
+      value.toSeq.flatMap(a => Seq(arg, a.toString))
+
+    private def list(arg: String, values: Seq[String]): Seq[String] =
+      if (values.nonEmpty) Seq(arg, values.mkString(",")) else Nil
+  }
+}

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -44,7 +44,7 @@ object JlinkPlugin extends AutoPlugin {
       val log = streams.value.log
       val run = runJavaTool(javaHome.in(jlinkBuildImage).value, log) _
 
-      val paths = fullClasspath.in(Compile).value.map(_.data.toString)
+      val paths = fullClasspath.in(Compile).value.map(_.data.getPath)
       val modules =
         (run("jdeps", "-R" +: "--print-module-deps" +: paths) !! log).trim
           .split(",")

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -20,7 +20,6 @@ import com.typesafe.sbt.packager.universal.UniversalPlugin
   * == Configuration ==
   *
   * This plugin adds new settings to configure your packaged application.
-  * The keys are defined in [[com.typesafe.sbt.packager.archetypes.jlink.JlinkKeys]]
   *
   * @example Enable this plugin in your `build.sbt` with
   *

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
@@ -77,7 +77,11 @@ object AshScriptPlugin extends AutoPlugin {
 
   override def projectSettings = Seq(
     bashScriptTemplateLocation := (sourceDirectory.value / "templates" / ashTemplate),
-    bashScriptDefines := Defines((scriptClasspath in bashScriptDefines).value, bashScriptConfigLocation.value),
+    bashScriptDefines := Defines(
+      (scriptClasspath in bashScriptDefines).value,
+      bashScriptConfigLocation.value,
+      bundledJvmLocation.value
+    ),
     bashScriptDefines ++= bashScriptExtraDefines.value
   )
 
@@ -93,8 +97,10 @@ object AshScriptPlugin extends AutoPlugin {
       *                     to include on the classpath.
       * @param configFile An (optional) filename from which the script will read arguments.
       */
-    def apply(appClasspath: Seq[String], configFile: Option[String]): Seq[String] =
-      (configFile map configFileDefine).toSeq ++ Seq(makeClasspathDefine(appClasspath))
+    def apply(appClasspath: Seq[String], configFile: Option[String], bundledJvm: Option[String]): Seq[String] =
+      (configFile map configFileDefine).toSeq ++
+        Seq(makeClasspathDefine(appClasspath)) ++
+        (bundledJvm map bundledJvmDefine).toSeq
 
     private[this] def makeClasspathDefine(cp: Seq[String]): String = {
       val fullString = cp map (
@@ -107,5 +113,8 @@ object AshScriptPlugin extends AutoPlugin {
 
     private[this] def configFileDefine(configFile: String) =
       "script_conf_file=\"%s\"" format (configFile)
+
+    private[this] def bundledJvmDefine(bundledJvm: String) =
+      """bundled_jvm="$(realpath "${app_home}/../%s")"""" format bundledJvm
   }
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
@@ -90,6 +90,10 @@ object AshScriptPlugin extends AutoPlugin {
     */
   object Defines {
 
+    @deprecated("1.3.21", "")
+    def apply(appClasspath: Seq[String], configFile: Option[String]): Seq[String] =
+      apply(appClasspath, configFile, None)
+
     /**
       * Creates the block of defines for a script.
       *

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -104,6 +104,10 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
     */
   object Defines {
 
+    @deprecated("1.3.21", "")
+    def apply(appClasspath: Seq[String], configFile: Option[String]): Seq[String] =
+      apply(appClasspath, configFile, None)
+
     /**
       * Creates the block of defines for a script.
       *

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -55,7 +55,11 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
   override def projectSettings: Seq[Setting[_]] = Seq(
     bashScriptTemplateLocation := (sourceDirectory.value / "templates" / bashTemplate),
     bashScriptExtraDefines := Nil,
-    bashScriptDefines := Defines((scriptClasspath in bashScriptDefines).value, bashScriptConfigLocation.value),
+    bashScriptDefines := Defines(
+      (scriptClasspath in bashScriptDefines).value,
+      bashScriptConfigLocation.value,
+      bundledJvmLocation.value
+    ),
     bashScriptDefines ++= bashScriptExtraDefines.value,
     bashScriptReplacements := generateScriptReplacements(bashScriptDefines.value),
     // Create a bashConfigLocation if options are set in build.sbt
@@ -107,8 +111,10 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
       *                     to include on the classpath.
       * @param configFile An (optional) filename from which the script will read arguments.
       */
-    def apply(appClasspath: Seq[String], configFile: Option[String]): Seq[String] =
-      (configFile map configFileDefine).toSeq ++ Seq(makeClasspathDefine(appClasspath))
+    def apply(appClasspath: Seq[String], configFile: Option[String], bundledJvm: Option[String]): Seq[String] =
+      (configFile map configFileDefine).toSeq ++
+        Seq(makeClasspathDefine(appClasspath)) ++
+        (bundledJvm map bundledJvmDefine).toSeq
 
     private[this] def makeClasspathDefine(cp: Seq[String]): String = {
       val fullString = cp map (
@@ -121,6 +127,9 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
 
     private[this] def configFileDefine(configFile: String) =
       "declare -r script_conf_file=\"%s\"" format configFile
+
+    private[this] def bundledJvmDefine(bundledJvm: String) =
+      """declare -r bundled_jvm="$(dirname "$app_home")/%s"""" format bundledJvm
   }
 
   private[this] def usageMainClassReplacement(mainClasses: Seq[String]): String =

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
@@ -52,7 +52,56 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with
                                              override val templateLocation: File,
                                              bundledJvmLocation: Option[String])
       extends ScriptConfig {
+
+    @deprecated("1.3.21", "")
+    def this(executableScriptName: String,
+             scriptClasspath: Seq[String],
+             configLocation: Option[String],
+             extraDefines: Seq[String],
+             replacements: Seq[(String, String)],
+             templateLocation: File) =
+      this(executableScriptName, scriptClasspath, configLocation, extraDefines, replacements, templateLocation, None)
+
+    @deprecated("1.3.21", "")
+    def copy(executableScriptName: String = executableScriptName,
+             scriptClasspath: Seq[String] = scriptClasspath,
+             configLocation: Option[String] = configLocation,
+             extraDefines: Seq[String] = extraDefines,
+             replacements: Seq[(String, String)] = replacements,
+             templateLocation: File = templateLocation): BatScriptConfig =
+      BatScriptConfig(
+        executableScriptName,
+        scriptClasspath,
+        configLocation,
+        extraDefines,
+        replacements,
+        templateLocation,
+        bundledJvmLocation
+      )
+
     override def withScriptName(scriptName: String): BatScriptConfig = copy(executableScriptName = scriptName)
+  }
+
+  object BatScriptConfig
+      extends scala.runtime.AbstractFunction6[String, Seq[String], Option[String], Seq[String], Seq[(String, String)], File, BatScriptConfig] {
+
+    @deprecated("1.3.21", "")
+    def apply(executableScriptName: String,
+              scriptClasspath: Seq[String],
+              configLocation: Option[String],
+              extraDefines: Seq[String],
+              replacements: Seq[(String, String)],
+              templateLocation: File): BatScriptConfig =
+      BatScriptConfig(
+        executableScriptName,
+        scriptClasspath,
+        configLocation,
+        extraDefines,
+        replacements,
+        templateLocation,
+        None
+      )
+
   }
 
   override protected[this] type SpecializedScriptConfig = BatScriptConfig

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
@@ -49,7 +49,8 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with
                                              configLocation: Option[String],
                                              extraDefines: Seq[String],
                                              override val replacements: Seq[(String, String)],
-                                             override val templateLocation: File)
+                                             override val templateLocation: File,
+                                             bundledJvmLocation: Option[String])
       extends ScriptConfig {
     override def withScriptName(scriptName: String): BatScriptConfig = copy(executableScriptName = scriptName)
   }
@@ -76,7 +77,8 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with
         configLocation = batScriptConfigLocation.value,
         extraDefines = batScriptExtraDefines.value,
         replacements = batScriptReplacements.value,
-        templateLocation = batScriptTemplateLocation.value
+        templateLocation = batScriptTemplateLocation.value,
+        bundledJvmLocation = bundledJvmLocation.value
       ),
       (mainClass in (Compile, batScriptReplacements)).value,
       (discoveredMainClasses in Compile).value,
@@ -106,6 +108,7 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with
                    replacements: Seq[(String, String)]): (String, String) = {
       val defines = Seq(makeWindowsRelativeClasspathDefine(config.scriptClasspath), Defines.mainClass(mainClass)) ++
         config.configLocation.map(Defines.configFileDefine) ++
+        config.bundledJvmLocation.map(Defines.bundledJvmDefine) ++
         config.extraDefines
       "APP_DEFINES" -> Defines(defines, replacements)
     }
@@ -134,6 +137,8 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with
 
     def mainClass(mainClass: String): String = s"""set "APP_MAIN_CLASS=$mainClass""""
     def configFileDefine(configFile: String): String = s"""set "SCRIPT_CONF_FILE=$configFile""""
+    def bundledJvmDefine(bundledJvm: String): String =
+      s"""set "BUNDLED_JVM=%APP_HOME%\\$bundledJvm"""
 
     // TODO - use more of the template writer for this...
     private[this] def replace(line: String, replacements: Seq[(String, String)]): String =

--- a/src/sbt-test/jlink/test-jlink-minimal/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-minimal/build.sbt
@@ -1,0 +1,53 @@
+// Tests basic jlink plugin functionality.
+
+import scala.sys.process.Process
+import com.typesafe.sbt.packager.Compat._
+
+enablePlugins(
+  JlinkPlugin,
+  ClasspathJarPlugin,
+  BashStartScriptPlugin,
+  BatStartScriptPlugin
+)
+
+// Exclude Scala to avoid linking additional modules
+autoScalaLibrary := false
+mappings in (Compile, packageDoc) := Seq()
+
+TaskKey[Unit]("runChecks") := {
+  val log = streams.value.log
+
+  def run(exe: String, args: Seq[String]): String = {
+    log.info(s"Running '$exe ${args.mkString(" ")}'")
+    Process(exe, args) !! log
+  }
+
+  val (extension, os) = sys.props("os.name").toLowerCase match {
+    case os if os.contains("mac") ⇒ (".app", 'mac)
+    case os if os.contains("win") ⇒ (".exe", 'windows)
+    case _ ⇒ ("", 'linux)
+  }
+
+  val stageDir = stagingDirectory.in(Universal).value
+  val bundledJvmDir = (stageDir / "jre")
+  val javaExe = (bundledJvmDir / "bin" / ("java" + extension)).getAbsolutePath
+
+  // This is useful for debugging.
+  val releaseInfo = IO.read(bundledJvmDir / "release")
+  log.info(s"Produced image:\n$releaseInfo")
+
+  // Run the application directly.
+  val classpathJar = (stageDir / "lib" / packageJavaClasspathJar.value.getName)
+    .getAbsolutePath
+  run(javaExe, Seq("-cp", classpathJar, "JlinkTestApp"))
+
+  // Make sure the scripts use the correct JVM
+  val startScripts = (os match {
+    case 'windows => makeBatScripts.value.map(_._2)
+    case _ => makeBashScripts.value.map(_._2)
+  }).map(s => (stageDir / s).getAbsolutePath)
+
+  startScripts.foreach { script =>
+    run(script, Nil)
+  }
+}

--- a/src/sbt-test/jlink/test-jlink-minimal/project/plugins.sbt
+++ b/src/sbt-test/jlink/test-jlink-minimal/project/plugins.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = sys.props("project.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'project.version' is not defined.
+               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else
+    addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+}

--- a/src/sbt-test/jlink/test-jlink-minimal/src/main/java/JlinkTestApp.java
+++ b/src/sbt-test/jlink/test-jlink-minimal/src/main/java/JlinkTestApp.java
@@ -1,0 +1,23 @@
+class JlinkTestApp {
+
+  public static void main(String[] args) {
+    // The corresponding module should have been linked since we're referring
+    // to the class directly.
+    try {
+      System.out.println(javax.xml.XMLConstants.class);
+      System.err.println("Directly referenced class should be present: OK");
+    } catch (NoClassDefFoundError e) {
+      System.err.println("Directly referenced class should be present: FAIL");
+      System.exit(1);
+    }
+
+    try {
+      // The corresponding module should not have been linked.
+      System.out.println(Class.forName("java.util.logging.Logger"));
+      System.err.println("Indirectly referenced class should not be present: FAIL");
+      System.exit(1);
+    } catch (ClassNotFoundException e) {
+      System.err.println("Indirectly referenced class should not be present: OK");
+    }
+  }
+}

--- a/src/sbt-test/jlink/test-jlink-minimal/test
+++ b/src/sbt-test/jlink/test-jlink-minimal/test
@@ -1,0 +1,3 @@
+# Run the jlink packaging
+> stage
+> runChecks

--- a/src/sphinx/archetypes/misc_archetypes.rst
+++ b/src/sphinx/archetypes/misc_archetypes.rst
@@ -22,3 +22,28 @@ ClasspathJar & LauncherJar Plugin
 ---------------------------------
 
 See the :ref:`long-classpaths` section for usage of these plugins.
+
+Jlink Plugin
+------------
+
+This plugin builds on Java's `jlink`_ tool to embed a JVM image (a stripped-down JRE)
+into your package. It produces a JVM image containing only the modules that are referenced
+from the dependency classpath.
+
+.. code-block:: scala
+
+  enablePlugins(JlinkPlugin)
+
+The plugin requires Oracle JDK 11 or OpenJDK 11. Although `jlink` and `jdeps` are also
+a part of the older JDK versions, those lack some of the newer features, which was not
+addressed in the current plugin version.
+
+This plugin must be run on the platform of the target installer. The tooling does *not*
+provide a means of creating, say, Windows installers on MacOS, or MacOS on Linux, etc.
+
+For further details on the capabilities of `jlink`, see the
+`jlink <https://docs.oracle.com/en/java/javase/11/tools/jlink.html>`_ and
+`jdeps <https://docs.oracle.com/en/java/javase/11/tools/jdeps.html>`_ references.
+(Note: only some of the possible settings are exposed through this plugin. Please submit a
+`Github <https://github.com/sbt/sbt-native-packager/issues>`_ issue or pull request if something specific is desired.)
+


### PR DESCRIPTION
This scans the `fullClasspath` (using `jdeps`), and builds a JVM image (using `jlink`) from all the referenced modules. The image is then "mounted" to a configurable prefix in `Universal / mappings` (`jre/` by default). The image location is then passed to the start scripts with the highest priority (higher than `JAVA_HOME`).

Potential issues (feedback required):
- I'm not sure how to wire this into the existing CI setup, since the whole thing requires Java 11.
- Java 9 support is theoretically possible, but would require some fiddling with `jdeps` output. I'm not sure it is worth the trouble.
- It might be better to only limit the image to the standard modules (`java.*`, `javafx.*`, `jdk.*`), since everything else is already provided by the `JavaAppPackaging`. I can think both of pros and cons to this - maybe this warrants adding a separate incision point for transforming the detected module list?