### PR TITLE
🐛 fix: use exec in forwarder scripts (#1664)

### DIFF
--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-forwarder-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/ash-forwarder-template
@@ -58,4 +58,4 @@ SCRIPT=$(realpath "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
 # execute the main start script
-$SCRIPTPATH/${{startScript}} -main ${{qualifiedClassName}} "$@"
+exec $SCRIPTPATH/${{startScript}} -main ${{qualifiedClassName}} "$@"

--- a/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-forwarder-template
+++ b/src/main/resources/com/typesafe/sbt/packager/archetypes/scripts/bash-forwarder-template
@@ -58,4 +58,4 @@ SCRIPT=$(realpath "$0")
 SCRIPTPATH=$(dirname "$SCRIPT")
 
 # execute the main start script
-$SCRIPTPATH/${{startScript}} -main ${{qualifiedClassName}} "$@"
+exec $SCRIPTPATH/${{startScript}} -main ${{qualifiedClassName}} "$@"


### PR DESCRIPTION
Fix #1664

I tested on a personal case but please consider I'm not super experienced in Bash/SH, thus I may be missing a reason for which it wouldn't be the desired behaviour.