### PR TITLE
JlinkPlugin: restrict linking to platform modules

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -186,20 +186,16 @@ object JlinkPlugin extends AutoPlugin {
   }
 
   private object JlinkOptions {
-    @deprecated("1.3.24", "")
-    def apply(addModules: Seq[String] = Nil, output: Option[File] = None): Seq[String] =
-      apply(addModules = addModules, output = output, modulePath = Nil)
-
     def apply(addModules: Seq[String], output: Option[File], modulePath: Seq[File]): Seq[String] =
       option("--output", output) ++
-        list("--add-modules", addModules) ++
-        list("--module-path", modulePath)
+        list("--add-modules", addModules, ",") ++
+        list("--module-path", modulePath, ":")
 
     private def option[A](arg: String, value: Option[A]): Seq[String] =
       value.toSeq.flatMap(a => Seq(arg, a.toString))
 
-    private def list[A](arg: String, values: Seq[A]): Seq[String] =
-      if (values.nonEmpty) Seq(arg, values.mkString(",")) else Nil
+    private def list[A](arg: String, values: Seq[A], separator: String): Seq[String] =
+      if (values.nonEmpty) Seq(arg, values.mkString(separator)) else Nil
   }
 
   // Jdeps output row

--- a/src/sbt-test/jlink/test-jlink-misc/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-misc/build.sbt
@@ -21,3 +21,44 @@ val issue1243 = project
     jlinkIgnoreMissingDependency := JlinkIgnore.everything,
     runChecks := jlinkBuildImage.value
   )
+
+// Should succeed for JARs with names that don't produce a legal automatic
+// module name.
+val issue1247BadAutoModuleName = project
+  .enablePlugins(JlinkPlugin)
+  .settings(
+    managedClasspath in Compile += {
+      // Build an empty jar with an unsupported name
+      val jarFile = target.value / "foo_2.11.jar"
+      IO.jar(Nil, jarFile, new java.util.jar.Manifest)
+      Attributed.blank(jarFile)
+    },
+    runChecks := jlinkBuildImage.value
+  )
+
+// Should succeed for jars containing external modules.
+val issue1247ExternalModule = project
+  .enablePlugins(JlinkPlugin)
+  .settings(
+    // An arbitrary JAR with a non-platform module.
+    libraryDependencies += "com.sun.xml.fastinfoset" % "FastInfoset" % "1.2.16",
+    runChecks := jlinkBuildImage.value
+  )
+
+// Should succeed for `java.*` modules from JakartaEE.
+val issue1247JakartaJavaModules = project
+  .enablePlugins(JlinkPlugin)
+  .settings(
+    libraryDependencies ++= List(
+      "jakarta.ws.rs" % "jakarta.ws.rs-api" % "2.1.5",
+      "jakarta.xml.bind" % "jakarta.xml.bind-api" % "2.3.2",
+
+      // We don't use the implementation from
+      // `com.sun.activation` because that doesn't include an explicit module
+      // declaration, and automatic modules are not properly supported
+      // with jdeps 11+.
+      // https://github.com/eclipse-ee4j/jaf/issues/13
+      "com.jwebmp.thirdparty" % "jakarta.activation" % "0.67.0.12"
+    ),
+    runChecks := jlinkBuildImage.value
+  )

--- a/src/sbt-test/jlink/test-jlink-misc/test
+++ b/src/sbt-test/jlink/test-jlink-misc/test
@@ -1,3 +1,6 @@
 # These tasks can be aggregated, but running them one by one means
 # more granular output in case of a failure.
 > issue1243/runChecks
+> issue1247BadAutoModuleName/runChecks
+> issue1247ExternalModule/runChecks
+> issue1247JakartaJavaModules/runChecks

--- a/src/sphinx/archetypes/misc_archetypes.rst
+++ b/src/sphinx/archetypes/misc_archetypes.rst
@@ -30,6 +30,10 @@ This plugin builds on Java's `jlink`_ tool to embed a JVM image (a stripped-down
 into your package. It produces a JVM image containing only the modules that are referenced
 from the dependency classpath.
 
+Note: Current implementation only detects the platform modules (that is, the ones present in
+the JDK used to build the image). Modular JARs and directories are packaged as specified
+by the `UniversalPlugin`.
+
 .. code-block:: scala
 
   enablePlugins(JlinkPlugin)


### PR DESCRIPTION
Closes #1247 .

This is a short-term solution to #1247, as outlined in https://github.com/sbt/sbt-native-packager/issues/1247#issuecomment-510532079 (point 1). The long-term solution (`JlinkPlugin` refactoring/rewrite - https://github.com/sbt/sbt-native-packager/issues/1247#issuecomment-510472779) will be a separate issue.

1. Fix `jlink` `--module-path` separator issue.
1. Filter detected dependencies - only link the platform modules.
1. Change `jlinkModulePath` to default to an empty list - we don't need it for platform modules.

Detecting platform modules has special cases - for [historical reasons](https://github.com/eclipse-ee4j/ee4j/issues/34) some Jakarta modules use `java.*` names, so we have to exclude them on a case by case basis. I'm not positive I got all of these - some seem to rely on automatic modules for their dependencies, and those are not properly supported by `jlink`/`jdeps` AFAICT... All in all, Jakarta's JPMS transition is a mess.