### PR TITLE
refactor: Use slash syntax in scripted

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,26 +77,26 @@ If you have enabled one of the archetypes (app or server),
 you can build your application with
 
 ```bash
-sbt <config-scope>:packageBin
+sbt <config-scope>/packageBin
 ```
 
 ### Examples
 
 ```bash
 # universal zip
-sbt universal:packageBin
+sbt Universal/packageBin
 
 # debian package
-sbt debian:packageBin
+sbt Debian/packageBin
 
 # rpm package
-sbt rpm:packageBin
+sbt Rpm/packageBin
 
 # docker image
-sbt docker:publishLocal
+sbt Docker/publishLocal
 
 # graalvm image
-sbt graalvm-native-image:packageBin
+sbt GraalVMNativeImage/packageBin
 ```
 
 Read more in the specific [format documentation][formats] on how to configure and build your package.

--- a/integration-tests-ansible/test-project-play-rpm/run-sbt-build.sh
+++ b/integration-tests-ansible/test-project-play-rpm/run-sbt-build.sh
@@ -5,4 +5,4 @@ set -euo pipefail
 IFS=$'\n\t'
 
 sbt --warn update compile
-sbt 'rpm:packageBin'
+sbt 'Rpm/packageBin'

--- a/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
@@ -133,7 +133,7 @@ class JDebConsole(log: Logger) extends org.vafer.jdeb.Console {
   * ==JDeb Packaging Task==
   *
   * This private class contains all the jdeb-plugin specific implementations. It's only invoked when the jdeb plugin is
-  * enabled and the `debian:packageBin` task is called. This means that all classes in `org.vafer.jdeb._` are only
+  * enabled and the `Debian/packageBin` task is called. This means that all classes in `org.vafer.jdeb._` are only
   * loaded when required and allows us to put the dependency in the "provided" scope. The provided scope means that we
   * have less dependency issues in an sbt build.
   */

--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -40,7 +40,7 @@ trait DebianKeys {
   val debianCombinedMappings =
     TaskKey[Seq[LinuxPackageMapping]]("debian-combined-mappings", "All the mappings of files for the final package.")
 
-  @deprecated("Use debian:stage instead", "1.2.0")
+  @deprecated("Use Debian/stage instead", "1.2.0")
   val debianExplodedPackage = TaskKey[File]("debian-exploded-package", "makes an exploded debian package")
   val lintian = TaskKey[Unit]("lintian", "runs the debian lintian tool on the current package.")
   val debianSign = TaskKey[File]("debian-sign", "runs the dpkg-sig command to sign the generated deb file.")

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -100,7 +100,7 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
   * ==Docker Client Task==
   *
   * This private class contains all the docker-plugin specific implementations. It's only invoked when the docker plugin
-  * is enabled and the `docker:publishLocal` task is called. This means that all classes in
+  * is enabled and the `Docker/publishLocal` task is called. This means that all classes in
   * `com.spotify.docker.client._` are only loaded when required and allows us to put the dependency in the "provided"
   * scope. The provided scope means that we have less dependency issues in an sbt build.
   */

--- a/src/main/scala/com/typesafe/sbt/packager/docker/LayeredMapping.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/LayeredMapping.scala
@@ -6,7 +6,7 @@ import java.io.File
   * Mapping of file to intermediate layers.
   *
   * @param layerId
-  *   The identifier in the layer used to increase cache hits in docker caching. LayerId is present in docker:stage
+  *   The identifier in the layer used to increase cache hits in docker caching. LayerId is present in Docker/stage
   *   directory structure and in intermediate image produced in the multi-stage docker build. None means the layering is
   *   skipped for this file.
   * @param file

--- a/src/main/scala/com/typesafe/sbt/packager/validation/ValidationKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/validation/ValidationKeys.scala
@@ -6,8 +6,8 @@ trait ValidationKeys {
 
   /**
     * A task that implements various validations for a format. Example usage:
-    *   - `sbt universal:packageBin::validatePackage`
-    *   - `sbt debian:packageBin::validatePackage`
+    *   - `sbt Universal/packageBin/validatePackage`
+    *   - `sbt Debian/packageBin/validatePackage`
     *
     * Each format should implement it's own validate. Implemented in #1026
     */

--- a/src/sbt-test/debian/daemon-group-gid-deb/test
+++ b/src/sbt-test/debian/daemon-group-gid-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 $ exists target/debian-test-0.1.0/etc

--- a/src/sbt-test/debian/daemon-user-deb/test
+++ b/src/sbt-test/debian/daemon-user-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check defaults

--- a/src/sbt-test/debian/daemon-user-homedir-deb/test
+++ b/src/sbt-test/debian/daemon-user-homedir-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check defaults

--- a/src/sbt-test/debian/daemon-user-shell-deb/test
+++ b/src/sbt-test/debian/daemon-user-shell-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check defaults

--- a/src/sbt-test/debian/daemon-user-uid-deb/test
+++ b/src/sbt-test/debian/daemon-user-uid-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 $ exists target/debian-test-0.1.0/etc

--- a/src/sbt-test/debian/file-permissions/test
+++ b/src/sbt-test/debian/file-permissions/test
@@ -1,3 +1,3 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb

--- a/src/sbt-test/debian/gen-changes/test
+++ b/src/sbt-test/debian/gen-changes/test
@@ -1,4 +1,4 @@
 # Run the debian packaging.
-> debian:genChanges
+> Debian/genChanges
 $ exists target/debian-test_0.1.0_all.deb
 $ exists target/debian-test_0.1.0_all.changes

--- a/src/sbt-test/debian/java-app-archetype/test
+++ b/src/sbt-test/debian/java-app-archetype/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 > stage
 $ exists target/universal/stage/bin/debian-test

--- a/src/sbt-test/debian/jdeb-conflicts/test
+++ b/src/sbt-test/debian/jdeb-conflicts/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
 $ mkdir src/resources/empty
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 > checkConflicts

--- a/src/sbt-test/debian/jdeb-dependencies/test
+++ b/src/sbt-test/debian/jdeb-dependencies/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
 $ mkdir src/resources/empty
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 > checkDependencies

--- a/src/sbt-test/debian/jdeb-dir-mappings/test
+++ b/src/sbt-test/debian/jdeb-dir-mappings/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
 $ mkdir src/resources/empty
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 > checkDirMappings

--- a/src/sbt-test/debian/jdeb-provides/test
+++ b/src/sbt-test/debian/jdeb-provides/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
 $ mkdir src/resources/empty
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 > checkProvides

--- a/src/sbt-test/debian/jdeb-script-replacements/test
+++ b/src/sbt-test/debian/jdeb-script-replacements/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
 $ mkdir src/resources/empty
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 > checkControlFiles

--- a/src/sbt-test/debian/log-directory/test
+++ b/src/sbt-test/debian/log-directory/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check defaults

--- a/src/sbt-test/debian/native-build-compress/test
+++ b/src/sbt-test/debian/native-build-compress/test
@@ -1,2 +1,2 @@
-> debian:packageBin
+> Debian/packageBin
 > checkDebCompression

--- a/src/sbt-test/debian/native-build-default/test
+++ b/src/sbt-test/debian/native-build-default/test
@@ -1,2 +1,2 @@
-> debian:packageBin
+> Debian/packageBin
 > checkDebCompression

--- a/src/sbt-test/debian/override-control-files/test
+++ b/src/sbt-test/debian/override-control-files/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 $ exists target/debian-test-0.1.0/etc

--- a/src/sbt-test/debian/override-etc-default/test
+++ b/src/sbt-test/debian/override-etc-default/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check files for defaults

--- a/src/sbt-test/debian/override-loader-functions/test
+++ b/src/sbt-test/debian/override-loader-functions/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check files for defaults

--- a/src/sbt-test/debian/override-start-script-systemd/test
+++ b/src/sbt-test/debian/override-start-script-systemd/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check files for defaults

--- a/src/sbt-test/debian/override-start-script-systemv/test
+++ b/src/sbt-test/debian/override-start-script-systemv/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check files for defaults

--- a/src/sbt-test/debian/override-start-script-upstart/test
+++ b/src/sbt-test/debian/override-start-script-upstart/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Check files for defaults

--- a/src/sbt-test/debian/simple-deb/test
+++ b/src/sbt-test/debian/simple-deb/test
@@ -1,3 +1,3 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb

--- a/src/sbt-test/debian/simple-jdeb/test
+++ b/src/sbt-test/debian/simple-jdeb/test
@@ -1,3 +1,3 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb

--- a/src/sbt-test/debian/systemd-deb/test
+++ b/src/sbt-test/debian/systemd-deb/test
@@ -1,10 +1,10 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 $ exists target/debian-test-0.1.0/lib/systemd/system/debian-test.service
-> show debian:serverLoader
-> show debian:linuxStartScriptTemplate
+> show Debian/serverLoader
+> show Debian/linuxStartScriptTemplate
 > plugins
 
 > checkStartupScript
@@ -15,5 +15,5 @@ $ exists target/debian-test-0.1.0/lib/systemd/system/debian-test.service
 # Test that serviceAutostart can be disabled
 
 > set every NativePackagerKeys.serviceAutostart := false
-> debian:packageBin
+> Debian/packageBin
 > checkNoAutostart

--- a/src/sbt-test/debian/sysvinit-deb/test
+++ b/src/sbt-test/debian/sysvinit-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 $ exists target/debian-test-0.1.0/etc
@@ -13,5 +13,5 @@ $ exists target/debian-test-0.1.0/etc/init.d/debian-test
 # Test that serviceAutostart can be disabled
 
 > set every NativePackagerKeys.serviceAutostart := false
-> debian:packageBin
+> Debian/packageBin
 > checkNoAutostart

--- a/src/sbt-test/debian/sysvinit-stoptimeouts-deb/test
+++ b/src/sbt-test/debian/sysvinit-stoptimeouts-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 $ exists target/debian-test-0.1.0/etc

--- a/src/sbt-test/debian/test-executableScriptName/test
+++ b/src/sbt-test/debian/test-executableScriptName/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 # Testing the packageName configuration
 $ exists target/debian-test-0.1.0/DEBIAN

--- a/src/sbt-test/debian/test-mapping-helpers/test
+++ b/src/sbt-test/debian/test-mapping-helpers/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 # Template directories

--- a/src/sbt-test/debian/test-mapping/test
+++ b/src/sbt-test/debian/test-mapping/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test-override_0.1.0_all.deb
 # Testing the packageName configuration
 $ exists target/debian-test-override-0.1.0/DEBIAN

--- a/src/sbt-test/debian/test-packageName/test
+++ b/src/sbt-test/debian/test-packageName/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test-override_0.1.0_all.deb
 # Testing the packageName configuration
 $ exists target/debian-test-override-0.1.0/DEBIAN

--- a/src/sbt-test/debian/upstart-deb-facilities/test
+++ b/src/sbt-test/debian/upstart-deb-facilities/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 $ exists target/debian-test-0.1.0/etc/init/debian-test.conf
 

--- a/src/sbt-test/debian/upstart-deb/test
+++ b/src/sbt-test/debian/upstart-deb/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> debian:packageBin
+> Debian/packageBin
 $ exists target/debian-test_0.1.0_all.deb
 
 $ exists target/debian-test-0.1.0/etc
@@ -20,5 +20,5 @@ $ exists target/debian-test-0.1.0/DEBIAN/postinst
 # Test that serviceAutostart can be disabled
 
 > set every NativePackagerKeys.serviceAutostart := false
-> debian:packageBin
+> Debian/packageBin
 > checkNoAutostart

--- a/src/sbt-test/docker/alias/test
+++ b/src/sbt-test/docker/alias/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run docker-alias-test:0.1.0 | grep -q "Hello world"'

--- a/src/sbt-test/docker/autoremove-multi-stage-intermediate-images/test
+++ b/src/sbt-test/docker/autoremove-multi-stage-intermediate-images/test
@@ -3,12 +3,12 @@
 # First make sure we start clean
 $ exec bash -c 'docker image prune -f --filter label=snp-multi-stage=intermediate'
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 # By default intermediate images will be removed
 -$ exec bash -c 'docker images --filter label=snp-multi-stage=intermediate | grep -q "<none>"'
 # Now lets change the default so we keep those images
 > set dockerAutoremoveMultiStageIntermediateImages := false
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker images --filter label=snp-multi-stage=intermediate | grep -q "<none>"'
 # Alright, now let's remove them by hand
 $ exec bash -c 'docker image prune -f --filter label=snp-multi-stage=intermediate'

--- a/src/sbt-test/docker/build-command/test
+++ b/src/sbt-test/docker/build-command/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run docker-build-command-test:0.1.0 | grep -q "docker build command override test"'

--- a/src/sbt-test/docker/build-options/test
+++ b/src/sbt-test/docker/build-options/test
@@ -1,4 +1,4 @@
 # Stage the distribution and ensure files show up.
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run docker-build-options-test:0.1.0 | grep -q "Hello world"'
 $ exec bash -c 'docker run docker-build-options-test:0.1.0-random-tag | grep -q "Hello world"'

--- a/src/sbt-test/docker/entrypoint/test
+++ b/src/sbt-test/docker/entrypoint/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 $ exec grep -q -F 'ENTRYPOINT ["/bin/sh", "-c", "env"]' target/docker/stage/Dockerfile

--- a/src/sbt-test/docker/envVars/test
+++ b/src/sbt-test/docker/envVars/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 > checkDockerfile

--- a/src/sbt-test/docker/file-permission/test
+++ b/src/sbt-test/docker/file-permission/test
@@ -1,32 +1,32 @@
 # Stage the distribution and ensure files show up.
-> docker:publishLocal
+> Docker/publishLocal
 > checkDockerfileDefaults
 
 $ copy-file changes/strategy-none.sbt change.sbt
 > reload
-> docker:publishLocal
+> Docker/publishLocal
 > checkDockerfileWithStrategyNone
 
 $ copy-file changes/strategy-none-gid.sbt change.sbt
 > reload
-> docker:publishLocal
+> Docker/publishLocal
 > checkDockerfileWithStrategyNoneGid
 
 $ copy-file changes/strategy-run.sbt change.sbt
 > reload
-> docker:publishLocal
+> Docker/publishLocal
 > checkDockerfileWithStrategyRun
 
 $ copy-file changes/dockerversion.sbt change.sbt
 > reload
--> docker:stage
+-> Docker/stage
 
 $ copy-file changes/strategy-copychown.sbt change.sbt
 > reload
-> docker:publishLocal
+> Docker/publishLocal
 > checkDockerfileWithStrategyCopyChown
 
 $ copy-file changes/write-execute.sbt change.sbt
 > reload
-> docker:publishLocal
+> Docker/publishLocal
 > checkDockerfileWithWriteExecute

--- a/src/sbt-test/docker/jdk-versions/test
+++ b/src/sbt-test/docker/jdk-versions/test
@@ -1,9 +1,9 @@
 > project jdk8
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run --rm jdk-versions:8 | grep -q "Hello JDK8!"'
 > project jdk9
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run --rm jdk-versions:9 | grep -q "Hello JDK9!"'
 > project jdk10
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run --rm jdk-versions:10 | grep -q "Hello JDK10!"'

--- a/src/sbt-test/docker/labels/test
+++ b/src/sbt-test/docker/labels/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 > checkDockerfile

--- a/src/sbt-test/docker/multiple-main-classes/test
+++ b/src/sbt-test/docker/multiple-main-classes/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 $ exec grep -q -F 'RUN ["chmod", "u+x,g+x", "/4/opt/docker/bin/multi-main-name"]' target/docker/stage/Dockerfile

--- a/src/sbt-test/docker/multiple-tags/test
+++ b/src/sbt-test/docker/multiple-tags/test
@@ -1,5 +1,5 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run docker-test:latest | grep -q "Hello world"'
 $ exec bash -c 'docker run docker-test:0.1.0 | grep -q "Hello world"'
 $ exec bash -c 'docker run docker-test:0.1 | grep -q "Hello world"'

--- a/src/sbt-test/docker/override-commands/test
+++ b/src/sbt-test/docker/override-commands/test
@@ -1,4 +1,4 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run docker-commands:latest | grep -q "Hello, World from Docker"'
 $ exec bash -c 'docker inspect -f "{{json .Config.Labels}}" docker-commands:latest | grep "MAINTAINER" | grep -q "Gary Coady"'

--- a/src/sbt-test/docker/ports/test
+++ b/src/sbt-test/docker/ports/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 $ exec grep -q -F 'EXPOSE 9000 9001 10000/udp 10001/udp' target/docker/stage/Dockerfile

--- a/src/sbt-test/docker/rmi/test
+++ b/src/sbt-test/docker/rmi/test
@@ -1,5 +1,5 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker images | grep -q rmi'
-> docker:clean
+> Docker/clean
 $ exec bash -c '[[ $(docker images) != "rmi"* ]]'

--- a/src/sbt-test/docker/simple-docker/test
+++ b/src/sbt-test/docker/simple-docker/test
@@ -1,3 +1,3 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run simple-docker:0.1.0 | grep -q "Hello world"'

--- a/src/sbt-test/docker/spotify-client/test
+++ b/src/sbt-test/docker/spotify-client/test
@@ -1,3 +1,3 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run docker-test:0.1.0 | grep -q "Hello world"'

--- a/src/sbt-test/docker/staging/test
+++ b/src/sbt-test/docker/staging/test
@@ -1,4 +1,4 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 $ exists target/docker/stage/Dockerfile
 $ exists target/docker/stage/opt

--- a/src/sbt-test/docker/test-busybox-create-user/test
+++ b/src/sbt-test/docker/test-busybox-create-user/test
@@ -1,3 +1,3 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run test-busybox-create-user:0.1.0 | grep -q "appuser"'

--- a/src/sbt-test/docker/test-executableScriptName/test
+++ b/src/sbt-test/docker/test-executableScriptName/test
@@ -1,5 +1,5 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exists target/docker/stage/Dockerfile
 $ exists target/docker/stage/4/opt/docker/bin/docker-exec
 > checkDockerfile

--- a/src/sbt-test/docker/test-layer-groups/test
+++ b/src/sbt-test/docker/test-layer-groups/test
@@ -1,5 +1,5 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exists target/docker/stage/Dockerfile
 $ exists target/docker/stage/4/opt/docker/bin/docker-groups
 $ exists target/docker/stage/2/opt/docker/lib/org.slf4j.slf4j-api-1.7.30.jar
@@ -17,7 +17,7 @@ $ exec bash -c 'docker rmi docker-groups:0.1.0'
 $ copy-file changes/nolayers.sbt layers.sbt
 > reload
 > clean
-> docker:publishLocal
+> Docker/publishLocal
 $ exists target/docker/stage/opt/docker/bin
 $ exists target/docker/stage/opt/docker/spark
 -$ exists target/docker/stage/2

--- a/src/sbt-test/docker/test-packageName-universal/test
+++ b/src/sbt-test/docker/test-packageName-universal/test
@@ -1,5 +1,5 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exists target/docker/stage/Dockerfile
 $ exists target/docker/stage/4/opt/docker/bin/docker-test
 > checkDockerfile

--- a/src/sbt-test/docker/test-packageName/test
+++ b/src/sbt-test/docker/test-packageName/test
@@ -1,5 +1,5 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exists target/docker/stage/Dockerfile
 $ exists target/docker/stage/4/opt/docker/bin/docker-test
 > checkDockerfile

--- a/src/sbt-test/docker/udp-only-ports/test
+++ b/src/sbt-test/docker/udp-only-ports/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 $ exec grep -q -F 'EXPOSE 10000/udp 10001/udp' target/docker/stage/Dockerfile

--- a/src/sbt-test/docker/update-latest/test
+++ b/src/sbt-test/docker/update-latest/test
@@ -1,3 +1,3 @@
 # Generate the Docker image locally
-> docker:publishLocal
+> Docker/publishLocal
 $ exec bash -c 'docker run docker-test:latest | grep -q "Hello world"'

--- a/src/sbt-test/docker/volumes/test
+++ b/src/sbt-test/docker/volumes/test
@@ -1,5 +1,5 @@
 # Stage the distribution and ensure files show up.
-> docker:stage
+> Docker/stage
 $ exec grep -q -F 'VOLUME ["/opt/docker/logs", "/opt/docker/config"]' target/docker/stage/Dockerfile
 $ exec grep -q -F 'RUN ["chown", "-R", "demiourgos728:root", "/opt/docker/logs", "/opt/docker/config"]' target/docker/stage/Dockerfile
 $ exec grep -q -F 'RUN ["mkdir", "-p", "/opt/docker/logs", "/opt/docker/config"]' target/docker/stage/Dockerfile

--- a/src/sbt-test/graalvm-native-image/docker-native-image/test
+++ b/src/sbt-test/graalvm-native-image/docker-native-image/test
@@ -1,3 +1,3 @@
 # Generate the GraalVM native image
-> show graalvm-native-image:packageBin
+> show GraalVMNativeImage/packageBin
 $ exec bash -c 'target/graalvm-native-image/docker-test | grep -q "Hello Graal"'

--- a/src/sbt-test/graalvm-native-image/simple-native-image/test
+++ b/src/sbt-test/graalvm-native-image/simple-native-image/test
@@ -1,3 +1,3 @@
 # Generate the GraalVM native image
-> show graalvm-native-image:packageBin
+> show GraalVMNativeImage/packageBin
 $ exec bash -c 'target/graalvm-native-image/simple-test | grep -q "Hello Graal"'

--- a/src/sbt-test/jdkpackager/test-package-image/test
+++ b/src/sbt-test/jdkpackager/test-package-image/test
@@ -1,3 +1,3 @@
 # Run the jdkpackager packaging
-> jdkPackager:packageBin
+> JDKPackager/packageBin
 > checkImage

--- a/src/sbt-test/jdkpackager/test-package-mappings/test
+++ b/src/sbt-test/jdkpackager/test-package-mappings/test
@@ -1,3 +1,3 @@
 # Run the jdkpackager packaging
-> jdkPackager:packageBin
+> JDKPackager/packageBin
 > checkImage

--- a/src/sbt-test/jdkpackager/test-package-minimal/test
+++ b/src/sbt-test/jdkpackager/test-package-minimal/test
@@ -1,3 +1,3 @@
 # Run the jdkpackager packaging
-> jdkPackager:packageBin
+> JDKPackager/packageBin
 > checkImage

--- a/src/sbt-test/rpm/changelog-test/test
+++ b/src/sbt-test/rpm/changelog-test/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test.spec
 

--- a/src/sbt-test/rpm/config-no-replace/test
+++ b/src/sbt-test/rpm/config-no-replace/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/x86_64/rpm-test-0.1.0-1.x86_64.rpm
 
 > unzip

--- a/src/sbt-test/rpm/override-loader-functions/test
+++ b/src/sbt-test/rpm/override-loader-functions/test
@@ -1,5 +1,5 @@
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 > checkLoaderScript

--- a/src/sbt-test/rpm/override-start-script-systemd/test
+++ b/src/sbt-test/rpm/override-start-script-systemd/test
@@ -1,5 +1,5 @@
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 > unzip

--- a/src/sbt-test/rpm/override-start-script-systemv/test
+++ b/src/sbt-test/rpm/override-start-script-systemv/test
@@ -1,5 +1,5 @@
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 > unzip

--- a/src/sbt-test/rpm/override-start-script-upstart/test
+++ b/src/sbt-test/rpm/override-start-script-upstart/test
@@ -1,5 +1,5 @@
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 > unzip

--- a/src/sbt-test/rpm/path-override-rpm/test
+++ b/src/sbt-test/rpm/path-override-rpm/test
@@ -1,5 +1,5 @@
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 > unzip

--- a/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-no-javarepack-rpm/test
@@ -1,5 +1,5 @@
 # Run the RPM packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-no-repack-0.1.0-2.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test-no-repack.spec
 

--- a/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
+++ b/src/sbt-test/rpm/scriplets-use-javarepack-rpm/test
@@ -1,5 +1,5 @@
 # Run the RPM packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-with-repack-0.1.0-2.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test-with-repack.spec
 

--- a/src/sbt-test/rpm/scriptlets-override-build-rpm/test
+++ b/src/sbt-test/rpm/scriptlets-override-build-rpm/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test.spec
 

--- a/src/sbt-test/rpm/scriptlets-override-rpm/test
+++ b/src/sbt-test/rpm/scriptlets-override-rpm/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 # Check rpm contents

--- a/src/sbt-test/rpm/scriptlets-rpm/test
+++ b/src/sbt-test/rpm/scriptlets-rpm/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test.spec
 

--- a/src/sbt-test/rpm/setarch-rpm/test
+++ b/src/sbt-test/rpm/setarch-rpm/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/i386/rpm-package-0.1.0-1.i386.rpm
 $ exists target/rpm/SPECS/rpm-package.spec
 

--- a/src/sbt-test/rpm/simple-rpm/test
+++ b/src/sbt-test/rpm/simple-rpm/test
@@ -1,6 +1,6 @@
-> rpm:stage
+> Rpm/stage
 $ exists target/rpm
 > checkSpecFile
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/x86_64/rpm-test-0.1.0-1.x86_64.rpm

--- a/src/sbt-test/rpm/snapshot-override-rpm/test
+++ b/src/sbt-test/rpm/snapshot-override-rpm/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-1-SNAPSHOT.noarch.rpm
 
 #Check release and version configured correctly

--- a/src/sbt-test/rpm/snapshot-rpm/test
+++ b/src/sbt-test/rpm/snapshot-rpm/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-SNAPSHOT.noarch.rpm
 
 #Check release and version configured correctly

--- a/src/sbt-test/rpm/symlink-rpm/test
+++ b/src/sbt-test/rpm/symlink-rpm/test
@@ -1,4 +1,4 @@
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-package-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-package.spec
 > checkSpecFile

--- a/src/sbt-test/rpm/systemd-rpm/test
+++ b/src/sbt-test/rpm/systemd-rpm/test
@@ -1,5 +1,5 @@
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 > unzip
@@ -14,6 +14,6 @@ $ exists usr/lib/systemd/system/rpm-test.service
 # test that autostart can be disabled
 
 > set every NativePackagerKeys.serviceAutostart := false
-> rpm:packageBin
+> Rpm/packageBin
 > checkSpecFile
 > checkSpecNoAutostart

--- a/src/sbt-test/rpm/sysvinit-rpm/test
+++ b/src/sbt-test/rpm/sysvinit-rpm/test
@@ -1,5 +1,5 @@
 # Run the rpm packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 
 > checkSpecFile
@@ -30,6 +30,6 @@ $ exists var/run/rpm-test
 # Test that serviceAutostart can be disabled
 
 > set every NativePackagerKeys.serviceAutostart := false
-> rpm:packageBin
+> Rpm/packageBin
 > checkSpecFile
 > checkSpecNoAutostart

--- a/src/sbt-test/rpm/test-artifactPath/test
+++ b/src/sbt-test/rpm/test-artifactPath/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm-package-0.1.0.rpm
 $ exists target/rpm/RPMS/noarch/rpm-package-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-package.spec

--- a/src/sbt-test/rpm/test-executableScriptName/test
+++ b/src/sbt-test/rpm/test-executableScriptName/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-test-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-test.spec
 

--- a/src/sbt-test/rpm/test-packageName/test
+++ b/src/sbt-test/rpm/test-packageName/test
@@ -1,5 +1,5 @@
 # Run the debian packaging.
-> rpm:packageBin
+> Rpm/packageBin
 $ exists target/rpm/RPMS/noarch/rpm-package-0.1.0-1.noarch.rpm
 $ exists target/rpm/SPECS/rpm-package.spec
 

--- a/src/sbt-test/universal/clear-stage-dir/test
+++ b/src/sbt-test/universal/clear-stage-dir/test
@@ -1,9 +1,9 @@
 # Stage the distribution and ensure files show up.
-> universal:stage
+> Universal/stage
 $ exists target/universal/stage/conf/test
 $ exists target/universal/stage/conf/test2
 $ delete src/universal/conf/test2
-> universal:stage
+> Universal/stage
 $ exists target/universal/stage/conf/test
 $ absent target/universal/stage/conf/test2
 

--- a/src/sbt-test/universal/publish/test
+++ b/src/sbt-test/universal/publish/test
@@ -1,6 +1,6 @@
 # Ensure we can publish to local file system.
-> universal:publish
+> Universal/publish
 # Ensure isSnpashot works correctly
-> universal:publish
+> Universal/publish
 # Ensure we can publish to local maven repository.
-> universal:publishM2
+> Universal/publishM2

--- a/src/sbt-test/universal/staging-custom-main/test
+++ b/src/sbt-test/universal/staging-custom-main/test
@@ -1,5 +1,5 @@
 # Stage the distribution and ensure main class can be run.
-> show universal:packageBin
+> show Universal/packageBin
 $ exists target/universal/stage-custom-main-0.1.0.zip
 > unzip
 $ exists stage-custom-main-0.1.0/bin/

--- a/src/sbt-test/universal/staging/test
+++ b/src/sbt-test/universal/staging/test
@@ -1,3 +1,3 @@
 # Stage the distribution and ensure files show up.
-> show universal:stage
+> show Universal/stage
 $ exists target/universal/stage/conf/test

--- a/src/sbt-test/universal/test-executableScriptName/test
+++ b/src/sbt-test/universal/test-executableScriptName/test
@@ -1,5 +1,5 @@
 # Run the zip packaging.
-> show universal:packageBin
+> show Universal/packageBin
 $ exists target/universal/simple-test-0.1.0.zip
 > unzip
 $ exists simple-test-0.1.0/bin/

--- a/src/sbt-test/universal/test-mapping-helpers/test
+++ b/src/sbt-test/universal/test-mapping-helpers/test
@@ -1,5 +1,5 @@
 # Run the universal packaging.
-> show universal:packageBin
+> show Universal/packageBin
 $ exists target/universal/simple-test-0.1.0.zip
 
 > unzip

--- a/src/sbt-test/universal/test-native-zip/test
+++ b/src/sbt-test/universal/test-native-zip/test
@@ -1,5 +1,5 @@
 # Run the zip packaging.
-> show universal:packageBin
+> show Universal/packageBin
 $ exists target/universal/simple-test-0.1.0.zip
 
 # TODO - Check contents of zips.  Ensure file permissions are preserved.

--- a/src/sbt-test/universal/test-packageName/test
+++ b/src/sbt-test/universal/test-packageName/test
@@ -1,11 +1,11 @@
 # Run the zip packaging.
-> show universal:packageBin
+> show Universal/packageBin
 $ exists target/universal/simple-package.zip
 
 # Run the tgz packaging.
-> universal:packageZipTarball
+> Universal/packageZipTarball
 $ exists target/universal/simple-package.tgz
 
 # Run the txz packaging.
-> universal:packageXzTarball
+> Universal/packageXzTarball
 $ exists target/universal/simple-package.txz

--- a/src/sbt-test/universal/test-zips-no-top-level-dir/test
+++ b/src/sbt-test/universal/test-zips-no-top-level-dir/test
@@ -1,13 +1,13 @@
 # Run the zip packaging.
-> show universal:packageBin
+> show Universal/packageBin
 $ exists target/universal/simple-test-0.1.0.zip
 
 # Run the tgz packaging.
-> universal:packageZipTarball
+> Universal/packageZipTarball
 $ exists target/universal/simple-test-0.1.0.tgz
 
 # Run the txz packaging.
-> universal:packageXzTarball
+> Universal/packageXzTarball
 $ exists target/universal/simple-test-0.1.0.txz
 
 

--- a/src/sbt-test/universal/test-zips/test
+++ b/src/sbt-test/universal/test-zips/test
@@ -1,25 +1,25 @@
 # Run the zip packaging.
-> show universal:packageBin
+> show Universal/packageBin
 $ exists target/universal/simple-test-0.1.0.zip
-> universal-docs:packageBin
+> UniversalDocs/packageBin
 $ exists target/universal-docs/simple-test-0.1.0.zip
-> universal-src:packageBin
+> UniversalSrc/packageBin
 $ exists target/universal-src/simple-test-0.1.0.zip
 
 # Run the tgz packaging.
-> universal:packageZipTarball
+> Universal/packageZipTarball
 $ exists target/universal/simple-test-0.1.0.tgz
-> universal-docs:packageZipTarball
+> UniversalDocs/packageZipTarball
 $ exists target/universal-docs/simple-test-0.1.0.tgz
-> universal-src:packageZipTarball
+> UniversalSrc/packageZipTarball
 $ exists target/universal-src/simple-test-0.1.0.tgz
 
 # Run the txz packaging.
-> universal:packageXzTarball
+> Universal/packageXzTarball
 $ exists target/universal/simple-test-0.1.0.txz
-> universal-docs:packageXzTarball
+> UniversalDocs/packageXzTarball
 $ exists target/universal-docs/simple-test-0.1.0.txz
-> universal-src:packageXzTarball
+> UniversalSrc/packageXzTarball
 $ exists target/universal-src/simple-test-0.1.0.txz
 
 

--- a/src/sbt-test/universal/validation/test
+++ b/src/sbt-test/universal/validation/test
@@ -1,6 +1,6 @@
 # Cannot create an empty distribution
--> universal:packageBin
+-> Universal/packageBin
 $ mkdir src/universal
 $ copy-file build.sbt src/universal/test-file
-> universal:packageBin
+> Universal/packageBin
 $ exists target/universal/simple-test-0.1.0.zip

--- a/src/sbt-test/windows/custom-wix/test
+++ b/src/sbt-test/windows/custom-wix/test
@@ -1,3 +1,3 @@
 # Run the windows packaging.
-> windows:packageBin
+> Windows/packageBin
 $ exists target/windows/custom-wix.msi

--- a/src/sbt-test/windows/java-app-archetype/test
+++ b/src/sbt-test/windows/java-app-archetype/test
@@ -1,5 +1,5 @@
 # Run the windows packaging.
-> windows:packageBin
+> Windows/packageBin
 $ exists target/windows/windows-test.msi
 > stage
 $ exists target/universal/stage/bin/windows-test.bat


### PR DESCRIPTION
Here's another offshoot from sbt 2.x migration (https://github.com/sbt/sbt-native-packager/pull/1647)

## Problem/Solution
In preparation for sbt 2.x, we need to migrate all the old style shell syntax in scripted tests to slash.
