### PR TITLE
Set minimum crossSbtVersions to sbt 1.3.0, to avoid repo.scala-sbt.org (it's on Maven Central)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ Global / onChangedBuildSource := ReloadOnSourceChanges
 Global / scalaVersion := "2.12.12"
 
 // crossBuildingSettings
-crossSbtVersions := Vector("1.1.6")
+crossSbtVersions := Vector("1.3.0")
 
 Compile / scalacOptions ++= Seq("-deprecation")
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")


### PR DESCRIPTION
I started to block [repo.scala-sbt.org](http://repo.scala-sbt.org/) and [repo.typesafe.com](http://repo.typesafe.com/) in my `/etc/hosts`.

I needed to bump `crossSbtVersions` to 1.3.0 so I could fetch all dependencies from maven central.

See
- https://github.com/sbt/sbt/issues/7202

this repo could go down again.

Related
- #1566
- https://github.com/sbt/sbt-dynver/pull/284