### PR TITLE
Update dockerGroupLayers documentation

### DIFF
--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -150,7 +150,7 @@ Environment Settings
     Lower index means the file would be a part of an earlier layer.
     The main idea behind this is to COPY dependencies *.jar's first as they should change rarely.
     In separate command COPY the application *.jar's that should change more often.
-    Defaults to detect whether the file name starts with ``ThisBuild / organization``.
+    Defaults to map the project artifacts and its dependencies to separate layers.
     To disable layers map all files to no layer using ``dockerGroupLayers in Docker := PartialFunction.empty``.
 
 Publishing Settings


### PR DESCRIPTION
Docs reflect the implementation since it's now based on JavaAppPackaging#projectDependencyArtifacts.
* https://github.com/sbt/sbt-native-packager/blob/master/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala#L59
* https://github.com/sbt/sbt-native-packager/blob/master/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala#L108