### PR TITLE
Downgrade scala-parser-combinators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,8 +40,12 @@ libraryDependencies ++= {
     case "2.10" => Nil
     case _ =>
       Seq(
-        "org.scala-lang.modules" %% "scala-parser-combinators" % "2.0.0",
-        "org.scala-lang.modules" %% "scala-xml" % "1.1.1"
+        // Do NOT upgrade these dependencies to 2.x or newer! sbt-native-packager is a sbt-plugin
+        // and gets published with Scala 2.12, therefore we need to stay at the same major version
+        // like the 2.12.x Scala compiler, otherwise we run into conflicts when using sbt 1.5+
+        // See https://github.com/scala/scala/pull/9743
+        "org.scala-lang.modules" %% "scala-parser-combinators" % "1.1.2", // Do not upgrade beyond 1.x
+        "org.scala-lang.modules" %% "scala-xml" % "1.3.0" // Do not upgrade beyond 1.x
       )
   }
 }


### PR DESCRIPTION
See explanation here: https://github.com/sbt/sbt-native-packager/pull/1442#issuecomment-909040300
Discussion in the scala repo: https://github.com/scala/scala/pull/9743
Same PR for twirl: https://github.com/playframework/twirl/pull/439

BTW I upgraded scala-xml to scala to 1.3.0, the latest release in the 1.x series, which is totally fine here (because we stay on 1.x)

@muuki88 I am pretty sure this needs to be done.