### PR TITLE
fix shellEscape function in ash-template

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-template
@@ -44,7 +44,7 @@ addApp () {
 }
 
 shellEscape () {
-  printf "'%s'" "$(printf %s "$1" | sed "s/'/'\\\\''/")"
+  printf "'%s'" "$(printf %s "$1" | sed "s/'/'\\\\''/g")"
 }
 
 addResidual () {

--- a/src/sbt-test/ash/command-line-settings/build.sbt
+++ b/src/sbt-test/ash/command-line-settings/build.sbt
@@ -23,10 +23,10 @@ TaskKey[Unit]("checkResidual") := {
 }
 
 TaskKey[Unit]("checkComplexResidual") := {
-  val args = Seq("-J-Dfoo=bar", "arg1", "--", "-J-Dfoo=bar", "arg 2", "--", "\"", "$foo", "'", "%s", "-y", "bla", "\\'", "\\\"")
+  val args = Seq("-J-Dfoo=bar", "arg1", "--", "-J-Dfoo=bar", "arg 2", "--", "\"", "$foo", "'", "%s", "-y", "bla", "\\'", "\\\"", "''")
   val cwd = (stagingDirectory in Universal).value
   val cmd = Seq((cwd / "bin" / packageName.value).getAbsolutePath) ++ args
-  val expected = """arg1|-J-Dfoo=bar|arg 2|--|"|$foo|'|%s|-y|bla|\'|\""""
+  val expected = """arg1|-J-Dfoo=bar|arg 2|--|"|$foo|'|%s|-y|bla|\'|\"|''"""
 
   val output = (sys.process.Process(cmd, cwd).!!).split("\n").last
   assert(output == expected, s"Application did not receive residual args '$expected' (got '$output')")


### PR DESCRIPTION
It currently only escapes the first `'` character, but they should all be escaped.

How are shell scripts still a thing in 2024?