### PR TITLE
use proper native image command on windows

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
@@ -37,7 +37,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
     target in GraalVMNativeImage := target.value / "graalvm-native-image",
     graalVMNativeImageOptions := Seq.empty,
     graalVMNativeImageGraalVersion := None,
-    graalVMNativeImageCommand := "native-image",
+    graalVMNativeImageCommand := (if (scala.util.Properties.isWin) "native-image.cmd" else "native-image"),
     resourceDirectory in GraalVMNativeImage := sourceDirectory.value / "graal",
     mainClass in GraalVMNativeImage := (mainClass in Compile).value
   ) ++ inConfig(GraalVMNativeImage)(scopedSettings)

--- a/src/sphinx/formats/graalvm-native-image.rst
+++ b/src/sphinx/formats/graalvm-native-image.rst
@@ -49,10 +49,8 @@ Settings
 
 ``native-image`` Executable Command (Pay attention if you are using Windows OS)
 
-Putting ``native-image`` in ``PATH`` does not work for Windows. ``native-image`` is a batch file in Windows that calls another executable to compile the Java classes to a standalone executable. Therefore, the full path to the batch file e.g. ``C:\Program Files\Java\graalvm\bin\native-image.cmd`` must be provided. It is important to include ``.cmd``.
-
   ``graalVMNativeImageCommand``
-    Set this parameter to point to ``native-image`` or ``native-image.cmd``. For Linux, set this parameter if it is inconvenient to make ``native-image`` available in your ``PATH``.
+    Set this parameter to point to ``native-image`` or ``native-image.cmd``. Set this parameter if it is inconvenient to make ``native-image`` available in your ``PATH``.
 
     For example:
 


### PR DESCRIPTION
previous fix assumed native-image.cmd from path won't work, but it seems to work fine