### PR TITLE
docker: make None the last layer group

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -167,7 +167,10 @@ object DockerPlugin extends AutoPlugin {
       val generalCommands = makeFromAs(base, "mainstage") +: makeMaintainer((maintainer in Docker).value).toSeq
       val stage0name = "stage0"
       val layerMappings = (dockerLayerMappings in Docker).value
-      val layerIdsAscending = layerMappings.map(_.layerId).distinct.sorted
+      val layerIdsAscending = layerMappings.map(_.layerId).distinct.sortWith { (a, b) =>
+        // Make the None (unspecified) layer the last layer
+        a.getOrElse(Int.MaxValue) < b.getOrElse(Int.MaxValue)
+      }
       val stage0: Seq[CmdLike] = strategy match {
         case DockerPermissionStrategy.MultiStage =>
           Seq(

--- a/src/sbt-test/docker/test-layer-groups/build.sbt
+++ b/src/sbt-test/docker/test-layer-groups/build.sbt
@@ -10,3 +10,27 @@ dockerPackageMappings in Docker ++= Seq(
 )
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.30"
+
+TaskKey[Unit]("checkDockerfile") := {
+  val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
+  val copyLines = dockerfile.linesIterator.toList.filter(_.startsWith("COPY --from=stage0"))
+  assertEquals(copyLines,
+    """COPY --from=stage0 --chown=demiourgos728:root /1/opt/docker /opt/docker
+      |COPY --from=stage0 --chown=demiourgos728:root /2/opt/docker /opt/docker
+      |COPY --from=stage0 --chown=demiourgos728:root /54/opt/docker /opt/docker
+      |COPY --from=stage0 --chown=demiourgos728:root /opt/docker /opt/docker""".stripMargin.linesIterator.toList)
+}
+
+TaskKey[Unit]("checkDockerfileWithNoLayers") := {
+  val dockerfile = IO.read((stagingDirectory in Docker).value / "Dockerfile")
+  val copyLines = dockerfile.linesIterator.toList.filter(_.startsWith("COPY --from=stage0"))
+  assertEquals(copyLines,
+    """COPY --from=stage0 --chown=demiourgos728:root /opt/docker /opt/docker""".stripMargin.linesIterator.toList)
+}
+
+def assertEquals(left: List[String], right: List[String]) =
+  assert(left == right,
+    "\n" + ((left zip right) flatMap { case (a: String, b: String) =>
+      if (a == b) Nil
+      else List("- " + a, "+ " + b)
+    }).mkString("\n"))

--- a/src/sbt-test/docker/test-layer-groups/test
+++ b/src/sbt-test/docker/test-layer-groups/test
@@ -12,6 +12,7 @@ $ exists target/docker/stage/54/opt/docker/spark
 
 $ exec bash -c 'docker run --rm --entrypoint=ls docker-groups:0.1.0 |tr "\n" "," | grep -q "bin,lib,other,spark"'
 $ exec bash -c 'docker rmi docker-groups:0.1.0'
+> checkDockerfile
 
 $ copy-file changes/nolayers.sbt layers.sbt
 > reload
@@ -25,3 +26,4 @@ $ exists target/docker/stage/opt/docker/spark
 $ exists target/docker/stage/opt/docker/lib/org.slf4j.slf4j-api-1.7.30.jar
 $ exists target/docker/stage/opt/docker/lib/com.example.docker-groups-0.1.0.jar
 $ exec bash -c 'docker run --rm --entrypoint=ls docker-groups:0.1.0 |tr "\n" "," | grep -q "bin,lib,other,spark"'
+> checkDockerfileWithNoLayers


### PR DESCRIPTION
Currently, if a user adds additional artifact to the Docker build
without modifying dockerGroupLayers, the artifact will have "None"
grouping and be put as the first layer in the output.

These additional artifacts are often configuration or supporting
assets. Making this the zeroth layer by default causes dependency
layer to not be re-used if any of these artifacts are changed.

Since not all users will care to modify dockerGroupLayers, the
default should be to make it such that adding additional artifact
does not break re-use of the dependency layer.