### PR TITLE
fix: Fix version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -147,9 +147,15 @@ def versionFmt(out: sbtdynver.GitDescribeOutput): String = {
   val snapshotSuffix =
     if (out.isSnapshot()) "-SNAPSHOT"
     else ""
-  out.ref.dropPrefix + snapshotSuffix
+  dropBackPubCommand(out.ref.dropPrefix) + snapshotSuffix
 }
-
+def dropBackPubCommand(ver: String): String = {
+  val nonComment =
+    if (ver.contains("#")) ver.split("#").head
+    else ver
+  if (nonComment.contains("@")) nonComment.split("@").head
+  else nonComment
+}
 def fallbackVersion(d: java.util.Date): String = s"HEAD-${sbtdynver.DynVer timestamp d}"
 
 ThisBuild / version := {


### PR DESCRIPTION
## Problem
Currently the CI on Appveyor is failing due to hash in the version number created by back publishing + custom version formatting.

## Solution
Adjust the formatting to drop back publishing command.