### PR TITLE
Remove sbt-vspp to fix release

### DIFF
--- a/.github/workflows/publish-site.yml
+++ b/.github/workflows/publish-site.yml
@@ -4,15 +4,15 @@ on:
     tags: ["*"]
 jobs:
   publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       # setup build environment
       - name: Setup JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,3 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 
 // binary compatibility checks
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.4")
-
-// for enterprise Artifactory compatibility
-addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")


### PR DESCRIPTION
sbt-vspp is no longer required for the latest sbt 1.x, and it currently breaks sbt 2.x publishing.