### PR TITLE
Assorted JlinkPlugin improvements

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkKeys.scala
@@ -29,4 +29,7 @@ private[packager] trait JlinkKeys {
 
   val jlinkBuildImage =
     TaskKey[File]("jlinkBuildImage", "Runs jlink. Yields the directory with the runtime image")
+
+  val jlinkModulePath =
+    TaskKey[Seq[File]]("jlinkModulePath", "Module path to supply to jlink")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -129,10 +129,8 @@ object JlinkPlugin extends AutoPlugin {
       .pair(file => IO.relativize(dir, file))
 
   private def runJavaTool(jvm: Option[File], log: Logger)(exeName: String, args: Seq[String]): ProcessBuilder = {
-    val exe = jvm match {
-      case None     => exeName
-      case Some(jh) => (jh / "bin" / exeName).getAbsolutePath
-    }
+    val jh = jvm.getOrElse(file(sys.props.getOrElse("java.home", sys.error("no java.home"))))
+    val exe = (jh / "bin" / exeName).getAbsolutePath
 
     log.info("Running: " + (exe +: args).mkString(" "))
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -202,5 +202,22 @@ object JlinkPlugin extends AutoPlugin {
     val nothing: ((String, String)) => Boolean = Function.const(false)
     val everything: ((String, String)) => Boolean = Function.const(true)
     def only(dependencies: (String, String)*): ((String, String)) => Boolean = dependencies.toSet.contains
+
+    /** This matches pairs by their respective ''package'' prefixes. This means that `"foo.bar"`
+      * matches `"foo.bar"`, `"foo.bar.baz"`, but not `"foo.barqux"`. Empty
+      * string matches anything.
+      */
+    def byPackagePrefix(prefixPairs: (String, String)*): ((String, String)) => Boolean = {
+      case (a, b) =>
+        prefixPairs.exists {
+          case (prefixA, prefixB) =>
+            packagePrefixMatches(prefixA, a) && packagePrefixMatches(prefixB, b)
+        }
+    }
+
+    private def packagePrefixMatches(prefix: String, s: String): Boolean =
+      prefix.isEmpty ||
+        s == prefix ||
+        s.startsWith(prefix + ".")
   }
 }

--- a/src/sphinx/archetypes/misc_archetypes.rst
+++ b/src/sphinx/archetypes/misc_archetypes.rst
@@ -50,14 +50,13 @@ The plugin analyzes the dependencies between packages using `jdeps`, and raises 
       "foo.bar" -> "bar.qux"
     )
 
-For large projects with a lot of dependencies this can get unwieldy. You can implement a more flexible ignore strategy:
+For large projects with a lot of dependencies this can get unwieldy. You can use a more flexible ignore strategy:
 
 .. code-block:: scala
 
-  jlinkIgnoreMissingDependency := {
-    case ("foo.bar", dependee) if dependee.startsWith("bar") => true
-    case _ => false
-  }
+  jlinkIgnoreMissingDependency := JlinkIgnore.byPackagePrefix(
+    "foo.bar" -> "bar"
+  )
 
 Otherwise you may opt out of the check altogether (which is not recommended):
 

--- a/src/test/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkSpec.scala
+++ b/src/test/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkSpec.scala
@@ -1,0 +1,23 @@
+package com.typesafe.sbt.packager.archetypes.jlink
+
+import org.scalatest.{FlatSpec, Matchers}
+import JlinkPlugin.Ignore.byPackagePrefix
+
+class JlinkSpec extends FlatSpec with Matchers {
+  "Ignore.byPackagePrefix()" should "match as expected for sample examples" in {
+    byPackagePrefix("" -> "")("foo" -> "bar") should be(true)
+
+    byPackagePrefix("foo" -> "bar")("foo" -> "bar") should be(true)
+    byPackagePrefix("foo" -> "bar")("bar" -> "foo") should be(false)
+    byPackagePrefix("foo" -> "bar")("baz" -> "bar") should be(false)
+    byPackagePrefix("foo" -> "bar")("foo" -> "baz") should be(false)
+
+    byPackagePrefix("foo" -> "bar")("foobaz" -> "barqux") should be(false)
+    byPackagePrefix("foo" -> "bar")("foo.baz" -> "bar.qux") should be(true)
+    byPackagePrefix("foo.baz" -> "bar.qux")("foo" -> "bar") should be(false)
+
+    byPackagePrefix("" -> "", "foo" -> "bar")("baz" -> "qux") should be(true)
+    byPackagePrefix("foo" -> "bar", "" -> "")("baz" -> "qux") should be(true)
+    byPackagePrefix("foo" -> "", "" -> "bar")("baz" -> "qux") should be(false)
+  }
+}


### PR DESCRIPTION
Closes #1240

Everything is as outlined in #1240, except I've decided against globbing in p.1. The semantics for that would have to be different enough to be confusing. Instead I've added simple package prefix matching.