### PR TITLE
Don't hard-code xz compression option "-9e". If compression level was…

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
@@ -200,7 +200,7 @@ object Archives {
     */
   def xz(f: File): File = {
     val par = f.getParentFile
-    sys.process.Process(Seq("xz", "-9e", "-S", ".xz", f.getAbsolutePath), Some(par)).! match {
+    sys.process.Process(Seq("xz", /*"-9e",*/ "-S", ".xz", f.getAbsolutePath), Some(par)).! match {
       case 0 => ()
       case n => sys.error("Error xz-ing " + f + ". Exit code: " + n)
     }


### PR DESCRIPTION
Don't hard-code compression option **`-9e`** in the xz command-line used by SBT. 

If the compression options weren't hard-coded, the user would be able to set the desired compression options via environment variable `XZ_OPT`. But, currently, since **`-9e`** is hard-coded, the options in `XZ_OPT` will always be overwritten by the actual xz command-line! Also **`-9e`** is *not* a good default to begin with. Level `-9` is very slow and needs a whole lot memory (can cause OOM killer to kill your build process!) for probably only a little improvement in compression ratio, compared to the *default* compression level. Furthermore, and even worse, option **`-e`** easily doubles compression time for marginal improvement in compression ratio (if at all). Option **`-e`**,  that's really something you'd use if don't care about compression time at all. IMHO it really makes much more sense to just use the xz defaults and let the user override them, via `XZ_OPT` environment variable, if desired.

...either that, or give the use a way to set the xz compression options in the `build.sbt` file (please see my [ticket](#1426) for details).

-----------------

**Form the xz manpage:**
* On compression levels:  
  > Unless you want to maximize the compression ratio, you probably don't want a higher preset level than -7 due to speed and memory usage.
* On the '-e' option:  
  > Modify the compression preset (-0 ... -9) so that a little bit better compression ratio can be achieved without increasing memory usage of the compressor or decompressor. The downside is that the compression time will increase dramatically (it can easily double).

https://linux.die.net/man/1/xz

-----------------

This fixes #1426.