### PR TITLE
Fix scope for rpmVendor

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -67,7 +67,7 @@ object RpmPlugin extends AutoPlugin {
     rpmOs := "Linux", // TODO - default to something else?
     rpmRelease := (if (isSnapshot.value) "SNAPSHOT" else "1"),
     rpmPrefix := None,
-    rpmVendor := "", // TODO - Maybe pull in organization?
+    rpmVendor in Rpm := "", // TODO - Maybe pull in organization?
     rpmLicense := None,
     rpmEpoch := None,
     rpmDistribution := None,
@@ -118,7 +118,7 @@ object RpmPlugin extends AutoPlugin {
       rpmRelease.value,
       rpmPrefix.value,
       (packageArchitecture in Rpm).value,
-      rpmVendor.value,
+      (rpmVendor in Rpm).value,
       rpmOs.value,
       (packageSummary in Rpm).value,
       (packageDescription in Rpm).value,

--- a/src/sbt-test/rpm/simple-rpm/build.sbt
+++ b/src/sbt-test/rpm/simple-rpm/build.sbt
@@ -15,7 +15,7 @@ packageDescription := """A fun package description of our software,
 
 rpmRelease := "1"
 
-rpmVendor := "typesafe"
+rpmVendor in Rpm := "typesafe"
 
 rpmUrl := Some("http://github.com/sbt/sbt-native-packager")
 


### PR DESCRIPTION
I've fixed only `rpmVendor` because it's mentioned in the docs as a required setting as `rpmVendor in Rpm := "someVendor"`. But now it works only without `Rpm` scope. 

Do you think that we need to scope all other settings? I could do it if needed.

Also the default value `None` looks better for me instead of empty string. I'm not very familiar with RPM specs unfortunately