### PR TITLE
remove docker-containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,6 @@ or provide a richer API for a single packaging format.
 - [sbt-bundle](https://github.com/sbt/sbt-bundle)
 - [sbt-docker](https://github.com/marcuslonnberg/sbt-docker)
   - This is in addition to the built-in [Docker Plugin](http://www.scala-sbt.org/sbt-native-packager/formats/docker.html) from  sbt-native.  Both generate docker images. `sbt-docker` provides more customization abilities, while the `DockerPlugin` in this project  integrates more directly with predefined archetypes.
-- [sbt-docker-containers](https://github.com/Dwolla/sbt-docker-containers) - enhances sbt-native-packager's docker functionality.
 - [sbt-heroku](https://github.com/heroku/sbt-heroku)
 - [sbt-newrelic](https://github.com/gilt/sbt-newrelic)
 - [sbt-packager](https://github.com/en-japan/sbt-packer)


### PR DESCRIPTION
Docker-containers 1.2.12 isn't valid for the current version of sbt-native-packager -- it looks for docker alias, which doesn't exist:

```
[error] java.lang.NoSuchMethodError: com.typesafe.sbt.packager.docker.DockerAlias.versioned()Ljava/lang/String;
[error] 	at com.dwolla.sbt.docker.DockerContainerPlugin$.$anonfun$tasks$1(DockerContainerPlugin.scala:36)
[error] 	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
[error] 	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:40)
[error] 	at sbt.std.Transform$$anon$4.work(System.scala:67)
[error] 	at sbt.Execute.$anonfun$submit$2(Execute.scala:269)
[error] 	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
[error] 	at sbt.Execute.work(Execute.scala:278)
[error] 	at sbt.Execute.$anonfun$submit$1(Execute.scala:269)
[error] 	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[error] 	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
[error] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[error] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
[error] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
[error] 	at java.lang.Thread.run(Thread.java:748)
[error] (Docker / dockerCreateArguments) java.lang.NoSuchMethodError: com.typesafe.sbt.packager.docker.DockerAlias.versioned()Ljava/lang/String;

```

https://github.com/Dwolla/sbt-docker-containers/blob/master/src/main/scala/com/dwolla/sbt/docker/DockerContainerPlugin.scala#L36