### PR TITLE
Fix for realpath in top-level directories

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -28,16 +28,19 @@ realpath () {
 
   if [ "$TARGET_FILE" == "." -o "$TARGET_FILE" == ".." ]; then
     cd "$TARGET_FILE"
-    TARGET_FILEPATH=
+  fi
+  TARGET_DIR="$(pwd -P)"
+  if [ "$TARGET_DIR" == "/" ]; then
+    TARGET_FILE="/$TARGET_FILE"
   else
-    TARGET_FILEPATH=/$TARGET_FILE
+    TARGET_FILE="$TARGET_DIR/$TARGET_FILE"
   fi
 
   # make sure we grab the actual windows path, instead of cygwin's path.
   if [[ "x$CHECK_CYGWIN" == "x" ]]; then
-    echo "$(pwd -P)/$TARGET_FILE"
+    echo "$TARGET_FILE"
   else
-    echo $(cygwinpath "$(pwd -P)/$TARGET_FILE")
+    echo $(cygwinpath "$TARGET_FILE")
   fi
 )
 }


### PR DESCRIPTION
The `realpath` function returns a slightly wrong path for top-level directories. `realpath /root` gives `//root`. This can cause real issues and has led me on a wild goose chase yesterday. (https://github.com/lynxkite/lynxkite/issues/200)

Maybe I should have filed a bug instead of a pull request. I'm not sure this is the best fix. And this same function is repeated in a few places. (`ash-template` in this repo, and another script in the `sbt` repo, at least.) Let me know what's your preference.

Thanks!