### PR TITLE
Fix bug introduced in #1527

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -286,7 +286,7 @@ object DockerPlugin extends AutoPlugin {
               s"--platform=${dockerBuildxPlatforms.value.mkString(",")}",
               "--push"
             ) ++ dockerBuildOptions.value :+ "."
-          else dockerBuildCommand.value
+          else dockerExecCommand.value
         alias.foreach { aliasValue =>
           publishDocker(context, execCommand, aliasValue.toString, log, multiplatform)
         }


### PR DESCRIPTION
See https://github.com/sbt/sbt-native-packager/pull/1527/files#diff-b866751bc91854625b6a5d821ae6a4df02736ceb3581779d81319caee1d9d2cdL278-R289

Error when publishing:
```bash
[error] ERROR: "docker buildx build" requires exactly 1 argument.
[error] See 'docker buildx build --help'.
[error] Usage:  docker buildx build [OPTIONS] PATH | URL | -
[error] Start a build
[error] stack trace is suppressed; run last my-app / Docker / publish for the full output
[error] (my-app / Docker / publish) Nonzero exit value: 1
[error] Total time: 189 s (03:09), completed 17 Jan 2023, 12:33:37 pm
```