### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,7 @@ on:
     # branches to consider in the event; optional, defaults to all
     branches:
       - $default-branch
+      - main
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         with:
           config-name: release-drafter.yml
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       # generate a github release
       - name: Generate release changelog
         id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.1.1
+        uses: heinrichreimer/github-changelog-generator-action@v2.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           cacheFile: '.github-changelog-cache'
@@ -42,6 +42,7 @@ jobs:
           output: LATEST_RELEASE.md
       - name: Read latest_release.md
         id: release_changelog
+        if: ${{ hashFiles('LATEST_RELEASE.md') != '' }}
         uses: juliangruber/read-file-action@v1
         with:
           path: ./LATEST_RELEASE.md


### PR DESCRIPTION
The `LATEST_RELEASE.md` cannot be created due to the following error

```
/usr/bin/docker run --name d3f580c1bcf1dd43ca881df3137b3aa9c3_872fb4 --label 5225d3 --workdir /github/workspace --rm -e "JAVA_HOME" -e "JAVA_HOME_8_X64" -e "INPUT_TOKEN" -e "INPUT_CACHEFILE" -e "INPUT_ISSUES" -e "INPUT_ISSUESWOLABELS" -e "INPUT_PULLREQUESTS" -e "INPUT_PRWOLABELS" -e "INPUT_UNRELEASED" -e "INPUT_ONLYLASTTAG" -e "INPUT_MAXISSUES" -e "INPUT_OUTPUT" -e "INPUT_REPO" -e "INPUT_USER" -e "INPUT_PROJECT" -e "INPUT_DATEFORMAT" -e "INPUT_BASE" -e "INPUT_HEADERLABEL" -e "INPUT_CONFIGURESECTIONS" -e "INPUT_ADDSECTIONS" -e "INPUT_FRONTMATTER" -e "INPUT_FILTERBYMILESTONE" -e "INPUT_AUTHOR" -e "INPUT_USERNAMESASGITHUBLOGINS" -e "INPUT_UNRELEASEDONLY" -e "INPUT_UNRELEASEDLABEL" -e "INPUT_INCLUDELABELS" -e "INPUT_EXCLUDELABELS" -e "INPUT_ISSUELINELABELS" -e "INPUT_EXCLUDETAGS" -e "INPUT_EXCLUDETAGSREGEX" -e "INPUT_SINCETAG" -e "INPUT_DUETAG" -e "INPUT_RELEASEURL" -e "INPUT_GITHUBSITE" -e "INPUT_GITHUBAPI" -e "INPUT_SIMPLELIST" -e "INPUT_FUTURERELEASE" -e "INPUT_RELEASEBRANCH" -e "INPUT_HTTPCACHE" -e "INPUT_CACHELOG" -e "INPUT_SSLCAFILE" -e "INPUT_VERBOSE" -e "INPUT_BREAKINGLABEL" -e "INPUT_BREAKINGLABELS" -e "INPUT_ENHANCEMENTLABEL" -e "INPUT_ENHANCEMENTLABELS" -e "INPUT_BUGSLABEL" -e "INPUT_BUGLABELS" -e "INPUT_DEPRECATEDLABEL" -e "INPUT_DEPRECATEDLABELS" -e "INPUT_REMOVEDLABEL" -e "INPUT_REMOVEDLABELS" -e "INPUT_SECURITYLABEL" -e "INPUT_SECURITYLABELS" -e "INPUT_ISSUESLABEL" -e "INPUT_PRLABEL" -e "INPUT_STRIPHEADERS" -e "INPUT_STRIPGENERATORNOTICE" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp":"/github/runner_temp" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/sbt-native-packager/sbt-native-packager":"/github/workspace" 5225d3:f580c1bcf1dd43ca881df3137b3aa9c3
#<Thread:0x000055960a8f3ab8@/usr/local/bundle/gems/github_changelog_generator-1.15.0/lib/github_changelog_generator/octo_fetcher.rb:319 run> terminated with exception (report_on_exception is true):
/usr/local/bundle/gems/octokit-4.14.0/lib/octokit/response/raise_error.rb:16:in `on_complete': GET https://api.github.com/repos/sbt/sbt-native-packager/compare/9ae9a8ac8125b3af7d9c14864bbcf26d1597203b...v1.11.1@3.x: 404 - Not Found // See: https://docs.github.com/rest/commits/commits#compare-two-commits (Octokit::NotFound)
```

during the release process ( https://github.com/sbt/sbt-native-packager/actions/runs/20948084649/job/60195023183 )

This system was always brittle anyways. Hopefully we get the release-drafter up and running, which is way more convenient and stable.