### PR TITLE
Adds cross platform architecture compilation for native image

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -254,7 +254,7 @@ jobs:
     - name: Setup GraalVM environment
       uses: olafurpg/setup-scala@v10
       with:
-        java-version: graalvm@22.0.0=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-linux-amd64-22.0.0.2.tar.gz
+        java-version: graalvm@22.3.2=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.2/graalvm-ce-java17-linux-amd64-22.3.2.tar.gz
     - name: Install native-image
       run: gu install native-image
     - name: Validate

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "com.github.sbt"
 homepage := Some(url("https://github.com/sbt/sbt-native-packager"))
 
 Global / onChangedBuildSource := ReloadOnSourceChanges
-Global / scalaVersion := "2.12.12"
+Global / scalaVersion := "2.12.13"
 
 // crossBuildingSettings
 crossSbtVersions := Vector("1.1.6")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.4
+sbt.version=1.9.3

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImageKeys.scala
@@ -14,6 +14,10 @@ trait GraalVMNativeImageKeys {
   val graalVMNativeImageGraalVersion = settingKey[Option[String]](
     "Version of GraalVM to build with. Setting this has the effect of generating a container build image to build the native image with this version of GraalVM."
   )
+
+  val graalVMNativeImagePlatformArch = settingKey[Option[String]](
+    "Platform architecture of GraalVM to build with. This only works when building the native image with a container."
+  )
 }
 
 trait GraalVMNativeImageKeysEx extends GraalVMNativeImageKeys {

--- a/src/sbt-test/graalvm-native-image/docker-native-image-arm64/build.sbt
+++ b/src/sbt-test/graalvm-native-image/docker-native-image-arm64/build.sbt
@@ -4,3 +4,4 @@ name := "docker-test"
 version := "0.1.0"
 graalVMNativeImageOptions := Seq("--no-fallback")
 graalVMNativeImageGraalVersion := Some("22.3.2")
+graalVMNativeImagePlatformArch := Some("arm64")

--- a/src/sbt-test/graalvm-native-image/docker-native-image-arm64/project/plugins.sbt
+++ b/src/sbt-test/graalvm-native-image/docker-native-image-arm64/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/graalvm-native-image/docker-native-image-arm64/src/main/scala/Main.scala
+++ b/src/sbt-test/graalvm-native-image/docker-native-image-arm64/src/main/scala/Main.scala
@@ -1,0 +1,5 @@
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello Graal")
+  }
+}

--- a/src/sbt-test/graalvm-native-image/docker-native-image-arm64/test
+++ b/src/sbt-test/graalvm-native-image/docker-native-image-arm64/test
@@ -1,0 +1,3 @@
+# Generate the GraalVM native image
+> show graalvm-native-image:packageBin
+$ exec bash -c 'docker run --platform arm64 -v .:/test -w /test ubuntu ./target/graalvm-native-image/docker-test | grep -q "Hello Graal"'

--- a/src/sbt-test/graalvm-native-image/simple-native-image/build.sbt
+++ b/src/sbt-test/graalvm-native-image/simple-native-image/build.sbt
@@ -1,5 +1,5 @@
 enablePlugins(GraalVMNativeImagePlugin)
 
 name := "simple-test"
-
 version := "0.1.0"
+graalVMNativeImageOptions := Seq("--no-fallback")


### PR DESCRIPTION
Closes #1443

This attempts to fill in the gap in cross platform architecture native image packaging. Added a new key `graalVMNativeImagePlatformArch: Option[String]` to specify the target platform architecture. Currently it only supports a single platform as doing multi platform would involve a much bigger change in the code base.

While this works technically, the performance is still rather lacking. When I crossed compiled (amd64 -> arm64) compile times took ~19x longer. The simple hello world test took over 5 minutes to produce a binary. 

The 5+ minutes test case also triggered a bug in [SBT #6771](https://github.com/sbt/sbt/issues/6671) causing the test to be aborted halfway through, but was recently fixed in SBT 1.9.3 hence the upgrade. Also updated the tests to use the `--no-fallback` option as I noticed that it was generating a fallback image when running the tests.

Also, it was a little tricky to correctly detect if an existing container was in the correct platform architecture when `graalVMNativeImagePlatformArch` is not defined. I used a docker image label to get around that since docker doesn't provide a way to report the host platform (using `uname -m` isn't ideal since it doesn't match docker's convention). The best it does is provide a special `local` value to signal building the image in the same platform architecture as the host.