### PR TITLE
Add `dockerBuildEnvVars` setting, fix docker test failure in CI

### DIFF
--- a/src/main/mima-filters/1.3.15.backward.excludes
+++ b/src/main/mima-filters/1.3.15.backward.excludes
@@ -79,3 +79,6 @@ ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sbt.packager.do
 ProblemFilters.exclude[ReversedMissingMethodProblem]("com.typesafe.sbt.packager.linux.LinuxKeys.com$typesafe$sbt$packager$linux$LinuxKeys$_setter_$daemonHome_=")
 ProblemFilters.exclude[ReversedMissingMethodProblem]("com.typesafe.sbt.packager.linux.LinuxKeys.daemonHome")
 ProblemFilters.exclude[DirectMissingMethodProblem]("com.typesafe.sbt.packager.linux.LinuxPlugin.makeReplacements")
+
+ProblemFilters.exclude[ReversedMissingMethodProblem]("com.typesafe.sbt.packager.docker.DockerKeys.dockerBuildEnvVars")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("com.typesafe.sbt.packager.docker.DockerKeys.com$typesafe$sbt$packager$docker$DockerKeys$_setter_$dockerBuildEnvVars_=")

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -39,6 +39,8 @@ trait DockerKeys {
   val dockerExecCommand = SettingKey[Seq[String]]("dockerExecCommand", "The shell command used to exec Docker")
   val dockerVersion = TaskKey[Option[DockerVersion]]("dockerVersion", "The docker server version")
   val dockerBuildOptions = SettingKey[Seq[String]]("dockerBuildOptions", "Options used for the Docker build")
+  val dockerBuildEnvVars =
+    SettingKey[Map[String, String]]("dockerBuildEnvVars", "Environment variables used for the Docker build")
   val dockerBuildCommand = SettingKey[Seq[String]]("dockerBuildCommand", "Command for building the Docker image")
   val dockerLabels = SettingKey[Map[String, String]]("dockerLabels", "Labels applied to the Docker image")
   val dockerEnvVars =
@@ -74,6 +76,7 @@ private[packager] trait DockerKeysEx extends DockerKeys {
       "Setting to true will cause Docker to bundle a tini in the container, to run as the init process, which is recommended for JVM apps. " +
       "Requires Docker API version 1.25+"
   )
+  val dockerBuildkitEnabled = TaskKey[Boolean]("dockerBuildkitEnabled", "Detects whether buildkit is enabled")
   val dockerBuildxPlatforms =
     SettingKey[Seq[String]]("dockerBuildxPlatforms", "The docker image platforms for buildx multi-platform build")
 }

--- a/src/sbt-test/docker/autoremove-multi-stage-intermediate-images/test
+++ b/src/sbt-test/docker/autoremove-multi-stage-intermediate-images/test
@@ -1,3 +1,5 @@
+# When using BuildKit, intermediate build steps are not exposed as images
+> 'set dockerBuildEnvVars += "DOCKER_BUILDKIT" -> "0"'
 # First make sure we start clean
 $ exec bash -c 'docker image prune -f --filter label=snp-multi-stage=intermediate'
 # Generate the Docker image locally

--- a/src/sphinx/formats/docker.rst
+++ b/src/sphinx/formats/docker.rst
@@ -185,6 +185,12 @@ Publishing Settings
     Overrides the default Docker build options.
     Defaults to ``Seq("--force-rm", "-t", "[dockerAlias]")``. This default is expanded if either ``dockerUpdateLatest`` or ``dockerBuildInit`` is set to true.
 
+  ``dockerBuildEnvVars``
+    The environment variables passed to the Docker build.
+    Defaults to empty.
+    For example, to disable Docker BuildKit:
+    ``dockerBuildEnvVars += "DOCKER_BUILDKIT" -> "0"``
+
   ``dockerExecCommand``
     Overrides the default Docker exec command.
     Defaults to ``Seq("docker")``


### PR DESCRIPTION
[Docker BuildKit](https://docs.docker.com/build/buildkit) became the default in Docker v23.0 which caused the test to fail. BuildKit doesn't expose intermediate containers as images, so the cleanup setting `dockerAutoremoveMultiStageIntermediateImages` is not relevant when running BuildKit.

I've added a setting `dockerBuildEnvVars` which can be used to disable BuildKit:
```sbt
dockerBuildEnvVars += "DOCKER_BUILDKIT" -> "0"
```
I've also improved BuildKit detection-- it now checks the docker version if `DOCKER_BUILDKIT` is not set.

This incidentally fixes #1518