### PR TITLE
add argument expansion for java args in bash

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -139,8 +139,9 @@ execRunner () {
   exec "$@"
 }
 addJava () {
-  dlog "[addJava] arg = '$1'"
-  java_args+=( "$1" )
+  local arg=$(eval echo "$1")
+  dlog "[addJava] arg = '$arg'"
+  java_args+=( "$arg" )
 }
 addApp () {
   dlog "[addApp] arg = '$1'"


### PR DESCRIPTION
Added java arguments expansion to bash.

It is useful if Java opts are dependent on env variables.
e.g. running on kubernetes the available memory can be set via env variable, like this:
```yaml
            - name: MEM_TOTAL_MB
              valueFrom:
                resourceFieldRef:
                  resource: limits.memory
                  divisor: 1Mi
```

In this way, you can set up Xmx and Xms to be some percentage of that value, e.g.:
```
    javaOptions in Universal ++= Seq(
      "-J-Xmx$((${MEM_TOTAL_MB:-256}*${MAX_HEAP_PERCENTAGE:-75}/100))m",
      "-J-Xms$((${MEM_TOTAL_MB:-256}*${MAX_HEAP_PERCENTAGE:-75}/100))m"
    )
```

after the image was built, in application.ini:
```
cat ./conf/application.ini 
# options from build
-J-Xmx$((${MEM_TOTAL_MB:-256}*${MAX_HEAP_PERCENTAGE:-75}/100))m
-J-Xms$((${MEM_TOTAL_MB:-256}*${MAX_HEAP_PERCENTAGE:-75}/100))m
```

then when the app stars on a pod, the calculated value is provided as a parameter to java, e.g.:
```
/usr/local/openjdk-8/bin/java
-Xmx768m
-Xms768m
-cp
/opt/....
```

without expansion change this doesn't work and you cannot provide the value that should be calculated.

Please review.

Thank you!