### PR TITLE
Fix multi-platform builds with multiple aliases.

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -300,9 +300,12 @@ object DockerPlugin extends AutoPlugin {
               "--push"
             ) ++ dockerBuildOptions.value :+ "."
           else dockerExecCommand.value
-        alias.foreach { aliasValue =>
-          publishDocker(context, execCommand, aliasValue.toString, log, multiplatform)
-        }
+        // For multiplatform builds, the alias are part of the `dockerBuildOptions` already.
+        if (multiplatform) publishDocker(context, execCommand, dockerAlias.value.tag.getOrElse(""), log, multiplatform)
+        else
+          alias.foreach { aliasValue =>
+            publishDocker(context, execCommand, aliasValue.toString, log, multiplatform)
+          }
       } tag (Tags.Network, Tags.Publish)
 
     def cleanTask =


### PR DESCRIPTION
Multi-platform builds append a `-t` argument for each alias to the `dockerBuildOptions`, but the `publishTask` function was ALWAYS iterating over the aliases even if it was a multi-platform build.

https://github.com/sbt/sbt-native-packager/blob/7c6885910c382784bcd2cd9fc63c2794a9dbd0a2/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala#L157-L159

The consequence was attempts to buildx and push the tags multiple times. In some environments this leads to build failures because you can't push the same tag twice.

This change simply does not iterate over the aliases for multiplatform builds.

Note: using `dockerUpdateLatest := true` counts as having multiple aliases, which is how I encountered this bug.