### PR TITLE
Add jdeps options settings to the jlink plugin

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
@@ -7,6 +7,8 @@ import sbt._
   * Available settings/tasks for the [[com.typesafe.sbt.packager.archetypes.jlink.JlinkPlugin]].
   */
 private[packager] trait JlinkKeys {
+  val jdepsOptions =
+    SettingKey[Seq[String]]("jdepsOptions", "Options for the jdeps utility")
 
   val jlinkBundledJvmLocation =
     TaskKey[String]("jlinkBundledJvmLocation", "The location of the resulting JVM image")

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -39,6 +39,7 @@ object JlinkPlugin extends AutoPlugin {
     target in jlinkBuildImage := target.value / "jlink" / "output",
     jlinkBundledJvmLocation := "jre",
     bundledJvmLocation := Some(jlinkBundledJvmLocation.value),
+    jdepsOptions := Seq("-R", "--print-module-deps"),
     jlinkOptions := (jlinkOptions ?? Nil).value,
     jlinkOptions ++= {
       val log = streams.value.log
@@ -46,7 +47,7 @@ object JlinkPlugin extends AutoPlugin {
 
       val paths = fullClasspath.in(Compile).value.map(_.data.getPath)
       val modules =
-        (run("jdeps", "-R" +: "--print-module-deps" +: paths) !! log).trim
+        (run("jdeps", jdepsOptions.value ++ paths) !! log).trim
           .split(",")
 
       JlinkOptions(addModules = modules, output = Some(target.in(jlinkBuildImage).value))


### PR DESCRIPTION
I just tested the jlink wrapper for my project but `jdeps` produced some `not found` for some classes:
```
Error: Missing dependencies from the module path and classpath.
To suppress this error, use --ignore-missing-deps to continue.

shapeless_2.12-2.3.3.jar
   shapeless.CachedImplicitMacros                     -> scala.reflect.macros.contexts.Context              not found
   shapeless.CachedImplicitMacros                     -> scala.tools.nsc.Global                             not found
   shapeless.CachedImplicitMacros                     -> scala.tools.nsc.typechecker.Analyzer               not found
   shapeless.CachedImplicitMacros                     -> scala.tools.nsc.typechecker.Contexts               not found
[...]
```

This PR adds a way to set or add options for `jdeps`. I tested on mac using java 12 and:
```
jlinkOptions ++= Seq("--no-header-files", "--no-man-pages", "--compress=2", "--strip-debug"),
jdepsOptions ++= Seq("--ignore-missing-deps")
```

/cc @nigredo-tori 