### PR TITLE
Change all references to macOS

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -250,7 +250,7 @@ jobs:
     - name: Validate
       run: sbt "^validateGraalVMNativeImage"
 
-  scripted-osx:
+  scripted-macos:
     runs-on: macos-latest
     strategy:
       fail-fast: false
@@ -269,7 +269,7 @@ jobs:
       with:
         java-version: zulu@1.8
     - name: Validate
-      run: sbt "^validate" "^validateOSX"
+      run: sbt "^validate" "^validateMacOS"
         
   scripted-windows:
     runs-on: windows-latest

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ different archetypes for common configurations, such as simple Java apps or serv
 * Build [native packages][formats] for different systems
   * Universal `zip`,`tar.gz`, `xz` archives
   * `deb` and `rpm` packages for Debian/RHEL based systems
-  * `dmg` for OSX
+  * `dmg` for macOS
   * `msi` for Windows
   * `docker` images
   * `graalvm` native images
 * Provide archetypes for common use cases
-  * [Java application][] with start scripts for Linux, OSX and Windows
+  * [Java application][] with start scripts for Linux, macOS and Windows
   * [Java server application][] adds support for service managers:s
     * Systemd
     * Systemv

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,7 @@ mimaBinaryIssueFilters ++= {
 publishMavenStyle := false
 
 // The release task doesn't run any tests. We rely on travis.ci and appveyor,
-// because it's impossible to run all tests (linux, macosx, windows) on a single computer.
+// because it's impossible to run all tests (linux, macos, windows) on a single computer.
 import ReleaseTransformations._
 releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
@@ -144,7 +144,7 @@ addCommandAlias(
   "validateJdkPackagerTravis",
   "scripted jdkpackager/test-package-minimal jdkpackager/test-package-mappings"
 )
-addCommandAlias("validateOSX", "; validate ; validateUniversal")
+addCommandAlias("validateMacOS", "; validate ; validateUniversal")
 
 // TODO check the cygwin scripted tests and run them on appveyor
 addCommandAlias("validateWindows", "; testOnly * -- -n windows ; scripted universal/dist universal/stage windows/*")

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-forwarder-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-forwarder-template
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Absolute path to this script
-# OS X doesn't support "readlink -f"
+# macOS doesn't support "readlink -f"
 realpath () {
   TARGET_FILE="$1"
   CHECK_CYGWIN="$2"

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerAntHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerAntHelper.scala
@@ -30,7 +30,7 @@ object JDKPackagerAntHelper {
       // Environment override
       sys.env.get("JDK_HOME").map(file),
       sys.env.get("JAVA_HOME").map(file),
-      // MacOS X
+      // macOS
       Try(sys.process.Process("/usr/libexec/java_home").!!.trim).toOption.map(file),
       // From system properties
       sys.props.get("java.home").map(file)

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerKeys.scala
@@ -24,10 +24,10 @@ trait JDKPackagerKeys {
       |    * `all`: Runs all of the installers for the platform on which it is running,
       |      and creates a disk image for the application.
       |    * `installer`: Runs all of the installers for the platform on which it is running.
-      |    * `image`: Creates a disk image for the application. On OS X, the image is
+      |    * `image`: Creates a disk image for the application. On macOS, the image is
       |      the .app file. On Linux, the image is the directory that gets installed.
-      |    * `dmg`: Generates a DMG file for OS X.
-      |    * `pkg`: Generates a .pkg package for OS X.
+      |    * `dmg`: Generates a DMG file for macOS.
+      |    * `pkg`: Generates a .pkg package for macOS.
       |    * `mac.appStore`: Generates a package for the Mac App Store.
       |    * `rpm`: Generates an RPM package for Linux.
       |    * `deb`: Generates a Debian package for Linux.

--- a/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
@@ -93,7 +93,7 @@ object Archives {
   /**
     * Makes a dmg file in the given target directory using the given name.
     *
-    *  Note:  Only works on OSX
+    *  Note:  Only works on macOS
     *
     *  @param target folder to build package in
     *  @param name of output (without extension)
@@ -111,7 +111,7 @@ object Archives {
   /**
     * Makes a dmg file in the given target directory using the given name.
     *
-    *  Note:  Only works on OSX
+    *  Note:  Only works on macOS
     *
     *  @param target folder to build package in
     *  @param name of output (without extension)
@@ -247,7 +247,7 @@ object Archives {
       // create the working directory
       IO.createDirectory(workingDirectory)
       IO.copy(temporaryMappings)
-      // setExecutable does not always work. There are known issues with macOSx where
+      // setExecutable does not always work. There are known issues with macOS where
       // the executable flags is missing after compression.
       for ((from, to) <- temporaryMappings if (to.getAbsolutePath contains "/bin/") || from.canExecute) {
         println("Making " + to.getAbsolutePath + " executable")

--- a/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
@@ -9,7 +9,7 @@ trait UniversalKeys {
     TaskKey[File]("package-zip-tarball", "Creates a tgz package.")
   val packageXzTarball =
     TaskKey[File]("package-xz-tarball", "Creates a txz package.")
-  val packageOsxDmg = TaskKey[File]("package-osx-dmg", "Creates a dmg package for OSX (only on osx).")
+  val packageOsxDmg = TaskKey[File]("package-osx-dmg", "Creates a dmg package for macOS (only on macOS).")
   val stage = TaskKey[File](
     "stage",
     "Create a local directory with all the files laid out as they would be in the final distribution."

--- a/src/main/scala/com/typesafe/sbt/packager/universal/ZipHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/ZipHelper.scala
@@ -52,7 +52,7 @@ object ZipHelper {
   /**
     * Creates a zip file with the apache commons compressor library.
     *
-    * Note: This is known to have some odd issues on MacOSX whereby executable permissions
+    * Note: This is known to have some odd issues on macOS whereby executable permissions
     * are not actually discovered, even though the Info-Zip headers exist and work on
     * many variants of linux.  Yay Apple.
     *

--- a/src/sphinx/archetypes/java_server/index.rst
+++ b/src/sphinx/archetypes/java_server/index.rst
@@ -3,7 +3,7 @@
 Java Server Application Archetype
 #################################
 
-.. hint:: Supports only **deb** and **rpm** packaging. No support for Windows or OSX
+.. hint:: Supports only **deb** and **rpm** packaging. No support for Windows or macOS
 
 In the :ref:`java-app-plugin` section we described how to build and customize settings related to an application.
 The server archetype adds additional features you may need when running your application as a service on a server.

--- a/src/sphinx/formats/graalvm-native-image.rst
+++ b/src/sphinx/formats/graalvm-native-image.rst
@@ -10,7 +10,7 @@ GraalVM's ``native-image`` compiles Java programs AOT (ahead-of-time) into nativ
 The plugin supports both using a local installation of the GraalVM ``native-image`` utility, or building inside a
 Docker container. If you intend to run the native image on Linux, then building inside a Docker container is
 recommended since GraalVM native images can only be built for the platform they are built on. By building in a Docker
-container, you can build Linux native images not just on Linux but also on Windows and OSX.
+container, you can build Linux native images not just on Linux but also on Windows and macOS.
 
 Requirements
 ------------

--- a/src/sphinx/formats/jdkpackager.rst
+++ b/src/sphinx/formats/jdkpackager.rst
@@ -4,7 +4,7 @@ JDKPackager Plugin
 ==================
 
 This plugin builds on Oracle's `javapackager`_ tool to generate  native application
-launchers and installers for MacOS X, Windows, and Linux. This plugin takes the settings and staged output from
+launchers and installers for macOS, Windows, and Linux. This plugin takes the settings and staged output from
 :ref:`java-app-plugin` and passes them through ``javapackager``
 to create native formats per Oracle's provided features.
 
@@ -13,7 +13,7 @@ to create native formats per Oracle's provided features.
 The actual mechanism used by this plugin is the support provided by the ``lib/ant-javafx.jar`` Ant task library,
 which provides more capabilities than the ``javapackager`` command line version, but the idea is the same.
 
-This plugin's most relevant addition to the core `sbt-native-packager` capabilities is the generation of MacOS X App
+This plugin's most relevant addition to the core `sbt-native-packager` capabilities is the generation of macOS App
 bundles and associated ``.dmg`` and ``.pkg`` package formats.  With this plugin complete drag-and-drop installable
 application bundles are possible, including the embedding of the JRE.  It can also generate Windows ``.exe`` and ``.msi``
 installers provided the requisite tools are available on the Windows build platform (see below). While Linux package
@@ -83,9 +83,9 @@ Settings
 
   * ``all``: Runs all of the installers for the platform on which it is running, and creates a disk image for the application.
   * ``installer``: Runs all of the installers for the platform on which it is running.
-  * ``image``: Creates a disk image for the application. On OS X, the image is the .app file. On Linux, the image is the directory that gets installed.
-  * ``dmg``: Generates a DMG file for OS X.
-  * ``pkg``: Generates a .pkg package for OS X.
+  * ``image``: Creates a disk image for the application. On macOS, the image is the .app file. On Linux, the image is the directory that gets installed.
+  * ``dmg``: Generates a DMG file for macOS.
+  * ``pkg``: Generates a .pkg package for macOS.
   * ``mac.appStore``: Generates a package for the Mac App Store.
   * ``rpm``: Generates an RPM package for Linux.
   * ``deb``: Generates a Debian package for Linux.

--- a/src/sphinx/formats/universal.rst
+++ b/src/sphinx/formats/universal.rst
@@ -132,7 +132,7 @@ Tasks
     for some types of archives.
 
   ``universal:package-osx-dmg``
-    Creates the ``dmg`` universal package.  This only work on OSX or systems with ``hdiutil``.
+    Creates the ``dmg`` universal package.  This only work on macOS or systems with ``hdiutil``.
 
   ``universal-docs:package-bin``
     Creates the ``zip`` universal documentation package.


### PR DESCRIPTION
Change all references to macOS (MacOS X, MacOSX, OS X, OSX, macOSx, macosx, osx).

That leaves the `TRAVIS_OS_NAME` env var, which seems to only supports
the variant 'osx', as far as I can tell.

It also leaves the `packageOsxDmg`/`package-osx-dmg` task key, that is
both public binary API and public semantic API, as keys are global in
sbt's build state - so I just left it as is for now.