### PR TITLE
FIX #1491 DockerPlugin doesn't work with multiple main classes 

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -109,6 +109,16 @@ ${{template_declares}}
 
 process_args "$@"
 
+# Fallback to custom mainclass if main class is not provided (this is the case if the JAR contains multiple apps)
+if [ "$app_mainclass" = "" ] || [ $custom_mainclass ];then
+  if [ "$custom_mainclass" = "" ]; then
+    echo "You need to pass -main argument."
+    exit 1
+  fi
+
+  app_mainclass=$custom_mainclass
+fi
+
 java_cmd="$(get_java_cmd)"
 
 # If a configuration file exist, read the contents to $opts

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -246,6 +246,16 @@ run() {
     mainclass=("${app_mainclass[@]}")
   fi
 
+  # Fallback to custom mainclass if main class is not provided (this is the case if the JAR contains multiple apps)
+  if [ "$app_mainclass" = "" ] || [ $custom_mainclass ];then
+    if [ "$custom_mainclass" = "" ]; then
+      echo "You need to pass -main argument."
+      exit 1
+    fi
+
+    app_mainclass=$custom_mainclass
+  fi
+
   # Now we check to see if there are any java opts on the environment. These get listed first, with the script able to override them.
   if [[ "$JAVA_OPTS" != "" ]]; then
     java_opts="${JAVA_OPTS}"

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
@@ -39,9 +39,11 @@ trait CommonStartScriptGenerator {
     */
   protected[this] val executableBitValue: Boolean
 
-  protected[this] def createReplacementsForMainScript(mainClass: String,
-                                                      mainClasses: Seq[String],
-                                                      config: SpecializedScriptConfig): Seq[(String, String)]
+  protected[this] def createReplacementsForMainScript(
+    mainClass: String,
+    mainClasses: Seq[String],
+    config: SpecializedScriptConfig
+  ): Seq[(String, String)]
 
   protected[this] trait ScriptConfig {
     val executableScriptName: String
@@ -59,11 +61,13 @@ trait CommonStartScriptGenerator {
     */
   protected[this] type SpecializedScriptConfig <: ScriptConfig
 
-  protected[this] def generateStartScripts(config: SpecializedScriptConfig,
-                                           mainClass: Option[String],
-                                           discoveredMainClasses: Seq[String],
-                                           targetDir: File,
-                                           log: sbt.Logger): Seq[(File, String)] =
+  protected[this] def generateStartScripts(
+    config: SpecializedScriptConfig,
+    mainClass: Option[String],
+    discoveredMainClasses: Seq[String],
+    targetDir: File,
+    log: sbt.Logger
+  ): Seq[(File, String)] =
     StartScriptMainClassConfig.from(mainClass, discoveredMainClasses) match {
       case NoMain =>
         log.warn("You have no main class in your project. No start script will be generated.")
@@ -77,10 +81,12 @@ trait CommonStartScriptGenerator {
           createForwarderScripts(config.executableScriptName, additional, targetDir, config, log)
     }
 
-  private[this] def generateMainScripts(discoveredMainClasses: Seq[String],
-                                        config: SpecializedScriptConfig,
-                                        targetDir: File,
-                                        log: sbt.Logger): Seq[(File, String)] = {
+  private[this] def generateMainScripts(
+    discoveredMainClasses: Seq[String],
+    config: SpecializedScriptConfig,
+    targetDir: File,
+    log: sbt.Logger
+  ): Seq[(File, String)] = {
     val classAndScriptNames = ScriptUtils.createScriptNames(discoveredMainClasses)
     ScriptUtils.warnOnScriptNameCollision(classAndScriptNames, log)
 
@@ -89,7 +95,9 @@ trait CommonStartScriptGenerator {
         case (_, script) => script == config.executableScriptName
       }
       .map(_ => classAndScriptNames)
-      .getOrElse(classAndScriptNames ++ Seq("" -> config.executableScriptName)) // empty string to enforce the custom class in scripts
+      .getOrElse(
+        classAndScriptNames ++ Seq("" -> config.executableScriptName)
+      ) // empty string to enforce the custom class in scripts
       .map {
         case (qualifiedClassName, scriptName) =>
           val newConfig = config.withScriptName(scriptName)
@@ -106,10 +114,12 @@ trait CommonStartScriptGenerator {
     * @param targetDir - Target directory for this script
     * @return File pointing to the created main script
     */
-  private[this] def createMainScript(mainClass: String,
-                                     config: SpecializedScriptConfig,
-                                     targetDir: File,
-                                     mainClasses: Seq[String]): (File, String) = {
+  private[this] def createMainScript(
+    mainClass: String,
+    config: SpecializedScriptConfig,
+    targetDir: File,
+    mainClasses: Seq[String]
+  ): (File, String) = {
     val template = resolveTemplate(config.templateLocation)
     val replacements = createReplacementsForMainScript(mainClass, mainClasses, config)
     val scriptContent = TemplateWriter.generateScript(template, replacements, eol, keySurround)
@@ -126,11 +136,13 @@ trait CommonStartScriptGenerator {
     if (defaultTemplateLocation.exists) defaultTemplateLocation.toURI.toURL
     else getClass.getResource(defaultTemplateLocation.getName)
 
-  private[this] def createForwarderScripts(executableScriptName: String,
-                                           discoveredMainClasses: Seq[String],
-                                           targetDir: File,
-                                           config: ScriptConfig,
-                                           log: sbt.Logger): Seq[(File, String)] = {
+  private[this] def createForwarderScripts(
+    executableScriptName: String,
+    discoveredMainClasses: Seq[String],
+    targetDir: File,
+    config: ScriptConfig,
+    log: sbt.Logger
+  ): Seq[(File, String)] = {
     val tmp = targetDir / scriptTargetFolder
     val forwarderTemplate = getClass.getResource(forwarderTemplateName)
     val classAndScriptNames = ScriptUtils.createScriptNames(discoveredMainClasses)

--- a/src/sbt-test/docker/multiple-main-classes/build.sbt
+++ b/src/sbt-test/docker/multiple-main-classes/build.sbt
@@ -1,0 +1,5 @@
+enablePlugins(JavaAppPackaging, AshScriptPlugin)
+
+name := "multi-main-name"
+
+version := "0.1.0"

--- a/src/sbt-test/docker/multiple-main-classes/project/plugins.sbt
+++ b/src/sbt-test/docker/multiple-main-classes/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/docker/multiple-main-classes/src/main/scala/Main1.scala
+++ b/src/sbt-test/docker/multiple-main-classes/src/main/scala/Main1.scala
@@ -1,0 +1,3 @@
+object Main1 extends App {
+  println("main1")
+}

--- a/src/sbt-test/docker/multiple-main-classes/src/main/scala/Main2.scala
+++ b/src/sbt-test/docker/multiple-main-classes/src/main/scala/Main2.scala
@@ -1,0 +1,3 @@
+object Main2 extends App {
+  println("main2")
+}

--- a/src/sbt-test/docker/multiple-main-classes/test
+++ b/src/sbt-test/docker/multiple-main-classes/test
@@ -1,0 +1,3 @@
+# Stage the distribution and ensure files show up.
+> docker:stage
+$ exec grep -q -F 'RUN ["chmod", "u+x,g+x", "/4/opt/docker/bin/multi-main-name"]' target/docker/stage/Dockerfile


### PR DESCRIPTION
This PR adds a script that matches the entrypoint in the Dockerfile. However you will still have to add a `-main` class argument to specify what you actually want to run, as there is no "default main class". 

Example on specify the main class as a parameter

```bash
docker run <your image name> -main com.example.Main2
```

Thanks to @fspillner for the inspiration and 90% of the code :heart: 