### PR TITLE
Update customize.rst.txt

### DIFF
--- a/_sources/archetypes/java_app/customize.rst.txt
+++ b/_sources/archetypes/java_app/customize.rst.txt
@@ -72,7 +72,7 @@ You can specify your options via the ``build.sbt``.
        s"-version=${version.value}"
     )
 
-For the ``-X`` settings you need to add a suffix ``-J`` so the start script will
+For the ``-X`` settings you need to add a prefix ``-J`` so the start script will
 recognize these as vm config parameters.
 
 When you use the  ``Universal / javaOptions`` sbt-native-packager will generate configuration files


### PR DESCRIPTION
Update docs to reference `-J` requirements in `javaOptions` as a prefix not a suffix to the setting.

Thanks in advance for reviewing and for maintaining this library! 