### PR TITLE
refactor: Rewrite unicode arrow

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerAntHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerAntHelper.scala
@@ -39,11 +39,11 @@ object JDKPackagerAntHelper {
 
     // Unlift searchPoint `Option`-s, and for each base directory, add the parent variant to cover nested JREs on Unix.
     val entryPoints =
-      searchPoints.flatten.flatMap(f ⇒ Seq(f, f.getAbsoluteFile))
+      searchPoints.flatten.flatMap(f => Seq(f, f.getAbsoluteFile))
 
     // On Windows we're often running in the JRE and not the JDK. If JDK is installed,
     // it's likely to be in a parallel directory, with the "jre" prefix changed to "jdk"
-    val entryPointsSpecialCaseWindows = entryPoints.flatMap { f ⇒
+    val entryPointsSpecialCaseWindows = entryPoints.flatMap { f =>
       if (f.getName.startsWith("jre"))
         Seq(f, f.getParentFile / ("jdk" + f.getName.drop(3)))
       else Seq(f)
@@ -52,11 +52,11 @@ object JDKPackagerAntHelper {
     // Now search for the tool
     entryPointsSpecialCaseWindows
       .map(_ / "lib" / jarname)
-      .find { f ⇒
+      .find { f =>
         logger.debug(s"Looking for '$jarname' in  '${f.getParent}'");
         f.exists()
       }
-      .map { f ⇒
+      .map { f =>
         logger.debug(s"Found '$f'!"); f
       }
   }
@@ -234,7 +234,7 @@ object JDKPackagerAntHelper {
       Seq("*.dmg", "*.pkg", "*.app", "*.msi", "*.exe", "*.deb", "*.rpm")
     val finder = globs.foldLeft(PathFinder.empty)(_ +++ output ** _)
     val result = finder.getPaths.headOption
-    result.foreach(f ⇒ s.log.info("Wrote " + f))
+    result.foreach(f => s.log.info("Wrote " + f))
     result.map(file)
   }
 
@@ -249,7 +249,7 @@ object JDKPackagerAntHelper {
 
   /** Build package via Ant build.xml definition. */
   private[jdkpackager] def buildPackageWithAnt(buildXML: File, target: File, s: TaskStreams): File = {
-    import org.apache.tools.ant.{Project ⇒ AntProject}
+    import org.apache.tools.ant.{Project => AntProject}
 
     val ap = new AntProject
     ap.setUserProperty("ant.file", buildXML.getAbsolutePath)
@@ -269,7 +269,7 @@ object JDKPackagerAntHelper {
 
   /** For piping Ant messages to sbt logger. */
   private class AntLogAdapter(s: TaskStreams) extends BuildListener {
-    import org.apache.tools.ant.{Project ⇒ AntProject}
+    import org.apache.tools.ant.{Project => AntProject}
     def buildFinished(event: BuildEvent): Unit = ()
     def buildStarted(event: BuildEvent): Unit = ()
     def targetStarted(event: BuildEvent): Unit = ()
@@ -278,11 +278,11 @@ object JDKPackagerAntHelper {
     def taskStarted(event: BuildEvent): Unit = ()
     def messageLogged(event: BuildEvent): Unit =
       event.getPriority match {
-        case AntProject.MSG_ERR ⇒ s.log.error(event.getMessage)
-        case AntProject.MSG_WARN ⇒ s.log.warn(event.getMessage)
-        case AntProject.MSG_INFO ⇒ s.log.info(event.getMessage)
-        case AntProject.MSG_VERBOSE ⇒ s.log.verbose(event.getMessage)
-        case _ ⇒ s.log.debug(event.getMessage)
+        case AntProject.MSG_ERR     => s.log.error(event.getMessage)
+        case AntProject.MSG_WARN    => s.log.warn(event.getMessage)
+        case AntProject.MSG_INFO    => s.log.info(event.getMessage)
+        case AntProject.MSG_VERBOSE => s.log.verbose(event.getMessage)
+        case _                      => s.log.debug(event.getMessage)
       }
   }
 }

--- a/src/sbt-test/jdkpackager/test-package-image/build.sbt
+++ b/src/sbt-test/jdkpackager/test-package-image/build.sbt
@@ -30,9 +30,9 @@ jdkPackagerAssociations := Seq(
 )
 
 lazy val iconGlob = sys.props("os.name").toLowerCase match {
-  case os if os.contains("mac") ⇒ "*.icns"
-  case os if os.contains("win") ⇒ "*.ico"
-  case _ ⇒ "*.png"
+  case os if os.contains("mac") => "*.icns"
+  case os if os.contains("win") => "*.ico"
+  case _                        => "*.png"
 }
 
 jdkAppIcon := (baseDirectory.value / ".." / ".." / ".." / ".." / "test-project-jdkpackager" ** iconGlob).getPaths.headOption
@@ -40,9 +40,9 @@ jdkAppIcon := (baseDirectory.value / ".." / ".." / ".." / ".." / "test-project-j
 
 TaskKey[Unit]("checkImage") := {
   val (extension, os) = sys.props("os.name").toLowerCase match {
-    case osys if osys.contains("mac") ⇒ (".app", 'mac)
-    case osys if osys.contains("win") ⇒ (".exe", 'windows)
-    case _ ⇒ ("", 'linux)
+    case osys if osys.contains("mac") => (".app", 'mac)
+    case osys if osys.contains("win") => (".exe", 'windows)
+    case _                            => ("", 'linux)
   }
   val expectedImage = (JDKPackager / target).value / "bundles" / (name.value + extension)
   println(s"Checking for '${expectedImage.getAbsolutePath}'")

--- a/src/sbt-test/jdkpackager/test-package-image/src/main/scala/ExampleApp.scala
+++ b/src/sbt-test/jdkpackager/test-package-image/src/main/scala/ExampleApp.scala
@@ -26,7 +26,7 @@ class ExampleApp extends Application {
       win.initOwner(stage)
 
       val args = getParameters.getRaw.mkString("\n")
-      val props = sys.props.toSeq.sortBy(_._1).map(p ⇒ s"${p._1}=${p._2}").mkString("\n")
+      val props = sys.props.toSeq.sortBy(_._1).map(p => s"${p._1}=${p._2}").mkString("\n")
 
       val content = new TextArea(Seq("## Application Arguments", args, "## System Properties", props).mkString("\n"))
       content.setPrefHeight(400)

--- a/src/sbt-test/jdkpackager/test-package-mappings/build.sbt
+++ b/src/sbt-test/jdkpackager/test-package-mappings/build.sbt
@@ -24,9 +24,9 @@ Universal / mappings ++= {
 }
 
 lazy val iconGlob = sys.props("os.name").toLowerCase match {
-  case os if os.contains("mac") ⇒ "*.icns"
-  case os if os.contains("win") ⇒ "*.ico"
-  case _ ⇒ "*.png"
+  case os if os.contains("mac") => "*.icns"
+  case os if os.contains("win") => "*.ico"
+  case _                        => "*.png"
 }
 
 jdkAppIcon := (baseDirectory.value / ".." / ".." / ".." / ".." / "test-project-jdkpackager" ** iconGlob).getPaths.headOption
@@ -34,26 +34,26 @@ jdkAppIcon := (baseDirectory.value / ".." / ".." / ".." / ".." / "test-project-j
 
 TaskKey[Unit]("checkImage") := {
   val (extension, os) = sys.props("os.name").toLowerCase match {
-    case osys if osys.contains("mac") ⇒ (".app", 'mac)
-    case osys if osys.contains("win") ⇒ (".exe", 'windows)
-    case _ ⇒ ("", 'linux)
+    case osys if osys.contains("mac") => (".app", 'mac)
+    case osys if osys.contains("win") => (".exe", 'windows)
+    case _                            => ("", 'linux)
   }
   val expectedImage = (JDKPackager / target).value / "bundles" / (name.value + extension)
   println(s"Checking for '${expectedImage.getAbsolutePath}'")
   assert(expectedImage.exists, s"Expected image file to be found at '$expectedImage'")
 
   val files = os match {
-    case 'mac ⇒
+    case 'mac =>
       Seq(
         expectedImage / "Contents" / "Java" / "README.md",
         expectedImage / "Contents" / "Java" / "stuff" / "something-1.md",
         expectedImage / "Contents" / "Java" / "stuff" / "something-2.md"
       )
-    case _ ⇒
+    case _ =>
       streams.value.log.warn("Test needs to be implemented for " + sys.props("os.name"))
       Seq.empty
   }
 
   println(s"Checking for ${files.map(_.getName).mkString(", ")}")
-  files.foreach(f ⇒ assert(f.exists, "Expected to find " + f))
+  files.foreach(f => assert(f.exists, "Expected to find " + f))
 }

--- a/src/sbt-test/jdkpackager/test-package-mappings/src/main/scala/ExampleApp.scala
+++ b/src/sbt-test/jdkpackager/test-package-mappings/src/main/scala/ExampleApp.scala
@@ -23,7 +23,7 @@ class ExampleApp extends Application {
       val win = new Stage(StageStyle.UTILITY)
       win.initModality(Modality.APPLICATION_MODAL)
       win.initOwner(stage)
-      val content = new TextArea(sys.props.toSeq.sortBy(_._1).map(p ⇒ s"${p._1}=${p._2}").mkString("\n"))
+      val content = new TextArea(sys.props.toSeq.sortBy(_._1).map(p => s"${p._1}=${p._2}").mkString("\n"))
       content.setPrefHeight(400)
       win.setScene(new Scene(content))
       win.sizeToScene()

--- a/src/sbt-test/jdkpackager/test-package-minimal/build.sbt
+++ b/src/sbt-test/jdkpackager/test-package-minimal/build.sbt
@@ -8,9 +8,9 @@ jdkPackagerType := "image"
 
 TaskKey[Unit]("checkImage") := {
   val extension = sys.props("os.name").toLowerCase match {
-    case os if os.contains("mac") ⇒ ".app"
-    case os if os.contains("win") ⇒ ".exe"
-    case _ ⇒ ""
+    case os if os.contains("mac") => ".app"
+    case os if os.contains("win") => ".exe"
+    case _                        => ""
   }
   val expectedImage = (JDKPackager / target).value / "bundles" / (name.value + extension)
   println(s"Checking for '${expectedImage.getAbsolutePath}'")

--- a/src/sbt-test/jdkpackager/test-package-minimal/src/main/scala/ExampleApp.scala
+++ b/src/sbt-test/jdkpackager/test-package-minimal/src/main/scala/ExampleApp.scala
@@ -23,7 +23,7 @@ class ExampleApp extends Application {
       val win = new Stage(StageStyle.UTILITY)
       win.initModality(Modality.APPLICATION_MODAL)
       win.initOwner(stage)
-      val content = new TextArea(sys.props.toSeq.sortBy(_._1).map(p ⇒ s"${p._1}=${p._2}").mkString("\n"))
+      val content = new TextArea(sys.props.toSeq.sortBy(_._1).map(p => s"${p._1}=${p._2}").mkString("\n"))
       content.setPrefHeight(400)
       win.setScene(new Scene(content))
       win.sizeToScene()

--- a/src/sbt-test/jlink/test-jlink-minimal/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-minimal/build.sbt
@@ -18,9 +18,9 @@ TaskKey[Unit]("runChecks") := {
   }
 
   val (extension, os) = sys.props("os.name").toLowerCase match {
-    case os if os.contains("mac") ⇒ (".app", 'mac)
-    case os if os.contains("win") ⇒ (".exe", 'windows)
-    case _ ⇒ ("", 'linux)
+    case os if os.contains("mac") => (".app", 'mac)
+    case os if os.contains("win") => (".exe", 'windows)
+    case _                        => ("", 'linux)
   }
 
   val stageDir = (Universal / stagingDirectory).value

--- a/src/sbt-test/jlink/test-jlink-misc/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-misc/build.sbt
@@ -106,8 +106,7 @@ val issue1293 = project
     // Use `paramaner` (and only it) as an automatic module
     jlinkModulePath := {
       // Get the full classpath with all the resolved dependencies.
-      (jlinkBuildImage / fullClasspath)
-        .value
+      (jlinkBuildImage / fullClasspath).value
         // Find the ones that have `paranamer` as their artifact names.
         .filter { item =>
           item.get(moduleID.key).exists { modId =>

--- a/src/sphinx/formats/jdkpackager.rst
+++ b/src/sphinx/formats/jdkpackager.rst
@@ -170,9 +170,9 @@ Here's what the build file looks like:
     packageDescription := "A test package using Oracle's JDK bundled javapackager tool."
 
     lazy val iconGlob = sys.props("os.name").toLowerCase match {
-      case os if os.contains("mac") ⇒ "*.icns"
-      case os if os.contains("win") ⇒ "*.ico"
-      case _ ⇒ "*.png"
+      case os if os.contains("mac") => "*.icns"
+      case os if os.contains("win") => "*.ico"
+      case _ => "*.png"
     }
 
     jdkAppIcon :=  (sourceDirectory.value ** iconGlob).getPaths.headOption.map(file)

--- a/test-project-jdkpackager/build.sbt
+++ b/test-project-jdkpackager/build.sbt
@@ -18,9 +18,9 @@ packageSummary := "JDKPackagerPlugin example package thingy"
 packageDescription := "A test package using Oracle's JDK bundled javapackager tool."
 
 lazy val iconGlob = sys.props("os.name").toLowerCase match {
-  case os if os.contains("mac") ⇒ "*.icns"
-  case os if os.contains("win") ⇒ "*.ico"
-  case _ ⇒ "*.png"
+  case os if os.contains("mac") => "*.icns"
+  case os if os.contains("win") => "*.ico"
+  case _                        => "*.png"
 }
 
 jdkAppIcon := (sourceDirectory.value ** iconGlob).getPaths.headOption.map(file)

--- a/test-project-jdkpackager/src/main/scala/ExampleApp.scala
+++ b/test-project-jdkpackager/src/main/scala/ExampleApp.scala
@@ -23,7 +23,7 @@ class ExampleApp extends Application {
       val win = new Stage(StageStyle.UTILITY)
       win.initModality(Modality.APPLICATION_MODAL)
       win.initOwner(stage)
-      val content = new TextArea(sys.props.toSeq.sortBy(_._1).map(p ⇒ s"${p._1}=${p._2}").mkString("\n"))
+      val content = new TextArea(sys.props.toSeq.sortBy(_._1).map(p => s"${p._1}=${p._2}").mkString("\n"))
       content.setPrefHeight(400)
       win.setScene(new Scene(content))
       win.sizeToScene()


### PR DESCRIPTION
Here's an offshoot from sbt 2.x migration https://github.com/sbt/sbt-native-packager/pull/1647

## Problem
The unicode arrow is deprecated.

## Solution
This rewrites it to `=>`.
