### PR TITLE
Add space between inline-literal symbol and word

### DIFF
--- a/src/sphinx/formats/graalvm-native-image.rst
+++ b/src/sphinx/formats/graalvm-native-image.rst
@@ -49,7 +49,7 @@ Settings
 
 ``native-image`` Executable Command (Pay attention if you are using Windows OS)
 ~~~~
-Putting ``native-image`` in ``PATH`` does not work for Windows. ``native-image``is a batch file in Windows that calls another executable to compile the Java classes to a standalone executable. Therefore, the full path to the batch file e.g. ``C:\Program Files\Java\graalvm\bin\native-image.cmd`` must be provided. It is important to include ``.cmd``.
+Putting ``native-image`` in ``PATH`` does not work for Windows. ``native-image`` is a batch file in Windows that calls another executable to compile the Java classes to a standalone executable. Therefore, the full path to the batch file e.g. ``C:\Program Files\Java\graalvm\bin\native-image.cmd`` must be provided. It is important to include ``.cmd``.
 
   ``graalVMNativeImageCommand``
     Set this parameter to point to ``native-image`` or ``native-image.cmd``. For Linux, set this parameter if it is inconvenient to make ``native-image`` available in your ``PATH``.


### PR DESCRIPTION
There is a missing space between `` and word causes paragraph to overrun the right margin