### PR TITLE
Add sbt-vspp for publishing the SBT plug-in in a Maven-consistent format

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 
 // binary compatibility checks
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.9.2")
+
+// for enterprise Artifactory compatibility
+addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")


### PR DESCRIPTION
This is to enable usage of sbt-native-packager in Enterprise environments where only the valid-POM format is accepted for JAR downloads, enabling the very powerful sbt-native-packager for thousands of developers.

More background here: https://github.com/esbeetee/sbt-vspp/blob/main/README.md