### PR TITLE
bat script: implement -jvm-debug

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -154,6 +154,12 @@ rem Processes incoming arguments and places them in appropriate global variables
     goto param_loop
   )
 
+  if "!_TEST_PARAM!"=="-jvm-debug" (
+    set _JAVA_PARAMS=!_JAVA_PARAMS! -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%~1
+    shift
+    goto param_loop
+  )
+
   if "!_TEST_PARAM:~0,2!"=="-J" (
     rem strip -J prefix
     call set _TEST_PARAM=!_TEST_PARAM:~2!

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bat-template
@@ -155,7 +155,7 @@ rem Processes incoming arguments and places them in appropriate global variables
   )
 
   if "!_TEST_PARAM!"=="-jvm-debug" (
-    set _JAVA_PARAMS=!_JAVA_PARAMS! -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%~1
+    set "_JAVA_PARAMS=!_JAVA_PARAMS! -agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=%~1"
     shift
     goto param_loop
   )

--- a/src/sbt-test/windows/test-bat-template/build.sbt
+++ b/src/sbt-test/windows/test-bat-template/build.sbt
@@ -59,7 +59,7 @@ TaskKey[Unit]("checkScript") := {
   ) = {
     val pr = new StringBuilder()
     val logger = ProcessLogger((o: String) => pr.append(o + "\n"), (e: String) => pr.append("error < " + e + "\n"))
-    val cmd = Seq("cmd", "/c", script.getAbsolutePath) ++ args
+    val cmd = script.getAbsolutePath +: args
     val result = sys.process.Process(cmd, None, env.toSeq: _*) ! logger
     if (result != expectedRC) {
       pr.append("error code: " + result + "\n")
@@ -82,7 +82,7 @@ TaskKey[Unit]("checkScript") := {
       fails.append(crlf2cr(pr.toString) + "\n")
       fails.append("\n--detail-------------------------------\n")
       pr.clear
-      sys.process.Process(Seq("cmd", "/c", detailScript.getAbsolutePath + " " + args), None, env.toSeq: _*) ! logger
+      sys.process.Process(detailScript.getAbsolutePath +: args, None, env.toSeq: _*) ! logger
       fails.append(crlf2cr(pr.toString) + "\n")
     }
     if (debugOutFile.exists) {


### PR DESCRIPTION
Typical usage is to add it to `conf/application.ini`:
```ini
# options from build
-Dfile.encoding=UTF-8
# ...

-jvm-debug 5005
```
