### PR TITLE
Add folders from Bloop and Metals to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ log/
 target/
 .cache
 .ensime*
+.bloop/*
+.metals/*


### PR DESCRIPTION
I don't know if it is intended but I saw that the `.metals` folder was included in the last commits.
So I added entries to the `.gitignore` file.

Feel free to ignore this PR if this is intended.