### PR TITLE
Only set executable permission on staged files if required and not set

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/Stager.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Stager.scala
@@ -30,7 +30,9 @@ object Stager {
     // TODO - Config file user-readable permissions....
     for {
       (from, to) <- copies
-      if from.canExecute
+      // Only set executable permission if it needs to be set. Note: calling to.setExecutable(true) if it's already
+      // executable is undesirable for a developer using inotify to watch this file as it will trigger events again
+      if from.canExecute && !to.canExecute
     } to.setExecutable(true)
     stageDirectory
   }


### PR DESCRIPTION
When staging files, only set the target executable permission if the source file is executable and the target file is not executable.

It can be problematic if setting the executable permission on a target file multiple times if using inotify to watch staged files as inotify events will be triggered even when the permission is already set. This fix ensures the executable permission is only set once, to avoid unnecessary inotify events.

I am using development tools to watch the stage directory but currently they get triggered if I run the stage task even when there aren't any changes due to setting the executable permission unnecessarily.

To see this in action, assuming you had an example project with stage script at `example/target/universal/stage/bin/example`  you can run the following to see a demonstration of this problem.

In a terminal run:
`inotifywait -m example/target/universal/stage/bin/example`

In another terminal run the following:
`sbt example/stage`

You'll see this output from the first terminal:
```
example/target/universal/stage/bin/example ATTRIB 
example/target/universal/stage/bin/example OPEN 
example/target/universal/stage/bin/example ACCESS 
example/target/universal/stage/bin/example CLOSE_NOWRITE,CLOSE 
```

Run `sbt example/stage` again and you'll see the same output. 

If you run `chmod u+x example/target/universal/stage/bin/example` you will still see the same output which demonstrates that the stage task has the same behaviour as this.

After applying the change in this pull request, running `sbt example/stage` multiple times will only trigger inotify events the first time the script is created.