### PR TITLE
Add support for docker:publish in DockerSpotifyClientPlugin

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -55,6 +55,7 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
   def clientSettings =
     Seq(
       publishLocal := publishLocalDocker.value,
+      publish := publishDocker.value,
       dockerVersion := dockerServerVersion.value,
       dockerApiVersion := dockerServerApiVersion.value
     )
@@ -69,6 +70,15 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
 
     val docker = new DockerClientTask()
     docker.packageDocker(primaryAlias, aliases, dockerDirectory, log)
+  }
+
+  def publishDocker: Def.Initialize[Task[Unit]] = Def.task {
+    val _ = publishLocal.value
+    val aliases = dockerAliases.value
+    val log = streams.value.log
+
+    val docker = new DockerClientTask()
+    docker.publishDocker(aliases, log)
   }
 
   def dockerServerVersion: Def.Initialize[Task[Option[DockerVersion]]] = Def.task {
@@ -104,16 +114,20 @@ private class DockerClientTask {
 
     log.info(s"PublishLocal using Docker API ${docker.version().apiVersion()}")
 
-    docker.build(Paths.get(dockerDirectory), primaryAlias.toString, new ProgressHandler {
-      override def progress(message: ProgressMessage): Unit =
-        Option(message.error()) match {
-          case Some(error) if error.nonEmpty => log.error(message.error())
-          case _                             => Option(message.stream()) foreach (v => log.info(v))
-        }
-    }, BuildParam.forceRm())
+    docker.build(Paths.get(dockerDirectory), primaryAlias.toString, progressHandler(log), BuildParam.forceRm())
 
     aliases.foreach { tag =>
       docker.tag(primaryAlias.toString, tag.toString, true)
+    }
+  }
+
+  def publishDocker(aliases: Seq[DockerAlias], log: Logger): Unit = {
+    val docker: DockerClient = DefaultDockerClient.fromEnv().build()
+
+    log.info(s"Publish using Docker API ${docker.version().apiVersion()}")
+
+    aliases.foreach { tag =>
+      docker.push(tag.toString, progressHandler(log))
     }
   }
 
@@ -125,5 +139,13 @@ private class DockerClientTask {
   def dockerServerApiVersion(): Option[DockerApiVersion] = {
     val docker: DockerClient = DefaultDockerClient.fromEnv().build()
     DockerApiVersion.parse(docker.version().apiVersion())
+  }
+
+  private def progressHandler(log: Logger) = new ProgressHandler {
+    override def progress(message: ProgressMessage): Unit =
+      Option(message.error()) match {
+        case Some(error) if error.nonEmpty => log.error(message.error())
+        case _                             => Option(message.stream()) foreach (v => log.info(v))
+      }
   }
 }


### PR DESCRIPTION
This adds support for pushing built tags in DockerSpotifyClientPlugin.
Additionally, this introduces a small refactoring to extract the
definition of the ProgressHandler, used by both building and pushing
tasks to log progress.