### PR TITLE
Fixes remote debug connections closing

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-template
@@ -154,7 +154,7 @@ addResidual () {
   residual_args+=( "$1" )
 }
 addDebugger () {
-  addJava "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=$1"
+  addJava "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:$1"
 }
 
 require_arg () {


### PR DESCRIPTION
sbt-native-packager Java App archetype remote debugging is broken when using `-jvm-debug <port>` in the docker entrypoint. It will start with `-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=<port>`, which will terminate the connection prematurely.

Adding the * before the port will allow all remote connections to connect to the debugger port, which was the old default behavior.

See https://bugs.openjdk.org/browse/JDK-8175050

