### PR TITLE
fix support for top-level `main` methods in Scala 3

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -129,4 +129,4 @@ java_cmd="$(get_java_cmd)"
 # If a configuration file exist, read the contents to $opts
 [ -f "$script_conf_file" ] && opts=$(loadConfigFile "$script_conf_file")
 
-eval "exec $java_cmd $java_opts -classpath $app_classpath $opts $app_mainclass $app_commands $residual_args"
+exec $java_cmd $java_opts -classpath $app_classpath $opts $app_mainclass $app_commands $residual_args

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -94,7 +94,7 @@ process_args () {
      -java-home) require_arg path "$1" "$2" && jre=`eval echo $2` && java_cmd="$jre/bin/java" && shift 2 ;;
 
  -D*|-agentlib*|-agentpath*|-javaagent*|-XX*) addJava "$1" && shift ;;
-                                         -J*) addJava "${1:2}" && shift ;;
+                                         -J*) addJava "$(printf %s "$1"  | sed s/^..//)" && shift ;;
                                            *) addResidual "$1" && shift ;;
     esac
   done

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -44,7 +44,7 @@ addApp () {
 }
 
 addResidual () {
-  residual_args="$residual_args \"$1\""
+  residual_args="$residual_args '$(printf %s "$1" | sed "s/'/'\\\\''/")'"
 }
 
 # Allow user to specify java options. These get listed first per bash-template.

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -44,7 +44,7 @@ addApp () {
 }
 
 shellEscape () {
-  printf \'%s\' "$(printf %s "$1" | sed "s/'/'\\\\''/")"
+  printf "'%s'" "$(printf %s "$1" | sed "s/'/'\\\\''/")"
 }
 
 addResidual () {

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -42,6 +42,7 @@ addJava () {
 addApp () {
   app_commands="$app_commands $1"
 }
+
 shellEscape () {
   printf \'%s\' "$(printf %s "$1" | sed "s/'/'\\\\''/")"
 }

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -42,9 +42,12 @@ addJava () {
 addApp () {
   app_commands="$app_commands $1"
 }
+shellEscape () {
+  printf \'%s\' "$(printf %s "$1" | sed "s/'/'\\\\''/")"
+}
 
 addResidual () {
-  residual_args="$residual_args '$(printf %s "$1" | sed "s/'/'\\\\''/")'"
+  residual_args="$residual_args $(shellEscape "$1")"
 }
 
 # Allow user to specify java options. These get listed first per bash-template.

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -129,4 +129,5 @@ java_cmd="$(get_java_cmd)"
 # If a configuration file exist, read the contents to $opts
 [ -f "$script_conf_file" ] && opts=$(loadConfigFile "$script_conf_file")
 
-exec $java_cmd $java_opts -classpath $app_classpath $opts $app_mainclass $app_commands $residual_args
+eval "set -- $residual_args"
+exec $java_cmd $java_opts -classpath $app_classpath $opts $app_mainclass $app_commands "$@"

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -143,13 +143,19 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
     else
       ""
 
+  private[this] def shellEscape(s: String): String =
+    if (s.startsWith("-jar"))
+      s
+    else
+      s"'${s.replace("'", "'\\''")}'"
+
   override protected[this] def createReplacementsForMainScript(
     mainClass: String,
     mainClasses: Seq[String],
     config: SpecializedScriptConfig
   ): Seq[(String, String)] =
     Seq(
-      "app_mainclass" -> mainClass,
+      "app_mainclass" -> shellEscape(mainClass),
       "available_main_classes" -> usageMainClassReplacement(mainClasses)
     ) ++ config.replacements
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -144,7 +144,7 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
       ""
 
   private[this] def shellEscape(s: String): String =
-    if (s.startsWith("-jar"))
+    if (s.startsWith("-jar "))
       s
     else
       s"'${s.replace("'", "'\\''")}'"

--- a/src/sbt-test/ash/command-line-settings/build.sbt
+++ b/src/sbt-test/ash/command-line-settings/build.sbt
@@ -23,10 +23,10 @@ TaskKey[Unit]("checkResidual") := {
 }
 
 TaskKey[Unit]("checkComplexResidual") := {
-  val args = """arg1 "arg 2" 'arg "3"'"""
+  val args = Seq("arg1", "arg 2")
   val cwd = (stagingDirectory in Universal).value
-  val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath, args)
+  val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath) ++ args
 
   val output = (sys.process.Process(cmd, cwd).!!).replaceAll("\n", "")
-  assert(output.contains(args), s"Application did not receive residual args '$args'")
+  assert(output.contains(args.mkString("|")), s"Application did not receive residual args '$args' ('$output')")
 }

--- a/src/sbt-test/ash/command-line-settings/build.sbt
+++ b/src/sbt-test/ash/command-line-settings/build.sbt
@@ -23,7 +23,7 @@ TaskKey[Unit]("checkResidual") := {
 }
 
 TaskKey[Unit]("checkComplexResidual") := {
-  val args = Seq("arg1", "arg 2")
+  val args = Seq("arg1", "arg 2", "\"", "$foo", "'")
   val cwd = (stagingDirectory in Universal).value
   val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath) ++ args
 

--- a/src/sbt-test/ash/command-line-settings/build.sbt
+++ b/src/sbt-test/ash/command-line-settings/build.sbt
@@ -23,10 +23,11 @@ TaskKey[Unit]("checkResidual") := {
 }
 
 TaskKey[Unit]("checkComplexResidual") := {
-  val args = Seq("--", "arg1", "arg 2", "--", "\"", "$foo", "'", "%s", "-y", "bla", "\\'", "\\\"")
+  val args = Seq("-J-Dfoo=bar", "arg1", "--", "-J-Dfoo=bar", "arg 2", "--", "\"", "$foo", "'", "%s", "-y", "bla", "\\'", "\\\"")
   val cwd = (stagingDirectory in Universal).value
   val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath) ++ args
+  val expected = """arg1|-J-Dfoo=bar|arg 2|--|"|$foo|'|%s|-y|bla|\'|\""""
 
-  val output = (sys.process.Process(cmd, cwd).!!).replaceAll("\n", "")
-  assert(output.contains(args.drop(1).mkString("|")), s"Application did not receive residual args '$args' ('$output')")
+  val output = (sys.process.Process(cmd, cwd).!!).split("\n").last
+  assert(output == expected, s"Application did not receive residual args '$expected' (got '$output')")
 }

