### PR TITLE
Use SOURCE_DATE_EPOCH for zip, tar, xz, gzip, rpm, msi

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/FileUtil.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/FileUtil.scala
@@ -1,5 +1,6 @@
 package com.typesafe.sbt
 package packager
+import sbt._
 
 import java.io.File
 import java.nio.file.Files
@@ -80,4 +81,24 @@ object permissions {
     def oct(args: Any*) = Integer.parseInt(sc.s(args: _*), 8)
   }
 
+}
+
+object sourceDateEpoch {
+
+  /**
+    * If the SOURCE_DATE_EPOCH environment variable is defined, change the mtime of the file (and
+    * all children recursively) to the epoch value. This is useful when trying to create
+    * reproducible builds since some packaging tools (e.g. tar, gzip) embed last modified times
+    * in the package. If the environment variable is not defined, this does nothing.
+    */
+  def apply(file: File): Unit =
+    sys.env.get("SOURCE_DATE_EPOCH").foreach { epoch =>
+      val millis = epoch.toLong
+      val par = file.getParentFile
+      val allPaths = file.allPaths.get().map(_.getAbsolutePath)
+      sys.process.Process(Seq("touch", "-h", "-m", s"--date=@$epoch") ++ allPaths, Some(par)).! match {
+        case 0 => ()
+        case n => sys.error("Error setting SOURCE_DATE_EPOCH on " + file + ". Exit code: " + n)
+      }
+    }
 }

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager.rpm
 
 import sbt._
 import com.typesafe.sbt.packager.linux.LinuxSymlink
+import com.typesafe.sbt.packager.sourceDateEpoch
 
 object RpmHelper {
 
@@ -22,6 +23,7 @@ object RpmHelper {
     copyFiles(spec, workArea, log)
     writeSpecFile(spec, workArea, log)
     spec.validate(log)
+    sourceDateEpoch(workArea)
     workArea
   }
 
@@ -99,7 +101,11 @@ object RpmHelper {
         "--define",
         "_topdir " + workArea.getAbsolutePath,
         "--define",
-        "_tmppath " + tmpRpmBuildDir.getAbsolutePath
+        "_tmppath " + tmpRpmBuildDir.getAbsolutePath,
+        "--define",
+        "%use_source_date_epoch_as_buildtime 1",
+        "--define",
+        "%clamp_mtime_to_source_date_epoch 1"
       ) ++ (
         if (gpg) Seq("--define", "_gpg_name " + "<insert keyname>", "--sign")
         else Seq.empty

--- a/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Archives.scala
@@ -186,6 +186,7 @@ object Archives {
     * NOTE: This will 'consume' the input file.
     */
   def gzip(f: File): File = {
+    sourceDateEpoch(f)
     val par = f.getParentFile
     sys.process.Process(Seq("gzip", "-9", f.getAbsolutePath), Some(par)).! match {
       case 0 => ()
@@ -199,6 +200,7 @@ object Archives {
     * NOTE: This will 'consume' the input file.
     */
   def xz(f: File): File = {
+    sourceDateEpoch(f)
     val par = f.getParentFile
     sys.process.Process(Seq("xz", "-S", ".xz", f.getAbsolutePath), Some(par)).! match {
       case 0 => ()
@@ -268,6 +270,8 @@ object Archives {
       val distdirs = topDirectory.map(_ :: Nil).getOrElse {
         IO.listFiles(workingDirectory).map(_.getName).toList // no top level dir, use all available
       }
+
+      sourceDateEpoch(workingDirectory)
 
       val temporaryTarFile = tempDirectory / (name + ".tar")
 


### PR DESCRIPTION
SOURCE_DATE_EPOCH is a standardized environment variable that can be set to create reproducbile builds:

  https://reproducible-builds.org/docs/source-date-epoch/

If the SOURCE_DATE_EPOCH environment variable is defined, its value is used during the creation of zip, tar, gzip, xz, rpm, and msi files in places where timestamp information is embedded in the resulting file.

To support this capability, a new sourceDateEpoch file utility is added which executes the touch command to set the mtime of the provided file/directory and all children. This utility is called on all source files for the listed packages.

For zip, this also adds the -o option to native zip, and calls setTime() for the non-native zip.

For rpm, this also sets the %use_source_date_epoch_as_buildtime and %clamp_mtime_to_source_date_epoch tunables to 1 to ensure the build time and timestamps embedded in the RPM are set to the epoch.

For msi, the SOURCE_DATE_EPOCH variable is also used to generate reproducible name-based UUIDs, using a combination of an identifier and the epoch value. Note that this does not change the "Product" GUID or the build time that is embedded in the MSI. There does not seem to be a way to change these, so MSI builds are not 100% reproducible. However, with these changes the output of tools like msidiff is much smaller and easier to confirm similar builds.

If SOURCE_DATE_EPOCH is not set then the current behavior is used. Archives and rpms use timestamps of when the files are modified/created, and MSI uses random GUIDs.