### PR TITLE
Support cross building

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -74,4 +74,6 @@ private[packager] trait DockerKeysEx extends DockerKeys {
       "Setting to true will cause Docker to bundle a tini in the container, to run as the init process, which is recommended for JVM apps. " +
       "Requires Docker API version 1.25+"
   )
+  val dockerBuildxPlatforms =
+    SettingKey[Seq[String]]("dockerBuildxPlatforms", "The docker image platforms for buildx multi-platform build")
 }

--- a/test-project-docker/build.sbt
+++ b/test-project-docker/build.sbt
@@ -6,3 +6,5 @@ version := "0.1.0"
 maintainer := "Gary Coady <gary@lyranthe.org>"
 dockerBaseImage := "openjdk:8-jre-alpine"
 dockerUpdateLatest := true
+dockerBuildxPlatforms := Seq("linux/arm64/v8", "linux/amd64")
+dockerUsername := Some("dswiecki")

--- a/test-project-docker/project/build.properties
+++ b/test-project-docker/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.5.4


### PR DESCRIPTION
Fixes #1503 
It's a POC how cross building can look like.
Assumes buildx available in system.
Problem and limitations:
- due to docker buildx sytnax pushing must be done at once with `docker buildx build` and all platforms. Otherwise, only the last arch is pushed, I could be done with `docker manifest` but would be more complex
- no changes in publishLocal - I assume that the user can only have arch version supporting his computer architecture locally
- binary compatibility - here I need your advice on whether you'll accept changing `publishDocker` signature and which version compatibility should be checked for

Example docker repo https://hub.docker.com/r/dswiecki/docker-test/tags