--- a/src/sbt-test/ash/command-line-settings/build.sbt
+++ b/src/sbt-test/ash/command-line-settings/build.sbt
@@ -23,10 +23,10 @@ TaskKey[Unit]("checkResidual") := {
 }
 
 TaskKey[Unit]("checkComplexResidual") := {
-  val args = Seq("arg1", "arg 2", "\"", "$foo", "'", "%s")
+  val args = Seq("--", "arg1", "arg 2", "--", "\"", "$foo", "'", "%s", "-y", "bla")
   val cwd = (stagingDirectory in Universal).value
   val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath) ++ args
 
   val output = (sys.process.Process(cmd, cwd).!!).replaceAll("\n", "")
-  assert(output.contains(args.mkString("|")), s"Application did not receive residual args '$args' ('$output')")
+  assert(output.contains(args.drop(1).mkString("|")), s"Application did not receive residual args '$args' ('$output')")
 }

--- a/src/sbt-test/ash/command-line-settings/build.sbt
+++ b/src/sbt-test/ash/command-line-settings/build.sbt
@@ -23,7 +23,7 @@ TaskKey[Unit]("checkResidual") := {
 }
 
 TaskKey[Unit]("checkComplexResidual") := {
-  val args = Seq("--", "arg1", "arg 2", "--", "\"", "$foo", "'", "%s", "-y", "bla")
+  val args = Seq("--", "arg1", "arg 2", "--", "\"", "$foo", "'", "%s", "-y", "bla", "\\'", "\\\"")
   val cwd = (stagingDirectory in Universal).value
   val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath) ++ args
 

