### PR TITLE
JlinkPlugin: add support for huge classpaths

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-compress" % "1.18",
   // for jdkpackager
   "org.apache.ant" % "ant" % "1.10.5",
+  // workaround for the command line size limit
   "com.github.eldis" % "tool-launcher" % "0.2.1",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ libraryDependencies ++= Seq(
   "org.apache.commons" % "commons-compress" % "1.18",
   // for jdkpackager
   "org.apache.ant" % "ant" % "1.10.5",
+  "com.github.eldis" % "tool-launcher" % "0.2.1",
   "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )
 

--- a/src/sbt-test/jlink/test-jlink-misc/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-misc/build.sbt
@@ -62,3 +62,21 @@ val issue1247JakartaJavaModules = project
     ),
     runChecks := jlinkBuildImage.value
   )
+
+// Should succeed for large classpaths.
+val issue1266 = project
+  .enablePlugins(JlinkPlugin)
+  .settings(
+    // An arbitrary JAR with a non-platform module.
+    libraryDependencies += "com.sun.xml.fastinfoset" % "FastInfoset" % "1.2.16",
+    // A lot of "dummy" dependencies, so that the resulting classpath is over
+    // the command line limit (2MB on my machine)
+    unmanagedJars in Compile ++= {
+      def mkPath(ix: Int) = target.value / s"there-is-no-such-file-$ix.jar"
+
+      1.to(300000).map(mkPath)
+    },
+    logLevel in jlinkModules := Level.Error,
+
+    runChecks := jlinkBuildImage.value
+  )

--- a/src/sbt-test/jlink/test-jlink-misc/test
+++ b/src/sbt-test/jlink/test-jlink-misc/test
@@ -4,3 +4,4 @@
 > issue1247BadAutoModuleName/runChecks
 > issue1247ExternalModule/runChecks
 > issue1247JakartaJavaModules/runChecks
+> issue1266/runChecks


### PR DESCRIPTION
Closes #1266.

As described [here](https://github.com/sbt/sbt-native-packager/issues/1266#issuecomment-541610521), this uses a [launcher](https://github.com/eldis/java-tool-launcher) with `@argfile` support to pass large argument lists to `jdeps` (and `jlink`, just in case).

Since this approach only uses the `java` executable, I've changed the process handling to use SBT's `ForkRun`. This way we don't need to reimplement `javaOptions` and `javaHome` support. There are more hoops to jump through to get the process output out of it, but I think this is worth it.