### PR TITLE
Update Graalvm docker repository & build version

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
@@ -27,7 +27,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
 
   import autoImport._
 
-  private val GraalVMBaseImage = "oracle/graalvm-ce"
+  private val GraalVMBaseImage = "ghcr.io/graalvm/graalvm-ce"
 
   override def requires: Plugins = JavaAppPackaging
 

--- a/src/sbt-test/graalvm-native-image/docker-native-image/build.sbt
+++ b/src/sbt-test/graalvm-native-image/docker-native-image/build.sbt
@@ -2,4 +2,4 @@ enablePlugins(GraalVMNativeImagePlugin)
 
 name := "docker-test"
 version := "0.1.0"
-graalVMNativeImageGraalVersion := Some("19.0.0")
+graalVMNativeImageGraalVersion := Some("21.0.0")


### PR DESCRIPTION
Closes #1394.

For some reason, the native-image binary is not able to find the Main class... when running `sbt scripted graalvm-native-image/*` 
Didn't look too deep into the cause yet.