### PR TITLE
Update scalafmt setting. enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,7 +1,7 @@
 # Version https://scalameta.org/scalafmt/docs/configuration.html#version
 version = 3.8.3
 # Dialect https://scalameta.org/scalafmt/docs/configuration.html#scala-dialects
-runner.dialect = scala212
+runner.dialect = scala212source3
 
 style = IntelliJ
 maxColumn = 120
@@ -14,3 +14,16 @@ project.excludePaths = [
   "glob:**/src/main/scala/com/typesafe/sbt/packager/windows/WixHelper.scala"
 ]
 project.layout = StandardConvention
+
+fileOverride {
+  "glob:**/src/**/scala-3/**" {
+    runner.dialect = scala3
+    runner.dialectOverride.allowAsForImportRename = false
+  }
+}
+
+rewrite.scala3.convertToNewSyntax = true
+rewrite.scala3.newSyntax.control = false
+runner.dialectOverride.allowSignificantIndentation = false
+runner.dialectOverride.allowAsForImportRename = false
+runner.dialectOverride.allowStarWildcardImport = false

--- a/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala
@@ -97,7 +97,7 @@ object SbtNativePackager extends AutoPlugin {
       * }}}
       */
     @deprecated("Use enablePlugins(JavaAppPackaging)", "1.x")
-    def java_application: Seq[Setting[_]] =
+    def java_application: Seq[Setting[?]] =
       projectSettings ++
         universal.UniversalPlugin.projectSettings ++
         linux.LinuxPlugin.projectSettings ++
@@ -113,7 +113,7 @@ object SbtNativePackager extends AutoPlugin {
       * }}}
       */
     @deprecated("Use enablePlugins(JavaServerAppPackaging)", "1.x")
-    def java_server: Seq[Setting[_]] =
+    def java_server: Seq[Setting[?]] =
       java_application ++ archetypes.JavaServerAppPackaging.projectSettings
   }
 

--- a/src/main/scala/com/typesafe/sbt/packager/FileUtil.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/FileUtil.scala
@@ -80,7 +80,7 @@ object permissions {
 
   /** Enriches string with `oct` interpolator, parsing string as base 8 integer. */
   implicit class OctalString(val sc: StringContext) extends AnyVal {
-    def oct(args: Any*) = Integer.parseInt(sc.s(args: _*), 8)
+    def oct(args: Any*) = Integer.parseInt(sc.s(args*), 8)
   }
 
 }