--- a/src/sbt-test/ash/command-line-settings/build.sbt
+++ b/src/sbt-test/ash/command-line-settings/build.sbt
@@ -23,7 +23,7 @@ TaskKey[Unit]("checkResidual") := {
 }
 
 TaskKey[Unit]("checkComplexResidual") := {
-  val args = Seq("arg1", "arg 2", "\"", "$foo", "'")
+  val args = Seq("arg1", "arg 2", "\"", "$foo", "'", "%s")
   val cwd = (stagingDirectory in Universal).value
   val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath) ++ args
 

--- a/src/sbt-test/ash/command-line-settings/test
+++ b/src/sbt-test/ash/command-line-settings/test
@@ -3,3 +3,4 @@
 $ exists target/universal/stage/bin/command-line-app
 > checkSystemProperty
 > checkResidual
+> checkComplexResidual

--- a/src/sbt-test/ash/top-level-main/build.sbt
+++ b/src/sbt-test/ash/top-level-main/build.sbt
@@ -1,0 +1,16 @@
+import com.typesafe.sbt.packager.Compat._
+
+enablePlugins(AshScriptPlugin)
+
+name := "top-level-main"
+
+version := "0.1.0"
+
+scalaVersion := "3.3.3"
+
+TaskKey[Unit]("runCheck") := {
+  val cwd = (stagingDirectory in Universal).value
+  val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath)
+  val output = sys.process.Process(cmd, cwd).!!
+  assert(output contains "SUCCESS!", "Output didn't contain success: " + output)
+}

--- a/src/sbt-test/ash/top-level-main/project/build.properties
+++ b/src/sbt-test/ash/top-level-main/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/src/sbt-test/ash/top-level-main/project/plugins.sbt
+++ b/src/sbt-test/ash/top-level-main/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/ash/top-level-main/src/main/scala/MainApp.scala
+++ b/src/sbt-test/ash/top-level-main/src/main/scala/MainApp.scala
@@ -1,0 +1,2 @@
+def main(args: Array[String]): Unit =
+  println("SUCCESS!")

--- a/src/sbt-test/ash/top-level-main/test
+++ b/src/sbt-test/ash/top-level-main/test
@@ -1,0 +1,3 @@
+# Run the staging and check the script.
+> stage
+> runCheck

--- a/src/sbt-test/bash/top-level-main/build.sbt
+++ b/src/sbt-test/bash/top-level-main/build.sbt
@@ -1,0 +1,16 @@
+import com.typesafe.sbt.packager.Compat._
+
+enablePlugins(JavaAppPackaging)
+
+name := "top-level-main"
+
+version := "0.1.0"
+
+scalaVersion := "3.3.3"
+
+TaskKey[Unit]("runCheck") := {
+  val cwd = (stagingDirectory in Universal).value
+  val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath)
+  val output = sys.process.Process(cmd, cwd).!!
+  assert(output contains "SUCCESS!", "Output didn't contain success: " + output)
+}

--- a/src/sbt-test/bash/top-level-main/project/build.properties
+++ b/src/sbt-test/bash/top-level-main/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.9

--- a/src/sbt-test/bash/top-level-main/project/plugins.sbt
+++ b/src/sbt-test/bash/top-level-main/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))

--- a/src/sbt-test/bash/top-level-main/src/main/scala/MainApp.scala
+++ b/src/sbt-test/bash/top-level-main/src/main/scala/MainApp.scala
@@ -1,0 +1,2 @@
+def main(args: Array[String]) =
+  println("SUCCESS!")

--- a/src/sbt-test/bash/top-level-main/test
+++ b/src/sbt-test/bash/top-level-main/test
@@ -1,0 +1,3 @@
+# Run the staging and check the script.
+> stage
+> runCheck


### PR DESCRIPTION
app_mainclass is currently not escaped correctly. This leads to problems in Scala 3 when you define `main` as a function at the top level (as opposed to inside an `object`. In this case, the main class generated by the Scala compiler will contain $ symbols that need to be escaped.

The `LauncherJarPlugin` abuses `mainClass` to set the `-jar foo.jar` parameter instead of a main class, so this case needs to be treated specially (I find this an ugly hack but haven't found a cleaner solution).
The `scripted-docker` test failures seem to be unrelated to my changes as they also occur in [other CI runs](https://github.com/sbt/sbt-native-packager/actions/runs/8395125752)