### PR TITLE
Omit removed Java modules from detected jlinkModules

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -119,11 +119,26 @@ object JlinkPlugin extends AutoPlugin {
       // At least the new modules shouldn't be doing this...
       val knownJakartaJavaModules = Set("java.xml.bind", "java.xml.soap", "java.ws.rs")
 
+      // Java platform modules that were officially removed.
+      // https://www.oracle.com/java/technologies/javase/jdk-11-relnote.html#JDK-8190378
+      val removedJavaModules = Set(
+        "java.xml.ws",
+        "java.xml.bind",
+        "java.activation",
+        "java.xml.ws.annotation",
+        "java.corba",
+        "java.transaction",
+        "java.se.ee",
+        "jdk.xml.ws",
+        "jdk.xml.bind"
+      )
+
       val filteredModuleDeps = detectedModuleDeps
         .filter { m =>
           m.startsWith("jdk.") || m.startsWith("java.")
         }
         .filterNot(knownJakartaJavaModules.contains)
+        .filterNot(removedJavaModules.contains)
 
       // We always want `java.base`, and `jlink` requires at least one module.
       (filteredModuleDeps + "java.base").toSeq

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -117,7 +117,7 @@ object JlinkPlugin extends AutoPlugin {
       // This requires special handling on our part when deciding if the module
       // is a part of the platform or not.
       // At least the new modules shouldn't be doing this...
-      val knownJakartaJavaModules = Set("java.xml.bind", "java.xml.soap", "java.ws.rs")
+      val knownJakartaJavaModules = Set("java.annotation", "java.xml.bind", "java.xml.soap", "java.ws.rs")
 
       // Java platform modules that were officially removed.
       // https://www.oracle.com/java/technologies/javase/jdk-11-relnote.html#JDK-8190378


### PR DESCRIPTION
We're already skipping detection for some Jakarta modules that have legacy `java.*` names. However, there is another source of information - the release notes for Java 11 have [a list](https://www.oracle.com/java/technologies/javase/jdk-11-relnote.html#JDK-8190378) of all removed modules. This PR filters these out as well. Although there is some overlap, I've opted to keep the lists from two sources separate, since the modules are filtered out for different reasons.

Regarding compatibility, this shouldn't impact most builds that use Java 11 and later. For such a build the removed modules could only have come from Jakarta artifacts and such, so they should be present in the project's classpath anyway. 