### PR TITLE
Use only Unix file separators when generating Unix scripts

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/AshScriptPlugin.scala
@@ -109,7 +109,7 @@ object AshScriptPlugin extends AutoPlugin {
     private[this] def makeClasspathDefine(cp: Seq[String]): String = {
       val fullString = cp map (
         n =>
-          if (n.startsWith(File.separator)) n
+          if (n.startsWith("/")) n
           else "$lib_dir/" + n
       ) mkString ":"
       "app_classpath=\"" + fullString + "\"\n"

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -124,7 +124,7 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
     private[this] def makeClasspathDefine(cp: Seq[String]): String = {
       val fullString = cp map (
         n =>
-          if (n.startsWith(File.separator)) n
+          if (n.startsWith("/")) n
           else "$lib_dir/" + n
       ) mkString ":"
       "declare -r app_classpath=\"" + fullString + "\"\n"


### PR DESCRIPTION
When generating Unix startup scripts, `scriptClasspath` always uses Unix file separators (`/`). Therefore, `File.separator` cannot be used because the build environment may be on another system (Windows). We must always use Unix file separator when working with Unix paths.

This problem was discovered by me when I tried to build a Linux docker image on Windows. Bash startup script had wrong classpath generated.