### PR TITLE
Fix typo in "Skip packageDoc" section

### DIFF
--- a/src/sphinx/formats/universal.rst
+++ b/src/sphinx/formats/universal.rst
@@ -323,7 +323,7 @@ this behaviour, add this to your ``build.sbt``
 
 .. code-block:: scala
 
-    compile / packageDoc / mappings := Seq()
+    Compile / packageDoc / mappings := Seq()
 
 Source `issue 651`_.
 


### PR DESCRIPTION
Setting needs to be set in the `Compile` configuration, not the `compile` task.