### PR TITLE
Fix for native-image to work in Windows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,8 +91,14 @@ mimaBinaryIssueFilters ++= {
     ProblemFilters.exclude[ReversedMissingMethodProblem](
       "com.typesafe.sbt.packager.docker.DockerKeys.dockerAutoremoveMultiStageIntermediateImages"
     ),
-    ProblemFilters.exclude[DirectMissingMethodProblem](
-      "com.typesafe.sbt.packager.docker.DockerPlugin.publishLocalDocker"
+    ProblemFilters
+      .exclude[DirectMissingMethodProblem]("com.typesafe.sbt.packager.docker.DockerPlugin.publishLocalDocker"),
+    // added via #1312
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "com.typesafe.sbt.packager.graalvmnativeimage.GraalVMNativeImageKeys.graalVMNativeImageCommand"
+    ),
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+      "com.typesafe.sbt.packager.graalvmnativeimage.GraalVMNativeImageKeys.com$typesafe$sbt$packager$graalvmnativeimage$GraalVMNativeImageKeys$_setter_$graalVMNativeImageCommand_="
     )
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -92,14 +92,7 @@ mimaBinaryIssueFilters ++= {
       "com.typesafe.sbt.packager.docker.DockerKeys.dockerAutoremoveMultiStageIntermediateImages"
     ),
     ProblemFilters
