### PR TITLE
Upgrade GraalVM to 22.3.3

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -254,7 +254,7 @@ jobs:
     - name: Setup GraalVM environment
       uses: olafurpg/setup-scala@v10
       with:
-        java-version: graalvm@22.0.0=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.0.0.2/graalvm-ce-java11-linux-amd64-22.0.0.2.tar.gz
+        java-version: graalvm@22.3.3=tgz+https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-22.3.3/graalvm-ce-java11-linux-amd64-22.3.3.tar.gz
     - name: Install native-image
       run: gu install native-image
     - name: Validate

--- a/src/sbt-test/graalvm-native-image/docker-native-image/build.sbt
+++ b/src/sbt-test/graalvm-native-image/docker-native-image/build.sbt
@@ -2,4 +2,4 @@ enablePlugins(GraalVMNativeImagePlugin)
 
 name := "docker-test"
 version := "0.1.0"
-graalVMNativeImageGraalVersion := Some("22.0.0.2")
+graalVMNativeImageGraalVersion := Some("22.3.3")


### PR DESCRIPTION
`Validate PR / scripted-graavlvm (pull_request)` sometimes fails with this error:
```
Run gu install native-image
Downloading: Release index file from oca.opensource.oracle.com
Internal error occurred: A JSONObject text must begin with '{' at 1 [character 2 line 1]
Error: Process completed with exit code 3.
```

`gu` is the [GraalVM Updater](https://www.graalvm.org/22.0/reference-manual/graalvm-updater/). Add the `--debug` flag to get more info.