### PR TITLE
Windows bat script improvements

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -149,7 +149,15 @@ rem Processes incoming arguments and places them in appropriate global variables
 
   if "!_TEST_PARAM:~0,2!"=="-J" (
     rem strip -J prefix
-    set _JAVA_PARAMS=!_JAVA_PARAMS! !_TEST_PARAM:~2!
+    call set _TEST_PARAM=!_TEST_PARAM:~2!
+    if not "!_TEST_PARAM:~0,5!" == "-XX:+" if not "!_TEST_PARAM:~0,5!" == "-XX:-" if "!_TEST_PARAM:~0,3!" == "-XX" (
+      rem special handling for -J-XX since '=' gets parsed away
+      for /F "delims== tokens=1,*" %%G in ("!_TEST_PARAM!") DO (
+        call set _TEST_PARAM=!_TEST_PARAM!=%%1
+        shift
+      )
+    )
+    set _JAVA_PARAMS=!_JAVA_PARAMS! !_TEST_PARAM!
     goto param_loop
   )
 

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -57,6 +57,11 @@ if defined BUNDLED_JVM (
 
 if "%_JAVACMD%"=="" set _JAVACMD=java
 
+rem if configuration files exist, prepend their contents to the script arguments so it can be processed by this runner
+call :parse_config "%SCRIPT_CONF_FILE%" SCRIPT_CONF_ARGS
+
+call :process_args %SCRIPT_CONF_ARGS% %%*
+
 rem Detect if this java is ok to use.
 for /F %%j in ('"%_JAVACMD%" -version  2^>^&1') do (
   if %%~j==java set JAVAINSTALLED=1
@@ -85,11 +90,6 @@ if "%JAVAOK%"=="false" (
   if defined DOUBLECLICKED pause
   exit /B 1
 )
-
-rem if configuration files exist, prepend their contents to the script arguments so it can be processed by this runner
-call :parse_config "%SCRIPT_CONF_FILE%" SCRIPT_CONF_ARGS
-
-call :process_args %SCRIPT_CONF_ARGS% %%*
 
 set _JAVA_OPTS=!_JAVA_OPTS! !_JAVA_PARAMS!
 
@@ -143,6 +143,13 @@ rem Processes incoming arguments and places them in appropriate global variables
 
   if "!_TEST_PARAM!"=="-main" (
     call set CUSTOM_MAIN_CLASS=%%1
+    shift
+    goto param_loop
+  )
+
+  if "!_TEST_PARAM!"=="-java-home" (
+    set "JAVA_HOME=%~1"
+    set "_JAVACMD=%~1\bin\java.exe"
     shift
     goto param_loop
   )

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -135,23 +135,21 @@ exit /B 0
 rem Processes incoming arguments and places them in appropriate global variables
 :process_args
   :param_loop
-  call set _PARAM1=%%1
-  set "_TEST_PARAM=%~1"
+  shift
+  call set _PARAM1=%%0
+  set "_TEST_PARAM=%~0"
 
   if ["!_PARAM1!"]==[""] goto param_afterloop
 
+  if "!_TEST_PARAM!"=="-main" (
+    call set CUSTOM_MAIN_CLASS=%%1
+    shift
+    goto param_loop
+  )
 
-  rem ignore arguments that do not start with '-'
-  if "%_TEST_PARAM:~0,1%"=="-" goto param_java_check
-  set _APP_ARGS=!_APP_ARGS! !_PARAM1!
-  shift
-  goto param_loop
-
-  :param_java_check
   if "!_TEST_PARAM:~0,2!"=="-J" (
     rem strip -J prefix
     set _JAVA_PARAMS=!_JAVA_PARAMS! !_TEST_PARAM:~2!
-    shift
     goto param_loop
   )
 
@@ -160,22 +158,18 @@ rem Processes incoming arguments and places them in appropriate global variables
     for /F "delims== tokens=1,*" %%G in ("!_TEST_PARAM!") DO (
       if not ["%%H"] == [""] (
         set _JAVA_PARAMS=!_JAVA_PARAMS! !_PARAM1!
-      ) else if [%2] neq [] (
+      ) else if [%1] neq [] (
         rem it was a normal property: -Dprop=42 or -Drop="42"
-        call set _PARAM1=%%1=%%2
+        call set _PARAM1=%%0=%%1
         set _JAVA_PARAMS=!_JAVA_PARAMS! !_PARAM1!
         shift
       )
     )
-  ) else (
-    if "!_TEST_PARAM!"=="-main" (
-      call set CUSTOM_MAIN_CLASS=%%2
-      shift
-    ) else (
-      set _APP_ARGS=!_APP_ARGS! !_PARAM1!
-    )
+    goto param_loop
   )
-  shift
+
+  set _APP_ARGS=!_APP_ARGS! !_PARAM1!
+
   goto param_loop
   :param_afterloop
 

--- a/src/sbt-test/windows/test-bat-template/build.sbt
+++ b/src/sbt-test/windows/test-bat-template/build.sbt
@@ -101,6 +101,12 @@ TaskKey[Unit]("checkScript") := {
     Map("show-vmargs" -> "true")
   )
   checkOutput(
+    "with -J-XX java-opts",
+    Seq("-J-XX:+UseG1GC", "-J-XX:-UnlockExperimentalVMOptions", "-J-XX:MaxGCPauseMillis=500"),
+    "vmarg #0 is [-XX:+UseG1GC]\nvmarg #1 is [-XX:-UnlockExperimentalVMOptions]\nvmarg #2 is [-XX:MaxGCPauseMillis=500]\nSUCCESS!",
+    Map("show-vmargs" -> "true")
+  )
+  checkOutput(
     "include space",
     Seq("""-Dtest.hoge=C:\Program Files\Java""", """"C:\Program Files\Java""""),
     "arg #0 is [C:\\Program Files\\Java]\nproperty(test.hoge) is [C:\\Program Files\\Java]\nSUCCESS!"


### PR DESCRIPTION
There are still some things missing for complete parity with the bash script but this gets us a little closer.

### Fixes parsing of `-J-XX:` options containing an equal sign

I'm using the same logic as [sbt's own launcher](https://github.com/sbt/sbt/blob/2f2a098742a7fcf06d63819162618d5fae976543/launcher-package/src/universal/bin/sbt.bat#L498C83-L518). Unless it starts with `-XX:+` or `-XX:-`, all `-XX:` options are parsed as two arguments

Fixes #1387 
Fixes #1090

Note that if you're using the workaround from #1387 by quoting the options in `application.ini`, that will no longer work.

### Implements `-java-home` option

Used like `-java-home "C:\Program Files\Eclipse Adoptium\jre-11.0.13.8-hotspot"` or `-java-home "%APP_HOME%\jre"`. The argument has higher priority than environment variables.

Fixes #1447
Fixes #1070
