### PR TITLE
Replace obsolete Bintray badge with Scaladex version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://api.travis-ci.org/sbt/sbt-native-packager.png?branch=master)](https://travis-ci.org/sbt/sbt-native-packager)
 [![Build status](https://ci.appveyor.com/api/projects/status/pbxd0untlcst4we7/branch/master?svg=true)](https://ci.appveyor.com/project/muuki88/sbt-native-packager/branch/master)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/0e9a7ec769c84e578f4550bf7da6bf05)](https://www.codacy.com/app/nepomukseiler/sbt-native-packager?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=sbt/sbt-native-packager&amp;utm_campaign=Badge_Grade)
-[ ![Download](https://api.bintray.com/packages/sbt/sbt-plugin-releases/sbt-native-packager/images/download.svg) ](https://bintray.com/sbt/sbt-plugin-releases/sbt-native-packager/_latestVersion)
+[![sbt-native-packager Scala version support](https://index.scala-lang.org/sbt/sbt-native-packager/sbt-native-packager/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-native-packager/sbt-native-packager)
 [![Join the chat at https://gitter.im/sbt/sbt-native-packager](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/sbt/sbt-native-packager?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Documentation Status](https://readthedocs.org/projects/sbt-native-packager/badge/?version=latest)](http://sbt-native-packager.readthedocs.org/en/latest/?badge=latest)
 


### PR DESCRIPTION
Unfortunately the Bintray badge on the readme is broken, I guess due to Bintray being [sunset](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)? However, this new Scaladex badge can replace the old Bintray badge - it summarises which versions of sbt are supported by sbt-native-packager (and what the latest sbt-native-packager version is for each of those sbt versions):

[![sbt-native-packager Scala version support](https://index.scala-lang.org/sbt/sbt-native-packager/sbt-native-packager/latest-by-scala-version.svg?targetType=Sbt)](https://index.scala-lang.org/sbt/sbt-native-packager/sbt-native-packager)

More details on the badge format here: https://github.com/scalacenter/scaladex/pull/660 (with some extra changes to better support sbt in https://github.com/scalacenter/scaladex/pull/674).