### PR TITLE
Add `is_cygwin` to ash-template which always returns `false`

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -29,6 +29,11 @@ realpath () {
 )
 }
 
+# ash-template is not designed to be used with Cygwin
+is_cygwin() {
+  return 1
+}
+
 # Allow user and template_declares (see below) to add java options.
 addJava () {
   java_opts="$java_opts $1"


### PR DESCRIPTION
For explanation see comments starting [here](https://github.com/sbt/sbt-native-packager/issues/978#issuecomment-454827566).
Basically we assume ash will only be run in docker images, but never in a cygwin environment.

Currently apps relying on the `is_cygwin` function are broken anyway, so adding this method definitely improves things.