### PR TITLE
JlinkPlugin: Sort missing dependencies before logging

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -71,6 +71,7 @@ object JlinkPlugin extends AutoPlugin {
         }
         .filterNot(shouldIgnore)
         .distinct
+        .sorted
 
       if (missingDeps.nonEmpty) {
         log.error(


### PR DESCRIPTION
This makes it easier to build the ignore expression afterwards.