### PR TITLE
Fix release name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ env.RELEASE_VERSION }}
+          release_name: Release ${{ github.ref }}
           body: ${{ steps.release_changelog.outputs.content }}
           draft: false
           prerelease: false


### PR DESCRIPTION
`RELEASE_VERSION` isn't defined so the release name is missing the version

![image](https://github.com/user-attachments/assets/2bcea369-c94f-44d2-b4e6-8cc06dfc504b)
