### PR TITLE
Move some defaults of docker to global scope

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -78,10 +78,7 @@ object DockerPlugin extends AutoPlugin {
     // Instead of making dockerPermissionStrategy dependent on the Docker version, what we do instead is to
     // run validation, and warn the build users if the strategy is not compatible with `docker` that's in scope.
     dockerPermissionStrategy := DockerPermissionStrategy.MultiStage,
-    dockerChmodType := DockerChmodType.UserGroupReadExecute
-  )
-
-  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+    dockerChmodType := DockerChmodType.UserGroupReadExecute,
     dockerBaseImage := "openjdk:8",
     dockerExposedPorts := Seq(),
     dockerExposedUdpPorts := Seq(),
@@ -90,14 +87,18 @@ object DockerPlugin extends AutoPlugin {
     dockerEnvVars := Map(),
     dockerRepository := None,
     dockerUsername := None,
+    dockerUpdateLatest := false,
+    dockerAutoremoveMultiStageIntermediateImages := true,
+    dockerCmd := Seq()
+  )
+
+  override lazy val projectSettings: Seq[Setting[_]] = Seq(
     dockerAlias := DockerAlias(
       (dockerRepository in Docker).value,
       (dockerUsername in Docker).value,
       (packageName in Docker).value,
       Option((version in Docker).value)
     ),
-    dockerUpdateLatest := false,
-    dockerAutoremoveMultiStageIntermediateImages := true,
     dockerLayerGrouping := { _: String =>
       None
     },
@@ -126,7 +127,6 @@ object DockerPlugin extends AutoPlugin {
         Seq(alias)
     },
     dockerEntrypoint := Seq(s"${(defaultLinuxInstallLocation in Docker).value}/bin/${executableScriptName.value}"),
-    dockerCmd := Seq(),
     dockerVersion := Try(
       Process(dockerExecCommand.value ++ Seq("version", "--format", "'{{.Server.Version}}'")).!!
     ).toOption

--- a/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
@@ -47,13 +47,14 @@ object UniversalPlugin extends AutoPlugin {
   override def projectConfigurations: Seq[Configuration] =
     Seq(Universal, UniversalDocs, UniversalSrc)
 
-  override lazy val buildSettings: Seq[Setting[_]] = Seq[Setting[_]](
-    // Since more than just the docker plugin uses the docker command, we define this in the universal plugin
-    // so that it can be configured once and shared by all plugins without requiring the docker plugin. Also, make it
-    // a build settings so that it can be overridden once, at the build level.
-    DockerPlugin.autoImport.dockerExecCommand := Seq("docker"),
-    containerBuildImage := None
-  )
+  override def globalSettings: Seq[Def.Setting[_]] =
+    Seq[Setting[_]](
+      // Since more than just the docker plugin uses the docker command, we define this in the universal plugin
+      // so that it can be configured once and shared by all plugins without requiring the docker plugin.
+      DockerPlugin.autoImport.dockerExecCommand := Seq("docker")
+    )
+
+  override lazy val buildSettings: Seq[Setting[_]] = Seq[Setting[_]](containerBuildImage := None)
 
   /** The basic settings for the various packaging types. */
   override lazy val projectSettings: Seq[Setting[_]] = Seq[Setting[_]](


### PR DESCRIPTION
SBT strongly recommends to use the global scope for default settings,
see https://www.scala-sbt.org/1.x/docs/Plugins-Best-Practices.html#Provide+default+values+in

This allows to set the docker image and common labels once in ThisBuild
for all subprojects, and makes it easier to use a different
docker-compatible container builder by overriding the command, e.g.

    sbt 'set ThisBuild / dockerExecCommand := Seq("podman")' docker:publish