### PR TITLE
Fix dependency handling in JlinkPlugin (+ general improvements)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,10 @@ jobs:
       name: "scripted jlink tests"
       jdk: oraclejdk11
       if: type = pull_request OR (type = push AND branch = master)
+    - script: sbt "^validateJlink"
+      name: "scripted jlink tests"
+      jdk: oraclejdk12
+      if: type = pull_request OR (type = push AND branch = master)
     - script: sbt "^validateDocker"
       name: "scripted docker integration-tests"
       if: type = pull_request OR (type = push AND branch = master)

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ jobs:
       if: type = pull_request OR (type = push AND branch = master)
     - script: sbt "^validateJlink"
       name: "scripted jlink tests"
-      jdk: oraclejdk12
+      jdk: openjdk12
       if: type = pull_request OR (type = push AND branch = master)
     - script: sbt "^validateDocker"
       name: "scripted docker integration-tests"

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
@@ -16,7 +16,12 @@ private[packager] trait JlinkKeys {
   val jlinkIgnoreMissingDependency =
     TaskKey[((String, String)) => Boolean](
       "jlinkIgnoreMissingDependency",
-      "A hook to mask missing package dependency issues"
+      """A hook to mask missing package dependency issues.
+        |This receives a pair of dependent and dependee packages (where the dependee package is NOT
+        |present in the classpath), and returns true if this dependency should be ignored. Any
+        |missing dependencies that are not ignored will result in an error when running
+        |jlinkBuildImage.
+      """.stripMargin
     )
 
   val jlinkOptions =

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
@@ -11,6 +11,14 @@ private[packager] trait JlinkKeys {
   val jlinkBundledJvmLocation =
     TaskKey[String]("jlinkBundledJvmLocation", "The location of the resulting JVM image")
 
+  val jlinkModules = TaskKey[Seq[String]]("jlinkModules", "Modules to link")
+
+  val jlinkIgnoreMissingDependency =
+    TaskKey[((String, String)) => Boolean](
+      "jlinkIgnoreMissingDependency",
+      "A hook to mask missing package dependency issues"
+    )
+
   val jlinkOptions =
     TaskKey[Seq[String]]("jlinkOptions", "Options for the jlink utility")
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -175,6 +175,22 @@ object JlinkPlugin extends AutoPlugin {
     final case class Module(name: String) extends Source
     final case class JarOrDir(name: String) extends Source
 
+    // Examples of package dependencies in jdeps output (whitespace may vary,
+    // but there will always be some leading whitespace):
+    // Dependency on a package(java.lang) in a module (java.base):
+    //   foo.bar -> java.lang java.base
+    // Dependency on a package (scala.collection) in a JAR
+    // (scala-library-2.12.8.jar):
+    //   foo.bar -> scala.collection scala-library-2.12.8.jar
+    // Dependency on a package (foo.baz) in a class directory (classes):
+    //   foo.bar -> foo.baz classes
+    // Missing dependency on a package (qux.quux):
+    //   foo.bar -> qux.quux not found
+    // There are also jar/directory/module-level dependencies, but we are
+    // not interested in those:
+    // foo.jar -> scala-library-2.12.8.jar
+    // classes -> java.base
+    // foo.jar -> not found
     private val pattern = """^\s+([^\s]+)\s+->\s+([^\s]+)\s+([^\s].*?)\s*$""".r
 
     def parse(s: String): Option[PackageDependency] = s match {

--- a/src/sbt-test/jlink/test-jlink-missing-deps/bar/src/main/java/bar/Bar.java
+++ b/src/sbt-test/jlink/test-jlink-missing-deps/bar/src/main/java/bar/Bar.java
@@ -1,0 +1,3 @@
+package bar;
+
+public class Bar {}

--- a/src/sbt-test/jlink/test-jlink-missing-deps/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-missing-deps/build.sbt
@@ -1,0 +1,21 @@
+// Tests jlink behavior with missing dependencies.
+
+import scala.sys.process.Process
+import com.typesafe.sbt.packager.Compat._
+
+
+// Exclude Scala to simplify the test
+autoScalaLibrary in ThisBuild := false
+
+// Simulate a missing dependency (foo -> bar)
+lazy val foo = project.dependsOn(bar % "provided")
+lazy val bar = project
+
+lazy val withoutIgnore = project.dependsOn(foo)
+  .enablePlugins(JlinkPlugin)
+
+lazy val withIgnore = project.dependsOn(foo)
+  .enablePlugins(JlinkPlugin)
+  .settings(
+    jlinkIgnoreMissingDependency := JlinkIgnore.only("foo" -> "bar")
+  )

--- a/src/sbt-test/jlink/test-jlink-missing-deps/foo/src/main/java/foo/Foo.java
+++ b/src/sbt-test/jlink/test-jlink-missing-deps/foo/src/main/java/foo/Foo.java
@@ -1,0 +1,7 @@
+package foo;
+
+public class Foo {
+  public Foo() {
+    new bar.Bar();
+  }
+}

--- a/src/sbt-test/jlink/test-jlink-missing-deps/project/plugins.sbt
+++ b/src/sbt-test/jlink/test-jlink-missing-deps/project/plugins.sbt
@@ -1,0 +1,8 @@
+{
+  val pluginVersion = sys.props("project.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'project.version' is not defined.
+               |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else
+    addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % sys.props("project.version"))
+}

--- a/src/sbt-test/jlink/test-jlink-missing-deps/test
+++ b/src/sbt-test/jlink/test-jlink-missing-deps/test
@@ -1,0 +1,5 @@
+> compile
+# Should fail since we have a missing dependency.
+-> withoutIgnore/jlinkBuildImage
+# Should work OK since the issue is silenced
+> withIgnore/jlinkBuildImage

--- a/src/sbt-test/jlink/test-jlink-missing-deps/withIgnore/src/main/java/WithIgnore.java
+++ b/src/sbt-test/jlink/test-jlink-missing-deps/withIgnore/src/main/java/WithIgnore.java
@@ -1,0 +1,5 @@
+class WithIgnore {
+  public WithIgnore() {
+    new foo.Foo();
+  }
+}

--- a/src/sbt-test/jlink/test-jlink-missing-deps/withoutIgnore/src/main/java/WithoutIgnore.java
+++ b/src/sbt-test/jlink/test-jlink-missing-deps/withoutIgnore/src/main/java/WithoutIgnore.java
@@ -1,0 +1,5 @@
+class WithoutIgnore {
+  public WithoutIgnore() {
+    new foo.Foo();
+  }
+}

--- a/src/sphinx/archetypes/misc_archetypes.rst
+++ b/src/sphinx/archetypes/misc_archetypes.rst
@@ -50,7 +50,16 @@ The plugin analyzes the dependencies between packages using `jdeps`, and raises 
       "foo.bar" -> "bar.qux"
     )
 
-For large projects with a lot of dependencies this can get unwieldy. You can implement a more flexible ignore strategy, or disable the check altogether:
+For large projects with a lot of dependencies this can get unwieldy. You can implement a more flexible ignore strategy:
+
+.. code-block:: scala
+
+  jlinkIgnoreMissingDependency := {
+    case ("foo.bar", dependee) if dependee.startsWith("bar") => true
+    case _ => false
+  }
+
+Otherwise you may opt out of the check altogether (which is not recommended):
 
 .. code-block:: scala
 

--- a/src/sphinx/archetypes/misc_archetypes.rst
+++ b/src/sphinx/archetypes/misc_archetypes.rst
@@ -41,6 +41,21 @@ addressed in the current plugin version.
 This plugin must be run on the platform of the target installer. The tooling does *not*
 provide a means of creating, say, Windows installers on MacOS, or MacOS on Linux, etc.
 
+The plugin analyzes the dependencies between packages using `jdeps`, and raises an error in case of a missing dependency (e.g. for a provided transitive dependency). The missing dependencies can be suppressed on a case-by-case basis (e.g. if you are sure the missing dependency is properly handled):
+
+.. code-block:: scala
+
+    jlinkIgnoreMissingDependency := JlinkIgnore.only(
+      "foo.bar" -> "bar.baz",
+      "foo.bar" -> "bar.qux"
+    )
+
+For large projects with a lot of dependencies this can get unwieldy. You can implement a more flexible ignore strategy, or disable the check altogether:
+
+.. code-block:: scala
+
+   jlinkIgnoreMissingDependency := JlinkIgnore.everything
+
 For further details on the capabilities of `jlink`, see the
 `jlink <https://docs.oracle.com/en/java/javase/11/tools/jlink.html>`_ and
 `jdeps <https://docs.oracle.com/en/java/javase/11/tools/jdeps.html>`_ references.


### PR DESCRIPTION
As outlined [here](https://github.com/sbt/sbt-native-packager/pull/1225#issuecomment-492264246):

1. Since `jdeps --print-module-deps` is unreliable - switch to parsing the full `jdeps`output.
1. The new `jdeps` behavior (throwing an error for missing dependencies) seems to be useful - include similar functionality into the new implementation.
1. Add a fine-grained way to silence missing dependencies from the previous point (`jlinkIgnoreMissingDependency`). Add convenience helpers (`JlinkPlugin.Ignore`).
1. Add a test for the new functionality.
1. Test the plugin against JDK 12.

General improvements:
1. Add a task for the list of modules (`jlinkModules`) to allow manually adding/removing these.
1. Add a level of indirection when using `Compile / fullClasspath` to allow injecting classpath elements for the scan. This can be useful if not all the relevant dependencies should be a part of the actual classpath (I have a use case for that).