### PR TITLE
Improved layer grouping

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -57,8 +57,13 @@ private[packager] trait DockerKeysEx extends DockerKeys {
   lazy val dockerAdditionalPermissions =
     taskKey[Seq[(DockerChmodType, String)]]("Explicit chmod calls to some of the paths.")
   val dockerApiVersion = TaskKey[Option[DockerApiVersion]]("dockerApiVersion", "The docker server api version")
+  @deprecated("Use dockerGroupLayers instead", "1.7.1")
   val dockerLayerGrouping = settingKey[String => Option[Int]](
     "Group files by path into in layers to increase docker cache hits. " +
+      "Lower index means the file would be a part of an earlier layer."
+  )
+  val dockerGroupLayers = taskKey[PartialFunction[(File, String), Int]](
+    "Group files by mapping into layers to increase docker cache hits. " +
       "Lower index means the file would be a part of an earlier layer."
   )
   val dockerLayerMappings =

--- a/src/sbt-test/docker/test-layer-groups/build.sbt
+++ b/src/sbt-test/docker/test-layer-groups/build.sbt
@@ -6,5 +6,7 @@ version := "0.1.0"
 
 dockerPackageMappings in Docker ++= Seq(
   (baseDirectory.value / "docker" / "spark-env.sh") -> "/opt/docker/spark/spark-env.sh",
-  (baseDirectory.value / "docker" / "log4j.properties") -> "/opt/docker/spark/log4j.properties"
+  (baseDirectory.value / "docker" / "log4j.properties") -> "/opt/docker/other/log4j.properties"
 )
+
+libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.30"

--- a/src/sbt-test/docker/test-layer-groups/changes/nolayers.sbt
+++ b/src/sbt-test/docker/test-layer-groups/changes/nolayers.sbt
@@ -1,1 +1,1 @@
-dockerLayerGrouping in Docker  := (_ => None)
+dockerGroupLayers in Docker := PartialFunction.empty

--- a/src/sbt-test/docker/test-layer-groups/layers.sbt
+++ b/src/sbt-test/docker/test-layer-groups/layers.sbt
@@ -1,14 +1,6 @@
-dockerLayerGrouping in Docker := {
+dockerGroupLayers in Docker := {
   val dockerBaseDirectory = (defaultLinuxInstallLocation in Docker).value
-  (path: String) =>
-    {
-      val pathInWorkdir = path.stripPrefix(dockerBaseDirectory)
-      if (pathInWorkdir.startsWith(s"/lib/${organization.value}"))
-        Some(2)
-      else if (pathInWorkdir.startsWith("/bin/"))
-        Some(123)
-      else if (pathInWorkdir.startsWith("/spark/"))
-        Some(54)
-      else None
-    }
+  (dockerGroupLayers in Docker).value.orElse {
+    case (_, path) if path.startsWith(dockerBaseDirectory + "/spark/") => 54
+  }
 }

--- a/src/sbt-test/docker/test-layer-groups/test
+++ b/src/sbt-test/docker/test-layer-groups/test
@@ -1,17 +1,27 @@
 # Generate the Docker image locally
 > docker:publishLocal
 $ exists target/docker/stage/Dockerfile
-$ exists target/docker/stage/123/opt/docker/bin/docker-groups
-$ exists target/docker/stage/opt
+$ exists target/docker/stage/1/opt/docker/bin/docker-groups
+$ exists target/docker/stage/1/opt/docker/lib/org.slf4j.slf4j-api-1.7.30.jar
+-$ exists target/docker/stage/1/opt/docker/lib/com.example.docker-groups-0.1.0.jar
+$ exists target/docker/stage/opt/docker/other
 $ exists target/docker/stage/2
+-$ exists target/docker/stage/2/opt/docker/lib/org.slf4j.slf4j-api-1.7.30.jar
+$ exists target/docker/stage/2/opt/docker/lib/com.example.docker-groups-0.1.0.jar
 $ exists target/docker/stage/54/opt/docker/spark
 
-$ exec bash -c 'docker run --rm --entrypoint=ls docker-groups:0.1.0 |tr "\n" "," | grep -q "bin,lib,spark"'
+$ exec bash -c 'docker run --rm --entrypoint=ls docker-groups:0.1.0 |tr "\n" "," | grep -q "bin,lib,other,spark"'
 $ exec bash -c 'docker rmi docker-groups:0.1.0'
 
 $ copy-file changes/nolayers.sbt layers.sbt
 > reload
+> clean
 > docker:publishLocal
 $ exists target/docker/stage/opt/docker/bin
 $ exists target/docker/stage/opt/docker/spark
-$ exec bash -c 'docker run --rm --entrypoint=ls docker-groups:0.1.0 |tr "\n" "," | grep -q "bin,lib,spark"'
+-$ exists target/docker/stage/1
+-$ exists target/docker/stage/2
+-$ exists target/docker/stage/54
+$ exists target/docker/stage/opt/docker/lib/org.slf4j.slf4j-api-1.7.30.jar
+$ exists target/docker/stage/opt/docker/lib/com.example.docker-groups-0.1.0.jar
+$ exec bash -c 'docker run --rm --entrypoint=ls docker-groups:0.1.0 |tr "\n" "," | grep -q "bin,lib,other,spark"'


### PR DESCRIPTION
The main purpose of this change is to make layer grouping more robust.  Instead of using a heuristic based on whether a library is in the same `organization` as the build (which is not always what you want, some builds may have sub projects with different organizations, and some builds may depend on external dependencies from the same organization), it checks whether the library in question is present in `projectDependencyArtifacts` (ie, whether its a dependency built by this build), if it is, then it goes in a higher layer.

Doing this change however required changing `dockerLayerGrouping` to be a `TaskKey` instead of a `SettingKey`, which is a non binary compatible change. So, `dockerLayerGrouping` has been deprecated, and a new `TaskKey`, `dockerGroupLayers` has been introduced.

Since a new task has been introduced, I also took advantage of that to improve the types, instead of just passing the destination path, which requires you to know how destination paths are built to check if a particular file should be in there, it passes the whole mapping, ie, the source file and the destination path, which means that you can match against the source file (which is what `projectDependencyArtifacts` gives you) as well. Also, I changed the type from a function that returns an `Option` to a `PartialFunction`, this makes composing it, to introduce new mappings, far simpler, as `PartialFunction[_, _]` composes trivially compared to `Function[_, Option[_]]`.