### PR TITLE
scala-steward: pin scala-library to 2.12

### DIFF
--- a/.github/.scala-steward.conf
+++ b/.github/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.pin = [
+  { groupId = "org.scala-lang", artifactId = "scala-library", version = "2.12." }
+]


### PR DESCRIPTION
SBT 1.x uses Scala 2.12. This should stop scala-steward from opening PRs like #1635 #1610 #1599 to update to Scala 2.13.

This will not affect the updates for Scala 3 / SBT 2.x because that artifact is named `scala3-library`.