### PR TITLE
DockerPlugin publishTask: switch --push flag to --output=type=registry

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -284,7 +284,7 @@ object DockerPlugin extends AutoPlugin {
               "buildx",
               "build",
               s"--platform=${dockerBuildxPlatforms.value.mkString(",")}",
-              "--push"
+              "--output=type=registry"
             ) ++ dockerBuildOptions.value :+ "."
           else dockerExecCommand.value
         alias.foreach { aliasValue =>


### PR DESCRIPTION
`--push` is shorthand for `--output=type=registry` (https://docs.docker.com/engine/reference/commandline/buildx_build/#push)

By specifying `--output=type=registry`, sbt can support when `docker` is a symlink to `podman`.