-      .exclude[DirectMissingMethodProblem]("com.typesafe.sbt.packager.docker.DockerPlugin.publishLocalDocker"),
-    // added via #1312
-    ProblemFilters.exclude[ReversedMissingMethodProblem](
-      "com.typesafe.sbt.packager.graalvmnativeimage.GraalVMNativeImageKeys.graalVMNativeImageCommand"
-    ),
-    ProblemFilters.exclude[ReversedMissingMethodProblem](
-      "com.typesafe.sbt.packager.graalvmnativeimage.GraalVMNativeImageKeys.com$typesafe$sbt$packager$graalvmnativeimage$GraalVMNativeImageKeys$_setter_$graalVMNativeImageCommand_="
-    )
+      .exclude[DirectMissingMethodProblem]("com.typesafe.sbt.packager.docker.DockerPlugin.publishLocalDocker")
   )
 }
 

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
@@ -8,12 +8,14 @@ import sbt._
   * GraalVM settings
   */
 trait GraalVMNativeImageKeys {
-  val graalVMNativeImageCommand = settingKey[String]("GraalVM native-image executable name")
-
   val graalVMNativeImageOptions =
     settingKey[Seq[String]]("GraalVM native-image options")
 
   val graalVMNativeImageGraalVersion = settingKey[Option[String]](
     "Version of GraalVM to build with. Setting this has the effect of generating a container build image to build the native image with this version of GraalVM."
   )
+}
+
+trait GraalVMNativeImageKeysEx extends GraalVMNativeImageKeys {
+  val graalVMNativeImageCommand = settingKey[String]("GraalVM native-image executable command")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
@@ -8,6 +8,8 @@ import sbt._
   * GraalVM settings
   */
 trait GraalVMNativeImageKeys {
+  val graalVMNativeImageCommand = settingKey[String]("GraalVM native-image executable name")
+
   val graalVMNativeImageOptions =
     settingKey[Seq[String]]("GraalVM native-image options")
 

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
@@ -21,7 +21,7 @@ import com.typesafe.sbt.packager.universal.UniversalPlugin
   */
 object GraalVMNativeImagePlugin extends AutoPlugin {
 
-  object autoImport extends GraalVMNativeImageKeys {
+  object autoImport extends GraalVMNativeImageKeysEx {
     val GraalVMNativeImage: Configuration = config("graalvm-native-image")
   }
 

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
@@ -28,7 +28,6 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
   import autoImport._
 
   private val GraalVMBaseImage = "oracle/graalvm-ce"
-  private val NativeImageCommand = "native-image"
 
   override def requires: Plugins = JavaAppPackaging
 
@@ -38,6 +37,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
     target in GraalVMNativeImage := target.value / "graalvm-native-image",
     graalVMNativeImageOptions := Seq.empty,
     graalVMNativeImageGraalVersion := None,
+    graalVMNativeImageCommand := "native-image",
     resourceDirectory in GraalVMNativeImage := sourceDirectory.value / "graal",
     mainClass in GraalVMNativeImage := (mainClass in Compile).value
   ) ++ inConfig(GraalVMNativeImage)(scopedSettings)
@@ -55,6 +55,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
     packageBin := {
       val targetDirectory = target.value
       val binaryName = name.value
+      val nativeImageCommand = graalVMNativeImageCommand.value
       val className = mainClass.value.getOrElse(sys.error("Could not find a main class."))
       val classpathJars = scriptClasspathOrdering.value
       val extraOptions = graalVMNativeImageOptions.value
@@ -65,7 +66,15 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
 
       UniversalPlugin.autoImport.containerBuildImage.value match {
         case None =>
-          buildLocal(targetDirectory, binaryName, className, classpathJars.map(_._1), extraOptions, streams.log)
+          buildLocal(
+            targetDirectory,
+            binaryName,
+            nativeImageCommand,
+            className,
+            classpathJars.map(_._1),
+            extraOptions,
+            streams.log
+          )
 
         case Some(image) =>
           val resourceMappings = MappingsHelper.relative(graalResources, graalResourceDirectories)
@@ -87,6 +96,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
 
   private def buildLocal(targetDirectory: File,
                          binaryName: String,
+                         nativeImageCommand: String,
                          className: String,
                          classpathJars: Seq[File],
                          extraOptions: Seq[String],
@@ -94,11 +104,12 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
     targetDirectory.mkdirs()
     val command = {
       val nativeImageArguments = {
-        val classpath = classpathJars.mkString(":")
+        val classpath = classpathJars.mkString(System.getProperty("path.separator"))
         Seq("--class-path", classpath, s"-H:Name=$binaryName") ++ extraOptions ++ Seq(className)
       }
-      Seq(NativeImageCommand) ++ nativeImageArguments
+      Seq(nativeImageCommand) ++ nativeImageArguments
     }
+
     sys.process.Process(command, targetDirectory) ! log match {
       case 0 => targetDirectory / binaryName
       case x => sys.error(s"Failed to run $command, exit status: " + x)

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
@@ -104,7 +104,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
     targetDirectory.mkdirs()
     val command = {
       val nativeImageArguments = {
-        val classpath = classpathJars.mkString(System.getProperty("path.separator"))
+        val classpath = classpathJars.mkString(java.io.File.pathSeparator)
         Seq("--class-path", classpath, s"-H:Name=$binaryName") ++ extraOptions ++ Seq(className)
       }
       Seq(nativeImageCommand) ++ nativeImageArguments

--- a/src/sphinx/formats/graalvm-native-image.rst
+++ b/src/sphinx/formats/graalvm-native-image.rst
@@ -47,6 +47,19 @@ Required Settings
 Settings
 --------
 
+``native-image`` Executable Command (Pay attention if you are using Windows OS)
+~~~~
+Putting ``native-image`` in ``PATH`` does not work for Windows. ``native-image``is a batch file in Windows that calls another executable to compile the Java classes to a standalone executable. Therefore, the full path to the batch file e.g. ``C:\Program Files\Java\graalvm\bin\native-image.cmd`` must be provided. It is important to include ``.cmd``.
+
+  ``graalVMNativeImageCommand``
+    Set this parameter to point to ``native-image`` or ``native-image.cmd``. For Linux, set this parameter if it is inconvenient to make ``native-image`` available in your ``PATH``.
+
+    For example:
+
+    .. code-block:: scala
+
+      graalVMNativeImageCommand := "C:/Program Files/Java/graalvm/bin/native-image.cmd"
+
 Docker Image Build Settings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
* The final native-image executable cannot be located in the file
  native-image.cmd unless the full path to native-image.cmd is
  given. Therefore, a new parameter is provided to the user to
  specify the native-image.cmd location.
* Picks the right CLASSPATH separator according to the OS
  instead of hardcoded to colon. Using Colon will fail in Windows
  build.
* Tested against GraalVM 20.0.0 and VS 2019.