--- a/src/main/scala/com/typesafe/sbt/packager/SettingsHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/SettingsHelper.scala
@@ -18,7 +18,7 @@ object SettingsHelper {
     packageTask: TaskKey[PluginCompat.FileRef],
     extension: String,
     classifier: Option[String] = None
-  ): Seq[Setting[_]] =
+  ): Seq[Setting[?]] =
     inConfig(config)(
       addArtifact(
         name.apply(Artifact(_, extension, extension, classifier = classifier, configurations = Vector.empty, None)),
@@ -31,7 +31,7 @@ object SettingsHelper {
     packageTask: TaskKey[PluginCompat.FileRef],
     extension: String,
     classifier: Option[String] = None
-  ): Seq[Setting[_]] =
+  ): Seq[Setting[?]] =
     // Why do we need the ivyPublishSettings and jvmPublishSettings ?
     inConfig(config)(Classpaths.ivyPublishSettings ++ Classpaths.jvmPublishSettings) ++ inConfig(config)(
       Seq(
@@ -97,6 +97,6 @@ object SettingsHelper {
     * @param config
     *   the ivy configuration to look for resolvers
     */
-  private def addResolver(config: Configuration): Seq[Setting[_]] =
+  private def addResolver(config: Configuration): Seq[Setting[?]] =
     Seq(otherResolvers ++= (config / publishTo).value.toSeq)
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaServerApplication.scala
@@ -40,7 +40,7 @@ object JavaServerAppPackaging extends AutoPlugin {
   val ETC_DEFAULT = "etc-default"
 
   /** These settings will be provided by this archetype */
-  def javaServerSettings: Seq[Setting[_]] =
+  def javaServerSettings: Seq[Setting[?]] =
     linuxSettings ++ debianSettings ++ rpmSettings
 
   /**
@@ -50,7 +50,7 @@ object JavaServerAppPackaging extends AutoPlugin {
     *   - logging directory
     *   - config directory
     */
-  def linuxSettings: Seq[Setting[_]] =
+  def linuxSettings: Seq[Setting[?]] =
     Seq(
       Linux / javaOptions := (Universal / javaOptions).value,
       // === logging directory mapping ===
@@ -76,7 +76,7 @@ object JavaServerAppPackaging extends AutoPlugin {
   /* etcDefaultConfig is dependent on serverLoading (systemd, systemv, etc.),
    * and is therefore distro specific. As such, these settings cannot be defined
    * in the global config scope. */
-  private[this] val etcDefaultConfig: Seq[Setting[_]] = Seq(
+  private[this] val etcDefaultConfig: Seq[Setting[?]] = Seq(
     linuxEtcDefaultTemplate := getEtcTemplateSource(sourceDirectory.value, (serverLoading ?? None).value),
     makeEtcDefault := makeEtcDefaultScript(
       packageName.value,
@@ -87,7 +87,7 @@ object JavaServerAppPackaging extends AutoPlugin {
     linuxPackageMappings ++= etcDefaultMapping(makeEtcDefault.value, bashScriptEnvConfigLocation.value)
   )
 
-  def debianSettings: Seq[Setting[_]] = {
+  def debianSettings: Seq[Setting[?]] = {
     import DebianPlugin.Names.{Postinst, Postrm, Preinst, Prerm}
     inConfig(Debian)(etcDefaultConfig) ++
       inConfig(Debian)(
@@ -118,7 +118,7 @@ object JavaServerAppPackaging extends AutoPlugin {
       )
   }
 
-  def rpmSettings: Seq[Setting[_]] =
+  def rpmSettings: Seq[Setting[?]] =
     inConfig(Rpm)(etcDefaultConfig) ++
       inConfig(Rpm)(
         Seq(

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -42,7 +42,7 @@ object JlinkPlugin extends AutoPlugin {
 
   override def requires: Plugins = JavaAppPackaging
 
-  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+  override lazy val projectSettings: Seq[Setting[?]] = Seq(
     jlinkBuildImage / target := target.value / "jlink" / "output",
     jlinkBundledJvmLocation := "jre",
     bundledJvmLocation := Some(jlinkBundledJvmLocation.value),

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptPlugin.scala
@@ -54,7 +54,7 @@ object BashStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator wit
 
   override protected[this] type SpecializedScriptConfig = BashScriptConfig
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     Seq(
       bashScriptTemplateLocation := (sourceDirectory.value / "templates" / bashTemplate),
       bashForwarderTemplateLocation := Some(sourceDirectory.value / "templates" / forwarderTemplateName),

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptPlugin.scala
@@ -86,7 +86,7 @@ object BatStartScriptPlugin extends AutoPlugin with ApplicationIniGenerator with
 
   override protected[this] type SpecializedScriptConfig = BatScriptConfig
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     Seq(
       batScriptTemplateLocation := (sourceDirectory.value / "templates" / batTemplate),
       batForwarderTemplateLocation := Some(sourceDirectory.value / "templates" / forwarderTemplateName),

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemVPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemVPlugin.scala
@@ -24,11 +24,11 @@ object SystemVPlugin extends AutoPlugin {
 
   override def requires = SystemloaderPlugin
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     inConfig(Debian)(systemVSettings) ++ debianSettings ++
       inConfig(Rpm)(systemVSettings) ++ rpmSettings
 
-  def systemVSettings: Seq[Setting[_]] =
+  def systemVSettings: Seq[Setting[?]] =
     Seq(
       // used by other archetypes to define systemloader dependent behaviour
       serverLoading := Some(ServerLoader.SystemV),
@@ -49,7 +49,7 @@ object SystemVPlugin extends AutoPlugin {
       )
     )
 
-  def debianSettings: Seq[Setting[_]] =
+  def debianSettings: Seq[Setting[?]] =
     inConfig(Debian)(
       Seq(
         // set the template
@@ -61,7 +61,7 @@ object SystemVPlugin extends AutoPlugin {
       )
     )
 
-  def rpmSettings: Seq[Setting[_]] =
+  def rpmSettings: Seq[Setting[?]] =
     inConfig(Rpm)(
       Seq(
         // set the template

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemdPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemdPlugin.scala
@@ -41,10 +41,10 @@ object SystemdPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     debianSettings ++ inConfig(Debian)(systemdSettings) ++ rpmSettings ++ inConfig(Rpm)(systemdSettings)
 
-  def systemdSettings: Seq[Setting[_]] =
+  def systemdSettings: Seq[Setting[?]] =
     Seq(
       // used by other archetypes to define systemloader dependent behaviour
       serverLoading := Some(ServerLoader.Systemd),
@@ -68,8 +68,8 @@ object SystemdPlugin extends AutoPlugin {
       linuxScriptReplacements += ("TimeoutStopSec" -> killTimeout.value.toString)
     )
 
-  def debianSettings: Seq[Setting[_]] = inConfig(Debian)(defaultLinuxStartScriptLocation := "/lib/systemd/system")
+  def debianSettings: Seq[Setting[?]] = inConfig(Debian)(defaultLinuxStartScriptLocation := "/lib/systemd/system")
 
-  def rpmSettings: Seq[Setting[_]] = inConfig(Rpm)(defaultLinuxStartScriptLocation := "/usr/lib/systemd/system")
+  def rpmSettings: Seq[Setting[?]] = inConfig(Rpm)(defaultLinuxStartScriptLocation := "/usr/lib/systemd/system")
 
 }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemloaderPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/SystemloaderPlugin.scala
@@ -43,11 +43,11 @@ object SystemloaderPlugin extends AutoPlugin {
       com.typesafe.sbt.packager.archetypes.systemloader.ServerLoader
   }
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     inConfig(Debian)(systemloaderSettings) ++ debianSettings ++
       inConfig(Rpm)(systemloaderSettings) ++ rpmSettings
 
-  def systemloaderSettings: Seq[Setting[_]] =
+  def systemloaderSettings: Seq[Setting[?]] =
     Seq(
       serverLoading := None,
       serviceAutostart := true,
@@ -90,7 +90,7 @@ object SystemloaderPlugin extends AutoPlugin {
     if (autostart) s"${addService}\n${startService}" else addService
   }
 
-  def debianSettings: Seq[Setting[_]] =
+  def debianSettings: Seq[Setting[?]] =
     inConfig(Debian)(
       Seq(
         // add automatic service start/stop
@@ -107,7 +107,7 @@ object SystemloaderPlugin extends AutoPlugin {
       )
     )
 
-  def rpmSettings: Seq[Setting[_]] =
+  def rpmSettings: Seq[Setting[?]] =
     inConfig(Rpm)(
       Seq(
         // add automatic service start/stop

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/UpstartPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/systemloader/UpstartPlugin.scala
@@ -27,10 +27,10 @@ object UpstartPlugin extends AutoPlugin {
 
   override def requires = SystemloaderPlugin
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     inConfig(Debian)(upstartSettings) ++ inConfig(Rpm)(upstartSettings)
 
-  def upstartSettings: Seq[Setting[_]] =
+  def upstartSettings: Seq[Setting[?]] =
     Seq(
       // used by other archetypes to define systemloader dependent behaviour
       serverLoading := Some(ServerLoader.Upstart),

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianNativePackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianNativePackaging.scala
@@ -34,7 +34,7 @@ trait DebianNativePackaging extends DebianPluginLike {
   /**
     * Using the native installed dpkg-build tools to build the debian package.
     */
-  private[debian] def debianNativeSettings: Seq[Setting[_]] =
+  private[debian] def debianNativeSettings: Seq[Setting[?]] =
     inConfig(Debian)(
       Seq(
         debianNativeBuildOptions += "-Znone", // packages are largely JARs, which are already compressed

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianPlugin.scala
@@ -68,7 +68,7 @@ object DebianPlugin extends AutoPlugin with DebianNativePackaging {
   /**
     * Enables native packaging by default
     */
-  override lazy val projectSettings: Seq[Setting[_]] = settings ++ debianSettings ++ debianNativeSettings
+  override lazy val projectSettings: Seq[Setting[?]] = settings ++ debianSettings ++ debianNativeSettings
 
   /**
     * the default debian settings for the debian namespaced settings
@@ -170,7 +170,7 @@ object DebianPlugin extends AutoPlugin with DebianNativePackaging {
     * ==Debian scoped settings==
     * Everything used inside the debian scope
     */
-  private def debianSettings: Seq[Setting[_]] =
+  private def debianSettings: Seq[Setting[?]] =
     inConfig(Debian)(
       Seq(
         packageArchitecture := "all",
@@ -479,7 +479,7 @@ object DebianDeployPlugin extends AutoPlugin {
 
   override def requires = DebianPlugin
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     SettingsHelper.makeDeploymentSettings(Debian, Debian / packageBin, "deb") ++
       SettingsHelper.addPackage(Debian, Debian / genChanges, "changes")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
@@ -38,7 +38,7 @@ object JDebPackaging extends AutoPlugin with DebianPluginLike {
 
   override def requires: Plugins = DebianPlugin
 
-  override lazy val projectSettings: Seq[Setting[_]] = inConfig(Debian)(jdebSettings)
+  override lazy val projectSettings: Seq[Setting[?]] = inConfig(Debian)(jdebSettings)
 
   def jdebSettings =
     Seq(

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -71,7 +71,7 @@ object DockerPlugin extends AutoPlugin {
 
   // Some of the default values are now provided in the global setting based on
   // sbt plugin best practice: https://www.scala-sbt.org/release/docs/Plugins-Best-Practices.html#Provide+default+values+in
-  override lazy val globalSettings: Seq[Setting[_]] = Seq(
+  override lazy val globalSettings: Seq[Setting[?]] = Seq(
     // See https://github.com/sbt/sbt-native-packager/issues/1187
     // Note: Do not make this setting depend on the Docker version.
     // Docker version may change depending on the person running the build, or even with something like
@@ -95,7 +95,7 @@ object DockerPlugin extends AutoPlugin {
     dockerCmd := Seq()
   )
 
-  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+  override lazy val projectSettings: Seq[Setting[?]] = Seq(
     dockerAlias := DockerAlias(
       (Docker / dockerRepository).value,
       (Docker / dockerUsername).value,
@@ -552,7 +552,7 @@ object DockerPlugin extends AutoPlugin {
         List(daemonUser, "||") :::
         List("adduser", "-S") :::
         (uidOpt.fold[List[String]](Nil)(List("-u", _))) :::
-        List("-G", daemonGroup, daemonUser, "))")): _*
+        List("-G", daemonGroup, daemonUser, "))"))*
     )
 
   /**
@@ -570,7 +570,7 @@ object DockerPlugin extends AutoPlugin {
     *   ENTRYPOINT command
     */
   private final def makeEntrypoint(entrypoint: Seq[String]): CmdLike =
-    ExecCmd("ENTRYPOINT", entrypoint: _*)
+    ExecCmd("ENTRYPOINT", entrypoint*)
 
   /**
     * Default CMD implementation as default parameters to ENTRYPOINT.
@@ -579,7 +579,7 @@ object DockerPlugin extends AutoPlugin {
     *   CMD with args in exec form
     */
   private final def makeCmd(args: Seq[String]): CmdLike =
-    ExecCmd("CMD", args: _*)
+    ExecCmd("CMD", args*)
 
   /**
     * @param exposedPorts
@@ -614,7 +614,7 @@ object DockerPlugin extends AutoPlugin {
       Seq(
         ExecCmd("RUN", Seq("mkdir", "-p") ++ exposedVolumes: _*),
         makeChown(daemonUser, daemonGroup, exposedVolumes),
-        ExecCmd("VOLUME", exposedVolumes: _*)
+        ExecCmd("VOLUME", exposedVolumes*)
       )
 
   /**
@@ -624,7 +624,7 @@ object DockerPlugin extends AutoPlugin {
     *   String representation of the Dockerfile described by commands
     */
   private final def makeDockerContent(commands: Seq[CmdLike]): String =
-    Dockerfile(commands: _*).makeContent
+    Dockerfile(commands*).makeContent
 
   /**
     * @param commands,
@@ -645,7 +645,7 @@ object DockerPlugin extends AutoPlugin {
   /**
     * uses the `Universal / mappings` to generate the `Docker / mappings`.
     */
-  def mapGenericFilesToDocker: Seq[Setting[_]] = {
+  def mapGenericFilesToDocker: Seq[Setting[?]] = {
     def renameDests(from: Seq[(PluginCompat.FileRef, String)], dest: String) =
       for {
         (f, path) <- from
@@ -711,7 +711,7 @@ object DockerPlugin extends AutoPlugin {
     log.debug("Working directory " + context.toString)
 
     val logger = if (buildkitEnabled) publishLocalBuildkitLogger(log) else publishLocalLogger(log)
-    val ret = sys.process.Process(buildCommand, context, envVars.toSeq: _*) ! logger
+    val ret = sys.process.Process(buildCommand, context, envVars.toSeq*) ! logger
 
     if (!buildkitEnabled && removeIntermediateImages) {
       val labelKey = "snp-multi-stage-id"

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerSpotifyClientPlugin.scala
@@ -49,7 +49,7 @@ object DockerSpotifyClientPlugin extends AutoPlugin {
 
   import DockerPlugin.autoImport._
 
-  override lazy val projectSettings: Seq[Setting[_]] = inConfig(Docker)(clientSettings)
+  override lazy val projectSettings: Seq[Setting[?]] = inConfig(Docker)(clientSettings)
 
   def clientSettings =
     Seq(

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
@@ -37,7 +37,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
 
   override def projectConfigurations: Seq[Configuration] = Seq(GraalVMNativeImage)
 
-  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+  override lazy val projectSettings: Seq[Setting[?]] = Seq(
     GraalVMNativeImage / target := target.value / "graalvm-native-image",
     graalVMNativeImageOptions := Seq.empty,
     graalVMNativeImageGraalVersion := None,
@@ -46,7 +46,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
     GraalVMNativeImage / mainClass := (Compile / mainClass).value
   ) ++ inConfig(GraalVMNativeImage)(scopedSettings)
 
-  private lazy val scopedSettings = Seq[Setting[_]](
+  private lazy val scopedSettings = Seq[Setting[?]](
     resourceDirectories := Seq(resourceDirectory.value),
     includeFilter := "*",
     resources := resourceDirectories.value.descendantsExcept(includeFilter.value, excludeFilter.value).get(),

--- a/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
@@ -21,7 +21,7 @@ object ClasspathJarPlugin extends AutoPlugin {
 
   override def requires = JavaAppPackaging
 
-  override lazy val projectSettings: Seq[Setting[_]] = Defaults
+  override lazy val projectSettings: Seq[Setting[?]] = Defaults
     .packageTaskSettings(packageJavaClasspathJar, packageJavaClasspathJar / mappings) ++ Seq(
     packageJavaClasspathJar / mappings := Nil,
     packageJavaClasspathJar / artifactClassifier := Option("classpath"),

--- a/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
@@ -24,7 +24,7 @@ object LauncherJarPlugin extends AutoPlugin {
 
   override def requires = JavaAppPackaging
 
-  override lazy val projectSettings: Seq[Setting[_]] = Defaults
+  override lazy val projectSettings: Seq[Setting[?]] = Defaults
     .packageTaskSettings(packageJavaLauncherJar, packageJavaLauncherJar / mappings) ++ Seq(
     packageJavaLauncherJar / mappings := Nil,
     packageJavaLauncherJar / artifactClassifier := Option("launcher"),

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
@@ -33,7 +33,7 @@ object JDKPackagerPlugin extends AutoPlugin {
 
   override def projectConfigurations: Seq[Configuration] = Seq(JDKPackager)
 
-  override lazy val projectSettings: Seq[Setting[_]] = Seq(
+  override lazy val projectSettings: Seq[Setting[?]] = Seq(
     jdkAppIcon := None,
     jdkPackagerType := "installer",
     jdkPackagerBasename := packageName.value + "-pkg",
@@ -90,6 +90,6 @@ object JDKPackagerDeployPlugin extends AutoPlugin {
   import JDKPackagerPlugin.autoImport._
   override def requires = JDKPackagerPlugin
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     SettingsHelper.makeDeploymentSettings(JDKPackager, JDKPackager / packageBin, "jdkPackager")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxMappingDSL.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxMappingDSL.scala
@@ -23,7 +23,7 @@ trait LinuxMappingDSL {
     *   directories to map
     */
   def packageDirectoryAndContentsMapping(dirs: (File, String)*) =
-    LinuxPackageMapping(mapDirectoryAndContents(dirs: _*))
+    LinuxPackageMapping(mapDirectoryAndContents(dirs*))
 
   /**
     * This method includes files and directories.

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPackageMapping.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPackageMapping.scala
@@ -32,7 +32,7 @@ case class LinuxPackageMapping(
   def withPerms(perms: String) = copy(fileData = fileData withPerms perms)
   def withConfig(c: String = "true") = copy(fileData = fileData withConfig c)
   def withContents() =
-    copy(mappings = M.mapDirectoryAndContents(mappings.toSeq *))
+    copy(mappings = M.mapDirectoryAndContents(mappings.toSeq*))
   def asDocs() = copy(fileData = fileData.asDocs())
 
   /** Modifies the current package mapping to have gzipped data. */

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
@@ -44,7 +44,7 @@ object LinuxPlugin extends AutoPlugin {
   /**
     * default linux settings
     */
-  def linuxSettings: Seq[Setting[_]] =
+  def linuxSettings: Seq[Setting[?]] =
     Seq(
       linuxPackageMappings := Seq.empty,
       linuxPackageSymlinks := Seq.empty,
@@ -105,7 +105,7 @@ object LinuxPlugin extends AutoPlugin {
   /**
     * maps the `mappings` content into `linuxPackageMappings` and `linuxPackageSymlinks`.
     */
-  def mapGenericFilesToLinux: Seq[Setting[_]] =
+  def mapGenericFilesToLinux: Seq[Setting[?]] =
     Seq(
       // First we look at the src/linux files
       linuxPackageMappings ++= {
@@ -240,14 +240,14 @@ object LinuxPlugin extends AutoPlugin {
       val renamed =
         for ((file, name) <- mappings)
           yield file -> rename(name)
-      packageMapping(renamed: _*)
+      packageMapping(renamed*)
     }
 
     Seq(
       packageMappingWithRename(binaries ++ directories: _*) withUser user withGroup group withPerms "0755",
-      packageMappingWithRename(compressedManPages: _*).gzipped withUser user withGroup group withPerms "0644",
-      packageMappingWithRename(configFiles: _*).withConfig() withUser user withGroup group withPerms "0644",
-      packageMappingWithRename(remaining: _*) withUser user withGroup group withPerms "0644"
+      packageMappingWithRename(compressedManPages*).gzipped withUser user withGroup group withPerms "0644",
+      packageMappingWithRename(configFiles*).withConfig() withUser user withGroup group withPerms "0644",
+      packageMappingWithRename(remaining*) withUser user withGroup group withPerms "0644"
     )
   }
 

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -212,6 +212,6 @@ object RpmDeployPlugin extends AutoPlugin {
 
   override def requires = RpmPlugin
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     SettingsHelper.makeDeploymentSettings(Rpm, Rpm / packageBin, "rpm")
 }

--- a/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
@@ -37,7 +37,7 @@ object UniversalPlugin extends AutoPlugin {
     /**
       * Use native zipping instead of java based zipping
       */
-    def useNativeZip: Seq[Setting[_]] =
+    def useNativeZip: Seq[Setting[?]] =
       makePackageSettings(packageBin, Universal)(makeNativeZip) ++
         makePackageSettings(packageBin, UniversalDocs)(makeNativeZip) ++
         makePackageSettings(packageBin, UniversalSrc)(makeNativeZip)
@@ -50,17 +50,17 @@ object UniversalPlugin extends AutoPlugin {
   override def projectConfigurations: Seq[Configuration] =
     Seq(Universal, UniversalDocs, UniversalSrc)
 
-  override def globalSettings: Seq[Def.Setting[_]] =
-    Seq[Setting[_]](
+  override def globalSettings: Seq[Def.Setting[?]] =
+    Seq[Setting[?]](
       // Since more than just the docker plugin uses the docker command, we define this in the universal plugin
       // so that it can be configured once and shared by all plugins without requiring the docker plugin.
       DockerPlugin.autoImport.dockerExecCommand := Seq("docker")
     )
 
-  override lazy val buildSettings: Seq[Setting[_]] = Seq[Setting[_]](containerBuildImage := None)
+  override lazy val buildSettings: Seq[Setting[?]] = Seq[Setting[?]](containerBuildImage := None)
 
   /** The basic settings for the various packaging types. */
-  override lazy val projectSettings: Seq[Setting[_]] = Seq[Setting[_]](
+  override lazy val projectSettings: Seq[Setting[?]] = Seq[Setting[?]](
     // For now, we provide delegates from dist/stage to universal...
     dist := (Universal / dist).value,
     stage := (Universal / stage).value,
@@ -78,7 +78,7 @@ object UniversalPlugin extends AutoPlugin {
     defaultUniversalArchiveOptions
 
   /** Creates all package types for a given configuration */
-  private[this] def makePackageSettingsForConfig(config: Configuration): Seq[Setting[_]] =
+  private[this] def makePackageSettingsForConfig(config: Configuration): Seq[Setting[?]] =
     makePackageSettings(packageBin, config)(makeZip) ++
       makePackageSettings(packageOsxDmg, config)(makeDmg) ++
       makePackageSettings(packageZipTarball, config)(makeTgz) ++
@@ -101,7 +101,7 @@ object UniversalPlugin extends AutoPlugin {
         config / target := target.value / config.name
       )
 
-  private[this] def defaultUniversalArchiveOptions: Seq[Setting[_]] =
+  private[this] def defaultUniversalArchiveOptions: Seq[Setting[?]] =
     Seq(
       Universal / packageZipTarball / universalArchiveOptions := Seq("-pcvf"),
       Universal / packageXzTarball / universalArchiveOptions := Seq("-pcvf"),
@@ -124,7 +124,7 @@ object UniversalPlugin extends AutoPlugin {
   /** Creates packaging settings for a given package key, configuration + archive type. */
   private[this] def makePackageSettings(packageKey: TaskKey[PluginCompat.FileRef], config: Configuration)(
     packager: Packager
-  ): Seq[Setting[_]] =
+  ): Seq[Setting[?]] =
     inConfig(config)(
       Seq(
         packageKey / universalArchiveOptions := Nil,
@@ -176,7 +176,7 @@ object UniversalDeployPlugin extends AutoPlugin {
 
   override def requires: Plugins = UniversalPlugin
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     SettingsHelper.makeDeploymentSettings(Universal, Universal / packageBin, "zip") ++
       SettingsHelper.addPackage(Universal, Universal / packageZipTarball, "tgz") ++
       SettingsHelper.makeDeploymentSettings(UniversalDocs, Universal / packageBin, "zip") ++

--- a/src/main/scala/com/typesafe/sbt/packager/windows/WindowsPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/windows/WindowsPlugin.scala
@@ -40,7 +40,7 @@ object WindowsPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override lazy val projectSettings: Seq[Setting[_]] = windowsSettings ++ mapGenericFilesToWindows
+  override lazy val projectSettings: Seq[Setting[?]] = windowsSettings ++ mapGenericFilesToWindows
   override def requires = UniversalPlugin
 
   override def projectConfigurations: Seq[Configuration] = Seq(Windows)
@@ -48,7 +48,7 @@ object WindowsPlugin extends AutoPlugin {
   /**
     * default windows settings
     */
-  def windowsSettings: Seq[Setting[_]] =
+  def windowsSettings: Seq[Setting[?]] =
     Seq(
       Windows / sourceDirectory := sourceDirectory.value / "windows",
       Windows / target := target.value / "windows",
@@ -147,7 +147,7 @@ object WindowsPlugin extends AutoPlugin {
   /**
     * set the `Windows / mappings` and the `wixFeatures`
     */
-  def mapGenericFilesToWindows: Seq[Setting[_]] =
+  def mapGenericFilesToWindows: Seq[Setting[?]] =
     Seq(
       Windows / mappings := (Universal / mappings).value,
       wixFeatures := {
@@ -229,6 +229,6 @@ object WindowsDeployPlugin extends AutoPlugin {
 
   override def requires = WindowsPlugin
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     SettingsHelper.makeDeploymentSettings(Windows, Windows / packageBin, "msi")
 }


### PR DESCRIPTION
fix Scala 3 warnings

```
[warn] -- Warning: /home/runner/work/sbt-native-packager/sbt-native-packager/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala:100:38 
[warn] 100 |    def java_application: Seq[Setting[_]] =
[warn]     |                                      ^
[warn]     |`_` is deprecated for wildcard arguments of types: use `?` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
[warn] -- Warning: /home/runner/work/sbt-native-packager/sbt-native-packager/src/main/scala/com/typesafe/sbt/PackagerPlugin.scala:116:33 
[warn] 116 |    def java_server: Seq[Setting[_]] =
[warn]     |                                 ^
[warn]     |`_` is deprecated for wildcard arguments of types: use `?` instead
[warn]     |This construct can be rewritten automatically under -rewrite -source 3.4-migration.
```