### PR TITLE
fix(Docker.*?Plugin): restore the sbt-standard task concurrency tags

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -60,26 +60,28 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
       dockerApiVersion := dockerServerApiVersion.value
     )
 
-  def publishLocalDocker: Def.Initialize[Task[Unit]] = Def.task {
-    val context = stage.value
-    val primaryAlias = dockerAlias.value
-    val aliases = dockerAliases.value
-    val log = streams.value.log
+  def publishLocalDocker: Def.Initialize[Task[Unit]] =
+    Def.task {
+      val context = stage.value
+      val primaryAlias = dockerAlias.value
+      val aliases = dockerAliases.value
+      val log = streams.value.log
 
-    val dockerDirectory = context.toString
+      val dockerDirectory = context.toString
 
-    val docker = new DockerClientTask()
-    docker.packageDocker(primaryAlias, aliases, dockerDirectory, log)
-  }
+      val docker = new DockerClientTask()
+      docker.packageDocker(primaryAlias, aliases, dockerDirectory, log)
+    } tag (Tags.Publish, Tags.Disk)
 
-  def publishDocker: Def.Initialize[Task[Unit]] = Def.task {
-    val _ = publishLocal.value
-    val aliases = dockerAliases.value
-    val log = streams.value.log
+  def publishDocker: Def.Initialize[Task[Unit]] =
+    Def.task {
+      val _ = publishLocal.value
+      val aliases = dockerAliases.value
+      val log = streams.value.log
 
-    val docker = new DockerClientTask()
-    docker.publishDocker(aliases, log)
-  }
+      val docker = new DockerClientTask()
+      docker.publishDocker(aliases, log)
+    } tag (Tags.Network, Tags.Publish)
 
   def dockerServerVersion: Def.Initialize[Task[Option[DockerVersion]]] = Def.task {
     val docker = new DockerClientTask()


### PR DESCRIPTION
The purpose of this PR is to restore (and adjust) the concurrency tags offered by sbt (https://www.scala-sbt.org/1.x/docs/Parallel-Execution.html) in order to control parallel execution.

By default, sbt tags the "publishLocal" and "publish" tasks with the `Publish` and `Network` tags so that one might limit the number of concurrent tasks competing for resources. 

On a large multi-project, multiple subprojects might be attempting to publishLocal simultaneously (i.e. spin up containers in order to build images) which can exhaust memory available to Docker or cause a longer time to build due to contention on the disk. This PR restores tags on the Docker/publish and Docker/publishLocal tasks so that the user can limit publications and/or image constructions to levels consistent with capacity.

The difference with sbt defaults is that the `publishLocal` task is tagged with the _Publish_ and **Disk** tags, while the `publish` task gets the sbt defaults _Publish_ and *Network*. In practice, the `publish` task will remain throttled by the availability of the *Disk* tag as well, as it depends on `publishLocal` anyway.