### PR TITLE
Discard files that are not jars

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
@@ -183,6 +183,7 @@ object JavaAppPackaging extends AutoPlugin {
   ): Seq[(File, String)] =
     for {
       dep <- deps
+      if dep.data.ext == "jar"
       realDep <- findRealDep(dep, projectArts)
     } yield realDep.data -> ("lib/" + getJarFullFilename(realDep))
 }


### PR DESCRIPTION
If your module has libraryDependencies that are not JARs, they end up on the classpath (they even get renamed during staging) when they're not jar.

For instance, consider this dependency:
```
libraryDependencies += "com.google.protobuf" % "protoc" % "3.18.2" withExplicitArtifacts Vector(
  Artifact("protoc").withType("jar").withExtension("exe").withClassifier(Some("osx-aarch_64"))
)
```

(located [on maven central](https://repo1.maven.org/maven2/com/google/protobuf/protoc/3.18.0/))

When you add that, you'll get a file an `Attributed[File]` at the following location: `/path/to/Caches/Coursier/v1/https/repo1.maven.org/maven2/com/google/protobuf/protoc/3.18.2/protoc-3.18.2-osx-aarch_64.exe`

When the `universalDepMappings` logic runs, it keeps the file (even it is not a jar, but furthermore, create a jar name for it like: `com.google.protobuf.protoc-3.18.2-osx-aarch_64.jar`

This PR is to avoid this issue, I did not create an issue for this because of the overhead of it. If you think this is not valid we can just close the PR.

It did not cause me any issue, as the file is on the classpath but the JVM probably ignores it because it's not a jar and the app is working correctly. It's just annoying that the file is renamed in packaging