### PR TITLE
Set homepage setting to GitHub repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 name := "sbt-native-packager"
 organization := "com.typesafe.sbt"
+homepage := Some(url("https://github.com/sbt/sbt-native-packager"))
 
 Global / scalaVersion := "2.12.7"
 


### PR DESCRIPTION
This enables Scala Steward to link to sbt-native-packager's homepage,
version diff, and release notes, see https://twitter.com/fst9000/status/1194716047376560129.