### PR TITLE
Partially replace compat layer with sbt-compat plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ target/
 .bloop/*
 .metals/*
 .bsp/
+
+.java-version
+.cursor/
+.vscode/
+.bloop/

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 // put jdeb on the classpath for scripted tests
 classpathTypes += "maven-plugin"
-addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0-SNAPSHOT")
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")
 
 libraryDependencies ++= Seq(
   // these dependencies have to be explicitly added by the user

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,8 @@ javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 // put jdeb on the classpath for scripted tests
 classpathTypes += "maven-plugin"
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0-SNAPSHOT")
+
 libraryDependencies ++= Seq(
   // these dependencies have to be explicitly added by the user
   "com.spotify" % "docker-client" % "8.16.0" % Provided,

--- a/src/main/scala-2.12/com/typesafe/sbt/packager/Compat.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/packager/Compat.scala
@@ -36,8 +36,4 @@ object Compat {
     *   a CacheStore
     */
   implicit def fileToCacheStore(file: java.io.File): CacheStore = CacheStore(file)
-
-  implicit class DefOps(private val self: sbt.Def.type) extends AnyVal {
-    def uncached[A](a: A): A = a
-  }
 }

--- a/src/main/scala-2.12/com/typesafe/sbt/packager/PluginCompat.scala
+++ b/src/main/scala-2.12/com/typesafe/sbt/packager/PluginCompat.scala
@@ -1,45 +1,14 @@
 package com.typesafe.sbt.packager
 
-import java.nio.file.{Path => NioPath}
 import java.util.jar.Attributes
 import sbt.*
-import xsbti.FileConverter
 
 object PluginCompat {
-  type FileRef = java.io.File
-  type ArtifactPath = java.io.File
-  type Out = java.io.File
   type IncludeArtifact = Artifact => Boolean
 
-  val artifactStr = sbt.Keys.artifact.key
-  val moduleIDStr = sbt.Keys.moduleID.key
-  def parseModuleIDStrAttribute(m: ModuleID): ModuleID = m
-  def moduleIDToStr(m: ModuleID): ModuleID = m
-  private[packager] def parseArtifactStrAttribute(a: Artifact): Artifact = a
-  def artifactToStr(art: Artifact): Artifact = art
-
-  private[packager] def toNioPath(a: Attributed[File])(implicit conv: FileConverter): NioPath =
-    a.data.toPath()
-  private[packager] def toNioPath(ref: File)(implicit conv: FileConverter): NioPath =
-    ref.toPath()
-  def toFile(a: Attributed[File])(implicit conv: FileConverter): File =
-    a.data
-  def toFile(ref: File)(implicit conv: FileConverter): File =
-    ref
-  private[packager] def artifactPathToFile(ref: File)(implicit conv: FileConverter): File =
-    ref
-  private[packager] def toArtifactPath(f: File)(implicit conv: FileConverter): ArtifactPath = f
-  private[packager] def toNioPaths(cp: Seq[Attributed[File]])(implicit conv: FileConverter): Vector[NioPath] =
-    cp.map(_.data.toPath()).toVector
-  private[packager] def toFiles(cp: Seq[Attributed[File]])(implicit conv: FileConverter): Vector[File] =
-    cp.map(_.data).toVector
-  def toFileRefsMapping(mappings: Seq[(File, String)])(implicit conv: FileConverter): Seq[(FileRef, String)] =
-    mappings
-  def toFileRef(x: File)(implicit conv: FileConverter): FileRef =
-    x
-  private[packager] def getName(ref: File): String =
+  private[packager] def getName(ref: java.io.File): String =
     ref.getName()
-  private[packager] def getArtifactPathName(ref: File): String =
+  private[packager] def getArtifactPathName(ref: java.io.File): String =
     ref.getName()
   private[packager] def classpathAttr = Attributes.Name.CLASS_PATH
   private[packager] def mainclassAttr = Attributes.Name.MAIN_CLASS

--- a/src/main/scala-3/com/typesafe/sbt/packager/PluginCompat.scala
+++ b/src/main/scala-3/com/typesafe/sbt/packager/PluginCompat.scala
@@ -1,59 +1,15 @@
 package com.typesafe.sbt.packager
 
-import java.io.File
-import java.nio.file.{Path => NioPath}
 import java.util.jar.Attributes
 import sbt.*
-import xsbti.{FileConverter, HashedVirtualFileRef, VirtualFile, VirtualFileRef}
-import sbt.internal.RemoteCache
+import xsbti.{HashedVirtualFileRef, VirtualFileRef}
 
 object PluginCompat {
-  type FileRef = HashedVirtualFileRef
-  type ArtifactPath = VirtualFileRef
-  type Out = VirtualFile
   type IncludeArtifact = Any => Boolean
 
-  val artifactStr = Keys.artifactStr
-  val moduleIDStr = Keys.moduleIDStr
-  def parseModuleIDStrAttribute(str: String): ModuleID =
-    Classpaths.moduleIdJsonKeyFormat.read(str)
-  def moduleIDToStr(m: ModuleID): String =
-    Classpaths.moduleIdJsonKeyFormat.write(m)
-
-  private[packager] def parseArtifactStrAttribute(str: String): Artifact =
-    import sbt.librarymanagement.LibraryManagementCodec.ArtifactFormat
-    import sjsonnew.support.scalajson.unsafe.*
-    Converter.fromJsonUnsafe[Artifact](Parser.parseUnsafe(str))
-  def artifactToStr(art: Artifact): String =
-    import sbt.librarymanagement.LibraryManagementCodec.ArtifactFormat
-    import sjsonnew.support.scalajson.unsafe.*
-    CompactPrinter(Converter.toJsonUnsafe(art))
-
-  private[packager] def toNioPath(a: Attributed[HashedVirtualFileRef])(using conv: FileConverter): NioPath =
-    conv.toPath(a.data)
-  private[packager] def toNioPath(ref: HashedVirtualFileRef)(using conv: FileConverter): NioPath =
-    conv.toPath(ref)
-  def toFile(a: Attributed[HashedVirtualFileRef])(using conv: FileConverter): File =
-    toNioPath(a).toFile()
-  def toFile(ref: HashedVirtualFileRef)(using conv: FileConverter): File =
-    toNioPath(ref).toFile()
-  private[packager] def artifactPathToFile(ref: VirtualFileRef)(using conv: FileConverter): File =
-    conv.toPath(ref).toFile()
-  private[packager] def toArtifactPath(f: File)(using conv: FileConverter): ArtifactPath =
-    conv.toVirtualFile(f.toPath())
-  private[packager] def toNioPaths(cp: Seq[Attributed[HashedVirtualFileRef]])(using
-    conv: FileConverter
-  ): Vector[NioPath] =
-    cp.map(toNioPath).toVector
-  private[packager] def toFiles(cp: Seq[Attributed[HashedVirtualFileRef]])(using conv: FileConverter): Vector[File] =
-    toNioPaths(cp).map(_.toFile())
-  def toFileRefsMapping(mappings: Seq[(File, String)])(using conv: FileConverter): Seq[(FileRef, String)] =
-    mappings.map { case (f, name) => toFileRef(f) -> name }
-  def toFileRef(x: File)(using conv: FileConverter): FileRef =
-    conv.toVirtualFile(x.toPath())
-  private[packager] def getName(ref: FileRef): String =
+  private[packager] def getName(ref: HashedVirtualFileRef): String =
     ref.name()
-  private[packager] def getArtifactPathName(ref: ArtifactPath): String =
+  private[packager] def getArtifactPathName(ref: VirtualFileRef): String =
     ref.name()
   private[packager] def classpathAttr: String = Attributes.Name.CLASS_PATH.toString()
   private[packager] def mainclassAttr: String = Attributes.Name.MAIN_CLASS.toString()

--- a/src/main/scala/com/typesafe/sbt/packager/MappingsHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/MappingsHelper.scala
@@ -60,10 +60,7 @@ object MappingsHelper extends Mapper {
     * @return
     *   a list of mappings
     */
-  def fromClasspath(
-    entries: Seq[Attributed[FileRef]],
-    target: String
-  ): Seq[(FileRef, String)] =
+  def fromClasspath(entries: Seq[Attributed[FileRef]], target: String): Seq[(FileRef, String)] =
     fromClasspath(entries, target, _ => true)
 
   /**
@@ -95,11 +92,10 @@ object MappingsHelper extends Mapper {
     includeArtifact: PluginCompat.IncludeArtifact,
     includeOnNoArtifact: Boolean = false
   ): Seq[(FileRef, String)] =
-    entries.filter(attr => attr.get(artifactStr).map(includeArtifact) getOrElse includeOnNoArtifact).map {
-      attribute =>
-        val file = attribute.data
-        val name = PluginCompat.getName(file)
-        file -> s"$target/${name}"
+    entries.filter(attr => attr.get(artifactStr).map(includeArtifact) getOrElse includeOnNoArtifact).map { attribute =>
+      val file = attribute.data
+      val name = PluginCompat.getName(file)
+      file -> s"$target/${name}"
     }
 
   /**

--- a/src/main/scala/com/typesafe/sbt/packager/MappingsHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/MappingsHelper.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager
 
 import sbt.{*, given}
 import sbt.io.*
+import sbtcompat.PluginCompat.*
 import xsbti.FileConverter
 
 /** A set of helper methods to simplify the writing of mappings */
@@ -38,10 +39,10 @@ object MappingsHelper extends Mapper {
   def contentOf(sourceDir: String): Seq[(File, String)] =
     contentOf(file(sourceDir))
 
-  def contentOf(sourceDir: File, conv0: FileConverter): Seq[(PluginCompat.FileRef, String)] = {
+  def contentOf(sourceDir: File, conv0: FileConverter): Seq[(FileRef, String)] = {
     implicit val conv: FileConverter = conv0
     contentOf(sourceDir).map { case (f, p) =>
-      PluginCompat.toFileRef(f) -> p
+      toFileRef(f) -> p
     }
   }
 
@@ -60,9 +61,9 @@ object MappingsHelper extends Mapper {
     *   a list of mappings
     */
   def fromClasspath(
-    entries: Seq[Attributed[PluginCompat.FileRef]],
+    entries: Seq[Attributed[FileRef]],
     target: String
-  ): Seq[(PluginCompat.FileRef, String)] =
+  ): Seq[(FileRef, String)] =
     fromClasspath(entries, target, _ => true)
 
   /**
@@ -89,12 +90,12 @@ object MappingsHelper extends Mapper {
     *   default is false. When there's no Artifact meta data remove it
     */
   def fromClasspath(
-    entries: Seq[Attributed[PluginCompat.FileRef]],
+    entries: Seq[Attributed[FileRef]],
     target: String,
     includeArtifact: PluginCompat.IncludeArtifact,
     includeOnNoArtifact: Boolean = false
-  ): Seq[(PluginCompat.FileRef, String)] =
-    entries.filter(attr => attr.get(PluginCompat.artifactStr).map(includeArtifact) getOrElse includeOnNoArtifact).map {
+  ): Seq[(FileRef, String)] =
+    entries.filter(attr => attr.get(artifactStr).map(includeArtifact) getOrElse includeOnNoArtifact).map {
       attribute =>
         val file = attribute.data
         val name = PluginCompat.getName(file)
@@ -104,10 +105,10 @@ object MappingsHelper extends Mapper {
   /**
     * Get the mappings for the given files relative to the given directories.
     */
-  def relative(files: Seq[File], dirs: Seq[File], conv0: FileConverter): Seq[(PluginCompat.FileRef, String)] = {
+  def relative(files: Seq[File], dirs: Seq[File], conv0: FileConverter): Seq[(FileRef, String)] = {
     implicit val conv: FileConverter = conv0
     (files --- dirs) pair (relativeTo(dirs) | flat) map { case (f, p) =>
-      PluginCompat.toFileRef(f) -> p
+      toFileRef(f) -> p
     }
   }
 }

--- a/src/main/scala/com/typesafe/sbt/packager/SettingsHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/SettingsHelper.scala
@@ -4,6 +4,7 @@ import sbt.{*, given}
 import sbt.Keys.*
 import sbt.librarymanagement.{IvyFileConfiguration, PublishConfiguration}
 import com.typesafe.sbt.packager.Compat.*
+import sbtcompat.PluginCompat.*
 import xsbti.FileConverter
 
 /**
@@ -15,7 +16,7 @@ object SettingsHelper {
 
   def addPackage(
     config: Configuration,
-    packageTask: TaskKey[PluginCompat.FileRef],
+    packageTask: TaskKey[FileRef],
     extension: String,
     classifier: Option[String] = None
   ): Seq[Setting[?]] =
@@ -28,7 +29,7 @@ object SettingsHelper {
 
   def makeDeploymentSettings(
     config: Configuration,
-    packageTask: TaskKey[PluginCompat.FileRef],
+    packageTask: TaskKey[FileRef],
     extension: String,
     classifier: Option[String] = None
   ): Seq[Setting[?]] =
@@ -58,7 +59,7 @@ object SettingsHelper {
             .withArtifacts(packagedArtifacts.value.toVector.map { case (a, f) =>
               val conv0 = fileConverter.value
               implicit val conv: FileConverter = conv0
-              (a, PluginCompat.toFile(f))
+              (a, toFile(f))
             })
             .withChecksums(checksums.value.toVector)
             .withOverwrite(isSnapshot.value)
@@ -70,7 +71,7 @@ object SettingsHelper {
             .withArtifacts(packagedArtifacts.value.toVector.map { case (a, f) =>
               val conv0 = fileConverter.value
               implicit val conv: FileConverter = conv0
-              (a, PluginCompat.toFile(f))
+              (a, toFile(f))
             })
             .withChecksums(checksums.value.toVector)
             .withOverwrite(isSnapshot.value)
@@ -82,7 +83,7 @@ object SettingsHelper {
             .withArtifacts(packagedArtifacts.value.toVector.map { case (a, f) =>
               val conv0 = fileConverter.value
               implicit val conv: FileConverter = conv0
-              (a, PluginCompat.toFile(f))
+              (a, toFile(f))
             })
             .withChecksums(checksums.value.toVector)
             .withOverwrite(isSnapshot.value)

--- a/src/main/scala/com/typesafe/sbt/packager/Stager.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Stager.scala
@@ -6,6 +6,7 @@ import sbt.util.CacheStore
 import java.io.File
 
 import com.typesafe.sbt.packager.Compat._
+import sbtcompat.PluginCompat._
 import xsbti.FileConverter
 
 object Stager {
@@ -24,12 +25,12 @@ object Stager {
     */
   def stageFiles(
     config: String
-  )(cacheDirectory: File, stageDirectory: File, mappings: Seq[(PluginCompat.FileRef, String)])(implicit
+  )(cacheDirectory: File, stageDirectory: File, mappings: Seq[(FileRef, String)])(implicit
     conv: FileConverter
   ): File = {
     val cache = cacheDirectory / ("packager-mappings-" + config)
     val copies = mappings map { case (ref, path) =>
-      PluginCompat.toFile(ref) -> (stageDirectory / path)
+      toFile(ref) -> (stageDirectory / path)
     }
     val store = CacheStore(cache)
     Sync.sync(store, FileInfo.hash)(copies)
@@ -48,7 +49,7 @@ object Stager {
     * @see
     *   stageFiles
     */
-  def stage(config: String)(streams: TaskStreams, stageDirectory: File, mappings: Seq[(PluginCompat.FileRef, String)])(
+  def stage(config: String)(streams: TaskStreams, stageDirectory: File, mappings: Seq[(FileRef, String)])(
     implicit conv: FileConverter
   ): File =
     stageFiles(config)(streams.cacheDirectory, stageDirectory, mappings)

--- a/src/main/scala/com/typesafe/sbt/packager/Stager.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/Stager.scala
@@ -23,9 +23,7 @@ object Stager {
     * @param mappings
     *   staging content
     */
-  def stageFiles(
-    config: String
-  )(cacheDirectory: File, stageDirectory: File, mappings: Seq[(FileRef, String)])(implicit
+  def stageFiles(config: String)(cacheDirectory: File, stageDirectory: File, mappings: Seq[(FileRef, String)])(implicit
     conv: FileConverter
   ): File = {
     val cache = cacheDirectory / ("packager-mappings-" + config)
@@ -49,8 +47,8 @@ object Stager {
     * @see
     *   stageFiles
     */
-  def stage(config: String)(streams: TaskStreams, stageDirectory: File, mappings: Seq[(FileRef, String)])(
-    implicit conv: FileConverter
+  def stage(config: String)(streams: TaskStreams, stageDirectory: File, mappings: Seq[(FileRef, String)])(implicit
+    conv: FileConverter
   ): File =
     stageFiles(config)(streams.cacheDirectory, stageDirectory, mappings)
 

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppKeys.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager.archetypes
 
 import sbt.{*, given}
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.FileRef
 
 /**
   * Available settings/tasks for the [[com.typesafe.sbt.packager.archetypes.JavaAppPackaging]] and all depending
@@ -17,10 +18,10 @@ trait JavaAppKeys {
   )
   @transient
   val scriptClasspathOrdering =
-    taskKey[Seq[(PluginCompat.FileRef, String)]]("The order of the classpath used at runtime for the bat/bash scripts.")
+    taskKey[Seq[(FileRef, String)]]("The order of the classpath used at runtime for the bat/bash scripts.")
   @transient
   val projectDependencyArtifacts =
-    taskKey[Seq[Attributed[PluginCompat.FileRef]]]("The set of exported artifacts from our dependent projects.")
+    taskKey[Seq[Attributed[FileRef]]]("The set of exported artifacts from our dependent projects.")
   @transient
   val scriptClasspath = TaskKey[Seq[String]](
     "scriptClasspath",

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
@@ -10,7 +10,7 @@ import com.typesafe.sbt.packager.linux.{LinuxFileMetaData, LinuxPackageMapping}
 import com.typesafe.sbt.packager.linux.LinuxPlugin.autoImport.{defaultLinuxInstallLocation, linuxPackageMappings}
 import com.typesafe.sbt.packager.Compat.*
 import sbtcompat.{PluginCompat => SbtCompat}
-import SbtCompat.{FileRef, toFile, parseModuleIDStrAttribute, parseArtifactStrAttribute, moduleIDToStr, artifactToStr}
+import SbtCompat.{artifactToStr, moduleIDToStr, parseArtifactStrAttribute, parseModuleIDStrAttribute, toFile, FileRef}
 import xsbti.FileConverter
 
 /**

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/JavaAppPackaging.scala
@@ -9,6 +9,8 @@ import com.typesafe.sbt.packager.Keys.packageName
 import com.typesafe.sbt.packager.linux.{LinuxFileMetaData, LinuxPackageMapping}
 import com.typesafe.sbt.packager.linux.LinuxPlugin.autoImport.{defaultLinuxInstallLocation, linuxPackageMappings}
 import com.typesafe.sbt.packager.Compat.*
+import sbtcompat.{PluginCompat => SbtCompat}
+import SbtCompat.{FileRef, toFile, parseModuleIDStrAttribute, parseArtifactStrAttribute, moduleIDToStr, artifactToStr}
 import xsbti.FileConverter
 
 /**
@@ -80,7 +82,7 @@ object JavaAppPackaging extends AutoPlugin {
       bundledJvmLocation := (bundledJvmLocation ?? None).value
     )
 
-  private def makeRelativeClasspathNames(mappings: Seq[(PluginCompat.FileRef, String)]): Seq[String] =
+  private def makeRelativeClasspathNames(mappings: Seq[(FileRef, String)]): Seq[String] =
     for {
       (_, name) <- mappings
     } yield
@@ -108,12 +110,12 @@ object JavaAppPackaging extends AutoPlugin {
 
   // Determines a nicer filename for an attributed jar file, using the
   // ivy metadata if available.
-  private def getJarFullFilename(dep: Attributed[PluginCompat.FileRef]): String = {
+  private def getJarFullFilename(dep: Attributed[FileRef]): String = {
     val filename: Option[String] = for {
-      moduleStr <- dep.metadata.get(PluginCompat.moduleIDStr)
-      artifactStr <- dep.metadata.get(PluginCompat.artifactStr)
-      module = PluginCompat.parseModuleIDStrAttribute(moduleStr)
-      artifact = PluginCompat.parseArtifactStrAttribute(artifactStr)
+      moduleStr <- dep.metadata.get(SbtCompat.moduleIDStr)
+      artifactStr0 <- dep.metadata.get(SbtCompat.artifactStr)
+      module = parseModuleIDStrAttribute(moduleStr)
+      artifact = parseArtifactStrAttribute(artifactStr0)
     } yield makeJarName(module.organization, module.name, module.revision, artifact.name, artifact.classifier)
     filename.getOrElse(PluginCompat.getName(dep.data))
   }
@@ -123,17 +125,17 @@ object JavaAppPackaging extends AutoPlugin {
     build.classpathTransitive.getOrElse(thisProject, Nil)
 
   // TODO - Should we pull in more than just JARs?  How do native packages come in?
-  private def isRuntimeArtifact(dep: Attributed[PluginCompat.FileRef]): Boolean =
+  private def isRuntimeArtifact(dep: Attributed[FileRef]): Boolean =
     dep
-      .get(PluginCompat.artifactStr)
-      .map(PluginCompat.parseArtifactStrAttribute)
+      .get(SbtCompat.artifactStr)
+      .map(parseArtifactStrAttribute)
       .map(_.`type` == "jar")
       .getOrElse {
         val name = PluginCompat.getName(dep.data)
         !(name.endsWith(".jar") || name.endsWith("-sources.jar") || name.endsWith("-javadoc.jar"))
       }
 
-  private def findProjectDependencyArtifacts: Def.Initialize[Task[Seq[Attributed[PluginCompat.FileRef]]]] =
+  private def findProjectDependencyArtifacts: Def.Initialize[Task[Seq[Attributed[FileRef]]]] =
     Def
       .setting {
         val stateTask = state.taskValue
@@ -142,8 +144,8 @@ object JavaAppPackaging extends AutoPlugin {
         val artTasks = refs map { ref =>
           extractArtifacts(stateTask, ref)
         }
-        val allArtifactsTask: Task[Seq[Attributed[PluginCompat.FileRef]]] =
-          artTasks.fold[Task[Seq[Attributed[PluginCompat.FileRef]]]](task(Nil)) { (previous, next) =>
+        val allArtifactsTask: Task[Seq[Attributed[FileRef]]] =
+          artTasks.fold[Task[Seq[Attributed[FileRef]]]](task(Nil)) { (previous, next) =>
             for {
               p <- previous
               n <- next
@@ -152,7 +154,7 @@ object JavaAppPackaging extends AutoPlugin {
         allArtifactsTask
       }
 
-  private def extractArtifacts(stateTask: Task[State], ref: ProjectRef): Task[Seq[Attributed[PluginCompat.FileRef]]] =
+  private def extractArtifacts(stateTask: Task[State], ref: ProjectRef): Task[Seq[Attributed[FileRef]]] =
     stateTask.flatMap { state =>
       val extracted = Project.extract(state)
       // TODO - Is this correct?
@@ -164,25 +166,25 @@ object JavaAppPackaging extends AutoPlugin {
         (art, file) <- arts.toSeq // TODO -Filter!
       } yield Attributed
         .blank(file)
-        .put(PluginCompat.moduleIDStr, PluginCompat.moduleIDToStr(module))
-        .put(PluginCompat.artifactStr, PluginCompat.artifactToStr(art))
+        .put(SbtCompat.moduleIDStr, moduleIDToStr(module))
+        .put(SbtCompat.artifactStr, artifactToStr(art))
     }
 
   private def findRealDep(
-    dep: Attributed[PluginCompat.FileRef],
-    projectArts: Seq[Attributed[PluginCompat.FileRef]],
+    dep: Attributed[FileRef],
+    projectArts: Seq[Attributed[FileRef]],
     conv0: FileConverter
-  ): Option[Attributed[PluginCompat.FileRef]] = {
+  ): Option[Attributed[FileRef]] = {
     implicit val conv: FileConverter = conv0
-    if (PluginCompat.toFile(dep.data).isFile) Some(dep)
+    if (toFile(dep.data).isFile) Some(dep)
     else
       projectArts.find { art =>
         // TODO - Why is the module not showing up for project deps?
         // (art.get(sbt.Keys.moduleID.key) ==  dep.get(sbt.Keys.moduleID.key)) &&
-        (art.get(PluginCompat.artifactStr), dep.get(PluginCompat.artifactStr)) match {
+        (art.get(SbtCompat.artifactStr), dep.get(SbtCompat.artifactStr)) match {
           case (Some(l0), Some(r0)) =>
-            val l = PluginCompat.parseArtifactStrAttribute(l0)
-            val r = PluginCompat.parseArtifactStrAttribute(r0)
+            val l = parseArtifactStrAttribute(l0)
+            val r = parseArtifactStrAttribute(r0)
             // TODO - extra attributes and stuff for comparison?
             // seems to break stuff if we do...
             l.name == r.name && l.classifier == r.classifier
@@ -193,10 +195,10 @@ object JavaAppPackaging extends AutoPlugin {
 
   // Converts a managed classpath into a set of lib mappings.
   private def universalDepMappings(
-    deps: Seq[Attributed[PluginCompat.FileRef]],
-    projectArts: Seq[Attributed[PluginCompat.FileRef]],
+    deps: Seq[Attributed[FileRef]],
+    projectArts: Seq[Attributed[FileRef]],
     conv0: FileConverter
-  ): Seq[(PluginCompat.FileRef, String)] =
+  ): Seq[(FileRef, String)] =
     for {
       dep <- deps
       realDep <- findRealDep(dep, projectArts, conv0)

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/jlink/JlinkPlugin.scala
@@ -9,6 +9,7 @@ import com.typesafe.sbt.SbtNativePackager.{Debian, Universal}
 import com.typesafe.sbt.packager.Keys.{bundledJvmLocation, packageName}
 import com.typesafe.sbt.packager.Compat._
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat._
 import com.typesafe.sbt.packager.archetypes.jlink._
 import com.typesafe.sbt.packager.archetypes.scripts.BashStartScriptKeys
 import com.typesafe.sbt.packager.universal.UniversalPlugin
@@ -59,7 +60,7 @@ object JlinkPlugin extends AutoPlugin {
       val javaHome0 = (jlinkBuildImage / javaHome).value.getOrElse(defaultJavaHome)
       val run = runJavaTool(javaHome0, log) _
       val paths =
-        (jlinkBuildImage / fullClasspath).value.map(PluginCompat.toNioPath).map(_.toString())
+        (jlinkBuildImage / fullClasspath).value.map(toNioPath).map(_.toString())
       val modulePath = (jlinkModules / jlinkModulePath).value
       val shouldIgnore = jlinkIgnoreMissingDependency.value
 
@@ -176,7 +177,7 @@ object JlinkPlugin extends AutoPlugin {
       val prefix0 = if (prefix.isEmpty) prefix else prefix + "/"
 
       findFiles(jlinkBuildImage.value).map { case (file, string) =>
-        val ref = PluginCompat.toFileRef(file)
+        val ref = toFileRef(file)
         (ref, prefix0 + string)
       }
     },

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ApplicationIniGenerator.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/ApplicationIniGenerator.scala
@@ -1,6 +1,7 @@
 package com.typesafe.sbt.packager.archetypes.scripts
 
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.*
 import java.io.File
 
 import sbt.{*, given}
@@ -13,12 +14,12 @@ trait ApplicationIniGenerator {
     *   the existing mappings plus a generated application.ini if custom javaOptions are specified
     */
   def generateApplicationIni(
-    universalMappings: Seq[(PluginCompat.FileRef, String)],
+    universalMappings: Seq[(FileRef, String)],
     javaOptions: Seq[String],
     bashScriptConfigLocation: Option[String],
     tmpDir: File,
     log: Logger
-  )(implicit conv: FileConverter): Seq[(PluginCompat.FileRef, String)] =
+  )(implicit conv: FileConverter): Seq[(FileRef, String)] =
     bashScriptConfigLocation
       .collect {
         case location if javaOptions.nonEmpty =>
@@ -44,7 +45,7 @@ trait ApplicationIniGenerator {
             case _ =>
               true
           }
-          val configFileRef = PluginCompat.toFileRef(configFile)
+          val configFileRef = toFileRef(configFile)
           (configFileRef -> pathMapping) +: filteredMappings
 
       }

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BashStartScriptKeys.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager.archetypes.scripts
 
 import sbt.{*, given}
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.FileRef
 
 /**
   * Keys related to the [[BashStartScriptPlugin]]
@@ -11,7 +12,7 @@ import com.typesafe.sbt.packager.PluginCompat
   */
 trait BashStartScriptKeys {
   @transient
-  val makeBashScripts = taskKey[Seq[(PluginCompat.FileRef, String)]]("Creates start scripts for this project.")
+  val makeBashScripts = taskKey[Seq[(FileRef, String)]]("Creates start scripts for this project.")
   @transient
   val bashScriptTemplateLocation =
     TaskKey[File]("bashScriptTemplateLocation", "The location of the bash script template.")

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptKeys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/BatStartScriptKeys.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager
 package archetypes.scripts
 
 import sbt._
+import sbtcompat.PluginCompat.FileRef
 
 /**
   * Keys related to the [[BatStartScriptPlugin]]
@@ -12,7 +13,7 @@ import sbt._
 trait BatStartScriptKeys {
   @transient
   val makeBatScripts =
-    taskKey[Seq[(PluginCompat.FileRef, String)]]("Creates start scripts for this project.")
+    taskKey[Seq[(FileRef, String)]]("Creates start scripts for this project.")
   @transient
   val batScriptTemplateLocation =
     TaskKey[File]("batScriptTemplateLocation", "The location of the bat script template.")

--- a/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/archetypes/scripts/CommonStartScriptGenerator.scala
@@ -4,6 +4,7 @@ import java.io.File
 import java.net.URL
 
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.archetypes.TemplateWriter
 import sbt.{*, given}
 import xsbti.FileConverter
@@ -71,7 +72,7 @@ trait CommonStartScriptGenerator {
     targetDir: File,
     conv: FileConverter,
     log: sbt.Logger
-  ): Seq[(PluginCompat.FileRef, String)] =
+  ): Seq[(FileRef, String)] =
     StartScriptMainClassConfig.from(mainClass, discoveredMainClasses) match {
       case NoMain =>
         log.warn("You have no main class in your project. No start script will be generated.")
@@ -91,7 +92,7 @@ trait CommonStartScriptGenerator {
     targetDir: File,
     conv: FileConverter,
     log: sbt.Logger
-  ): Seq[(PluginCompat.FileRef, String)] = {
+  ): Seq[(FileRef, String)] = {
     val classAndScriptNames = ScriptUtils.createScriptNames(discoveredMainClasses)
     ScriptUtils.warnOnScriptNameCollision(classAndScriptNames, log)
 
@@ -128,7 +129,7 @@ trait CommonStartScriptGenerator {
     targetDir: File,
     mainClasses: Seq[String],
     conv0: FileConverter
-  ): (PluginCompat.FileRef, String) = {
+  ): (FileRef, String) = {
     implicit val conv: FileConverter = conv0
     val template = resolveTemplate(config.templateLocation)
     val replacements = createReplacementsForMainScript(mainClass, mainClasses, config)
@@ -139,7 +140,7 @@ trait CommonStartScriptGenerator {
     IO.write(script, scriptContent)
     // TODO - Better control over this!
     script.setExecutable(executableBitValue)
-    val scriptRef = PluginCompat.toFileRef(script)
+    val scriptRef = toFileRef(script)
     scriptRef -> s"$scriptTargetFolder/$scriptNameWithSuffix"
   }
 
@@ -154,7 +155,7 @@ trait CommonStartScriptGenerator {
     config: ScriptConfig,
     conv0: FileConverter,
     log: sbt.Logger
-  ): Seq[(PluginCompat.FileRef, String)] = {
+  ): Seq[(FileRef, String)] = {
     implicit val conv: FileConverter = conv0
     val tmp = targetDir / scriptTargetFolder
     val forwarderTemplate =
@@ -170,7 +171,7 @@ trait CommonStartScriptGenerator {
 
       IO.write(file, scriptContent)
       file.setExecutable(executableBitValue)
-      val fileRef = PluginCompat.toFileRef(file)
+      val fileRef = toFileRef(file)
       fileRef -> s"$scriptTargetFolder/$scriptName"
     }
   }

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianNativePackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianNativePackaging.scala
@@ -81,12 +81,9 @@ trait DebianNativePackaging extends DebianPluginLike {
       )
     )
 
-  private[this] def dpkgGenChanges(
-    debFile: FileRef,
-    changelog: Option[File],
-    data: PackageMetaData,
-    targetDir: File
-  )(implicit conv: FileConverter): FileRef = {
+  private[this] def dpkgGenChanges(debFile: FileRef, changelog: Option[File], data: PackageMetaData, targetDir: File)(
+    implicit conv: FileConverter
+  ): FileRef = {
     println(s"Changelog: $changelog")
     changelog match {
       case None =>

--- a/src/main/scala/com/typesafe/sbt/packager/debian/DebianNativePackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/DebianNativePackaging.scala
@@ -5,6 +5,7 @@ import com.typesafe.sbt.SbtNativePackager.Debian
 import com.typesafe.sbt.packager.Keys._
 import com.typesafe.sbt.packager.linux.LinuxFileMetaData
 import com.typesafe.sbt.packager.Compat._
+import sbtcompat.PluginCompat._
 import sbt.Keys.*
 import sbt.{*, given}
 import xsbti.FileConverter
@@ -47,7 +48,7 @@ trait DebianNativePackaging extends DebianPluginLike {
           val conv0 = fileConverter.value
           implicit val conv: FileConverter = conv0
           val deb = packageBin.value
-          val debFile = PluginCompat.toFile(deb)
+          val debFile = toFile(deb)
           val role = debianSignRole.value
           val log = streams.value.log
           sys.process
@@ -62,7 +63,7 @@ trait DebianNativePackaging extends DebianPluginLike {
           val conv0 = fileConverter.value
           implicit val conv: FileConverter = conv0
           val deb = packageBin.value
-          val debFile = PluginCompat.toFile(deb)
+          val debFile = toFile(deb)
           sys.process.Process(Seq("lintian", "-c", "-v", debFile.getName), Some(debFile.getParentFile)).!
         },
         /** Implementation of the actual packaging */
@@ -81,11 +82,11 @@ trait DebianNativePackaging extends DebianPluginLike {
     )
 
   private[this] def dpkgGenChanges(
-    debFile: PluginCompat.FileRef,
+    debFile: FileRef,
     changelog: Option[File],
     data: PackageMetaData,
     targetDir: File
-  )(implicit conv: FileConverter): PluginCompat.FileRef = {
+  )(implicit conv: FileConverter): FileRef = {
     println(s"Changelog: $changelog")
     changelog match {
       case None =>
@@ -95,7 +96,7 @@ trait DebianNativePackaging extends DebianPluginLike {
         val debSrc = targetDir / "../tmp" / Names.DebianSource
         debSrc.mkdirs()
         copyAndFixPerms(chlog, debSrc / Names.Changelog, LinuxFileMetaData("0644"))
-        val debFileFile = PluginCompat.toFile(debFile)
+        val debFileFile = toFile(debFile)
         IO.writeLines(debSrc / Names.Files, List(debFileFile.getName + " " + data.section + " " + data.priority))
         // dpkg-genchanges needs a "source" control file, located in a "debian" directory
         IO.writeLines(debSrc / Names.Control, List(data.makeSourceControl()))
@@ -109,7 +110,7 @@ trait DebianNativePackaging extends DebianPluginLike {
           case e: Exception =>
             throw new RuntimeException("Failure generating changes file.", e)
         }
-        val changesFileRef = PluginCompat.toFileRef(changesFile)
+        val changesFileRef = toFileRef(changesFile)
         changesFileRef
     }
   }
@@ -122,7 +123,7 @@ trait DebianNativePackaging extends DebianPluginLike {
     buildOptions: Seq[String],
     conv0: FileConverter,
     log: Logger
-  ): PluginCompat.FileRef = {
+  ): FileRef = {
     implicit val conv: FileConverter = conv0
     log.info("Building debian package with native implementation")
     // Make the package.  We put this in fakeroot, so we can build the package with root owning files.
@@ -136,7 +137,7 @@ trait DebianNativePackaging extends DebianPluginLike {
         sys.error("Failure packaging debian file.  Exit code: " + x)
     }
     val out = stageDir / ".." / archive
-    PluginCompat.toFileRef(out)
+    toFileRef(out)
   }
 
 }

--- a/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/JDebPackaging.scala
@@ -3,6 +3,7 @@ package debian
 
 import com.typesafe.sbt.packager.Compat.*
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.archetypes.TemplateWriter
 import com.typesafe.sbt.packager.universal.Archives
 import sbt.{*, given}
@@ -87,7 +88,7 @@ object JDebPackaging extends AutoPlugin with DebianPluginLike {
         val debianFile = targetDir.getParentFile / archive
         val debMaker = new JDebPackagingTask()
         debMaker.packageDebian(mappings, symlinks, debianFile, targetDir, fileConverter.value, log)
-        PluginCompat.toFileRef(debianFile)
+        toFileRef(debianFile)
       },
       packageBin := Def.uncached((packageBin dependsOn debianControlFile).value),
       packageBin := Def.uncached((packageBin dependsOn debianConffilesFile).value),

--- a/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/debian/Keys.scala
@@ -3,6 +3,7 @@ package packager
 package debian
 
 import sbt.{*, given}
+import sbtcompat.PluginCompat.FileRef
 import linux.LinuxPackageMapping
 
 /** DEB packaging specific build targets. */
@@ -54,12 +55,12 @@ trait DebianKeys {
   val lintian = TaskKey[Unit]("lintian", "runs the debian lintian tool on the current package.")
   @transient
   val debianSign =
-    taskKey[PluginCompat.FileRef]("runs the dpkg-sig command to sign the generated deb file.")
+    taskKey[FileRef]("runs the dpkg-sig command to sign the generated deb file.")
   val debianSignRole =
     SettingKey[String]("debian-sign-role", "The role to use when signing a debian file (defaults to 'builder').")
   @transient
   val genChanges =
-    taskKey[PluginCompat.FileRef]("runs the dpkg-genchanges command to generate the .changes file.")
+    taskKey[FileRef]("runs the dpkg-genchanges command to generate the .changes file.")
 
   // Debian control scripts
   val debianControlScriptsDirectory = SettingKey[File](

--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -10,6 +10,7 @@ import com.typesafe.sbt.packager.universal.UniversalPlugin.autoImport.stage
 import com.typesafe.sbt.packager.validation._
 import sbt.Keys.*
 import sbt.{*, given}
+import sbtcompat.PluginCompat.*
 
 import java.io.File
 import java.util.UUID
@@ -122,7 +123,7 @@ object DockerPlugin extends AutoPlugin {
       val oldFunction = dockerLayerGrouping.value
 
       // By default we set this to a function that always returns None.
-      val oldPartialFunction = Function.unlift((tuple: (PluginCompat.FileRef, String)) => oldFunction(tuple._2))
+      val oldPartialFunction = Function.unlift((tuple: (FileRef, String)) => oldFunction(tuple._2))
 
       val libDir = dockerBaseDirectory + "/lib/"
       val binDir = dockerBaseDirectory + "/bin/"
@@ -225,7 +226,7 @@ object DockerPlugin extends AutoPlugin {
                   .getOrElse {
                     // We couldn't find a source file for the mapping, so try with a dummy source file,
                     // in case there is an explicitly configured path based layer mapping, eg for a directory.
-                    layerToPath.lift((PluginCompat.toFileRef(new File("/dev/null")), v))
+                    layerToPath.lift((toFileRef(new File("/dev/null")), v))
                   }
                 makeChmod(tpe, Seq(pathInLayer(v, layerId)))
               }
@@ -368,7 +369,7 @@ object DockerPlugin extends AutoPlugin {
         val conv0 = fileConverter.value
         implicit val conv: FileConverter = conv0
         val xs = (Docker / mappings).value
-        val fileMappings = xs.map { case (ref, p) => PluginCompat.toFile(ref) -> p }
+        val fileMappings = xs.map { case (ref, p) => toFile(ref) -> p }
         Seq(
           nonEmptyMappings(fileMappings),
           filesExist(fileMappings),
@@ -646,7 +647,7 @@ object DockerPlugin extends AutoPlugin {
     * uses the `Universal / mappings` to generate the `Docker / mappings`.
     */
   def mapGenericFilesToDocker: Seq[Setting[?]] = {
-    def renameDests(from: Seq[(PluginCompat.FileRef, String)], dest: String) =
+    def renameDests(from: Seq[(FileRef, String)], dest: String) =
       for {
         (f, path) <- from
         pathWithValidSeparator = if (Path.sep == '/') path else path.replace(Path.sep, '/')

--- a/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/Keys.scala
@@ -3,6 +3,7 @@ package packager
 package docker
 
 import sbt._
+import sbtcompat.PluginCompat.FileRef
 
 /**
   * Docker settings
@@ -13,7 +14,7 @@ trait DockerKeys {
   val dockerGenerateConfig = TaskKey[File]("docker-generate-config", "Generates configuration file for Docker.")
   @transient
   val dockerPackageMappings =
-    taskKey[Seq[(PluginCompat.FileRef, String)]]("Generates location mappings for Docker build.")
+    taskKey[Seq[(FileRef, String)]]("Generates location mappings for Docker build.")
 
   val dockerBaseImage =
     SettingKey[String]("dockerBaseImage", "Base image for Dockerfile.")
@@ -71,7 +72,7 @@ private[packager] trait DockerKeysEx extends DockerKeys {
       "Lower index means the file would be a part of an earlier layer."
   )
   @transient
-  val dockerGroupLayers = taskKey[PartialFunction[(PluginCompat.FileRef, String), Int]](
+  val dockerGroupLayers = taskKey[PartialFunction[(FileRef, String), Int]](
     "Group files by mapping into layers to increase docker cache hits. " +
       "Lower index means the file would be a part of an earlier layer."
   )

--- a/src/main/scala/com/typesafe/sbt/packager/docker/LayeredMapping.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/LayeredMapping.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager
 package docker
 
 import java.io.File
+import sbtcompat.PluginCompat.FileRef
 
 /**
   * Mapping of file to intermediate layers.
@@ -15,4 +16,4 @@ import java.io.File
   * @param path
   *   The path in the final image
   */
-case class LayeredMapping(layerId: Option[Int], file: PluginCompat.FileRef, path: String)
+case class LayeredMapping(layerId: Option[Int], file: FileRef, path: String)

--- a/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/graalvmnativeimage/GraalVMNativeImagePlugin.scala
@@ -6,6 +6,7 @@ import java.io.ByteArrayInputStream
 import com.typesafe.sbt.packager.{MappingsHelper, Stager}
 import com.typesafe.sbt.packager.Keys.*
 import com.typesafe.sbt.packager.Compat.*
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
 import com.typesafe.sbt.packager.docker.{Cmd, DockerPlugin, Dockerfile, ExecCmd}
 import com.typesafe.sbt.packager.universal.UniversalPlugin
@@ -79,11 +80,11 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
             binaryName,
             nativeImageCommand,
             className,
-            classpathJars.map(x => PluginCompat.toFile(x._1)),
+            classpathJars.map(x => toFile(x._1)),
             extraOptions,
             UnbufferedProcessLogger(streams.log)
           )
-          PluginCompat.toFileRef(file)
+          toFileRef(file)
 
         case Some(image) =>
           val resourceMappings = MappingsHelper.relative(graalResources, graalResourceDirectories, conv)
@@ -100,7 +101,7 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
             conv,
             streams
           )
-          PluginCompat.toFileRef(file)
+          toFileRef(file)
       }
     }
   )
@@ -140,10 +141,10 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
     targetDirectory: File,
     binaryName: String,
     className: String,
-    classpathJars: Seq[(PluginCompat.FileRef, String)],
+    classpathJars: Seq[(FileRef, String)],
     extraOptions: Seq[String],
     dockerCommand: Seq[String],
-    resources: Seq[(PluginCompat.FileRef, String)],
+    resources: Seq[(FileRef, String)],
     image: String,
     conv0: FileConverter,
     streams: TaskStreams
@@ -223,8 +224,8 @@ object GraalVMNativeImagePlugin extends AutoPlugin {
 
   private def stage(
     targetDirectory: File,
-    classpathJars: Seq[(PluginCompat.FileRef, String)],
-    resources: Seq[(PluginCompat.FileRef, String)],
+    classpathJars: Seq[(FileRef, String)],
+    resources: Seq[(FileRef, String)],
     streams: TaskStreams
   )(implicit conv: FileConverter): File = {
     val stageDir = targetDirectory / "stage"

--- a/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/ClasspathJarPlugin.scala
@@ -7,6 +7,7 @@ import sbt.Package.ManifestAttributes
 import sbt.{*, given}
 import sbt.Keys._
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.FileRef
 import com.typesafe.sbt.packager.Keys._
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
@@ -15,8 +16,8 @@ object ClasspathJarPlugin extends AutoPlugin {
 
   object autoImport {
     @transient
-    val packageJavaClasspathJar: TaskKey[PluginCompat.FileRef] =
-      taskKey[PluginCompat.FileRef]("Creates a Java classpath jar that specifies the classpath in its manifest")
+    val packageJavaClasspathJar: TaskKey[FileRef] =
+      taskKey[FileRef]("Creates a Java classpath jar that specifies the classpath in its manifest")
   }
   import autoImport._
 

--- a/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
@@ -18,9 +18,8 @@ object LauncherJarPlugin extends AutoPlugin {
 
   object autoImport {
     @transient
-    val packageJavaLauncherJar: TaskKey[FileRef] = taskKey[FileRef](
-      "Creates a Java launcher jar that specifies the main class and classpath in its manifest"
-    )
+    val packageJavaLauncherJar: TaskKey[FileRef] =
+      taskKey[FileRef]("Creates a Java launcher jar that specifies the main class and classpath in its manifest")
   }
 
   import autoImport._

--- a/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jar/LauncherJarPlugin.scala
@@ -8,6 +8,7 @@ import sbt.{*, given}
 import sbt.Keys._
 import com.typesafe.sbt.packager.Compat.*
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat._
 import com.typesafe.sbt.packager.Keys._
 import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging
@@ -17,7 +18,7 @@ object LauncherJarPlugin extends AutoPlugin {
 
   object autoImport {
     @transient
-    val packageJavaLauncherJar: TaskKey[PluginCompat.FileRef] = taskKey[PluginCompat.FileRef](
+    val packageJavaLauncherJar: TaskKey[FileRef] = taskKey[FileRef](
       "Creates a Java launcher jar that specifies the main class and classpath in its manifest"
     )
   }
@@ -45,21 +46,21 @@ object LauncherJarPlugin extends AutoPlugin {
       val conv0 = fileConverter.value
       implicit val conv: FileConverter = conv0
       val a = (packageJavaLauncherJar / artifactPath).value
-      Some(s"""-jar "$$lib_dir/${PluginCompat.artifactPathToFile(a).getName}"""")
+      Some(s"""-jar "$$lib_dir/${artifactPathToFile(a).getName}"""")
     },
     bashScriptDefines / scriptClasspath := Nil,
     Compile / batScriptReplacements / mainClass := Def.uncached {
       val conv0 = fileConverter.value
       implicit val conv: FileConverter = conv0
       val a = (packageJavaLauncherJar / artifactPath).value
-      Some(s"""-jar "%APP_LIB_DIR%\\${PluginCompat.artifactPathToFile(a).getName}"""")
+      Some(s"""-jar "%APP_LIB_DIR%\\${artifactPathToFile(a).getName}"""")
     },
     batScriptReplacements / scriptClasspath := Nil,
     Universal / mappings += {
       val javaLauncher = packageJavaLauncherJar.value
       val conv0 = fileConverter.value
       implicit val conv: FileConverter = conv0
-      javaLauncher -> ("lib/" + PluginCompat.toFile(javaLauncher).getName)
+      javaLauncher -> ("lib/" + toFile(javaLauncher).getName)
     }
   )
 }

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerAntHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerAntHelper.scala
@@ -1,6 +1,7 @@
 package com.typesafe.sbt.packager.jdkpackager
 
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.jdkpackager.JDKPackagerPlugin.autoImport._
 import org.apache.tools.ant.{BuildEvent, BuildListener, ProjectHelper}
 import sbt.Keys.*
@@ -137,7 +138,7 @@ object JDKPackagerAntHelper {
   private[jdkpackager] def deployDOM(
     basename: String,
     packageType: String,
-    mainJar: PluginCompat.ArtifactPath,
+    mainJar: ArtifactPath,
     outputDir: File,
     infoDOM: InfoDOM,
     conv0: FileConverter
@@ -163,7 +164,7 @@ object JDKPackagerAntHelper {
         <fx:fileset refid="data.files"/>
       </fx:resources>
 
-      <fx:bundleArgument arg="mainJar" value={"lib/" + PluginCompat.artifactPathToFile(mainJar).getName} />
+      <fx:bundleArgument arg="mainJar" value={"lib/" + artifactPathToFile(mainJar).getName} />
 
     </fx:deploy>
   }
@@ -181,7 +182,7 @@ object JDKPackagerAntHelper {
     antExtraClasspath: Seq[File],
     name: String,
     sourceDir: File,
-    mappings: Seq[(PluginCompat.FileRef, String)],
+    mappings: Seq[(FileRef, String)],
     platformDOM: PlatformDOM,
     applicationDOM: ApplicationDOM,
     deployDOM: DeployDOM
@@ -258,7 +259,7 @@ object JDKPackagerAntHelper {
     target: File,
     conv0: FileConverter,
     s: TaskStreams
-  ): PluginCompat.FileRef = {
+  ): FileRef = {
     import org.apache.tools.ant.{Project => AntProject}
     implicit val conv: FileConverter = conv0
 
@@ -276,7 +277,7 @@ object JDKPackagerAntHelper {
 
     // Not sure what to do when we can't find the result
     val result = findResult(target, s).getOrElse(target)
-    PluginCompat.toFileRef(result)
+    toFileRef(result)
   }
 
   /** For piping Ant messages to sbt logger. */

--- a/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/jdkpackager/JDKPackagerPlugin.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager.jdkpackager
 
 import com.typesafe.sbt.SbtNativePackager
 import com.typesafe.sbt.packager.Compat.*
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.Keys.*
 import com.typesafe.sbt.packager.SettingsHelper
 import com.typesafe.sbt.packager.archetypes.JavaAppPackaging

--- a/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/linux/LinuxPlugin.scala
@@ -7,6 +7,7 @@ import com.typesafe.sbt.SbtNativePackager.Universal
 import com.typesafe.sbt.packager.Keys.*
 import com.typesafe.sbt.packager.universal.UniversalPlugin
 import com.typesafe.sbt.packager.archetypes.TemplateWriter
+import sbtcompat.PluginCompat.*
 import xsbti.FileConverter
 
 /**
@@ -128,7 +129,7 @@ object LinuxPlugin extends AutoPlugin {
         val linuxPackageName = (Linux / packageName).value
         for {
           (file, name) <- (Universal / mappings).value
-          if !PluginCompat.toFile(file).isDirectory
+          if !toFile(file).isDirectory
           if name startsWith "bin/"
           if !(name endsWith ".bat") // IGNORE windows-y things.
         } yield LinuxSymlink("/usr/" + name, installLocation + "/" + linuxPackageName + "/" + name)
@@ -142,7 +143,7 @@ object LinuxPlugin extends AutoPlugin {
         val configLocation = defaultLinuxConfigLocation.value
         val needsConfLink =
           (Universal / mappings).value exists { case (file, destination) =>
-            (destination startsWith "conf/") && !PluginCompat.toFile(file).isDirectory
+            (destination startsWith "conf/") && !toFile(file).isDirectory
           }
         if (needsConfLink)
           Seq(
@@ -257,16 +258,16 @@ object LinuxPlugin extends AutoPlugin {
   private[this] def getUniversalFolderMappings(
     pkg: String,
     installLocation: String,
-    mappings: Seq[(PluginCompat.FileRef, String)],
+    mappings: Seq[(FileRef, String)],
     conv0: FileConverter
   ): Seq[LinuxPackageMapping] = {
     implicit val conv: FileConverter = conv0
     // TODO - More windows filters...
-    def isWindowsFile(f: (PluginCompat.FileRef, String)): Boolean =
+    def isWindowsFile(f: (FileRef, String)): Boolean =
       f._2 endsWith ".bat"
 
     val filtered = mappings.filterNot(isWindowsFile).map { case (x, p) =>
-      (PluginCompat.toFile(x), p)
+      (toFile(x), p)
     }
 
     if (filtered.isEmpty) Seq.empty

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -2,6 +2,7 @@ package com.typesafe.sbt.packager.rpm
 
 import sbt.{*, given}
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.linux.LinuxSymlink
 import com.typesafe.sbt.packager.sourceDateEpoch
 import xsbti.FileConverter
@@ -35,8 +36,8 @@ object RpmHelper {
 
   private[rpm] def defaultRpmArtifactPath(stagingArea: File, meta: RpmMetadata)(implicit
     conv: FileConverter
-  ): PluginCompat.ArtifactPath =
-    PluginCompat.toArtifactPath(
+  ): ArtifactPath =
+    toArtifactPath(
       stagingArea / "RPMS" / meta.arch / s"${meta.name}-${meta.version}-${meta.release}.${meta.arch}.rpm"
     )
 
@@ -54,7 +55,7 @@ object RpmHelper {
     */
   def buildRpm(spec: RpmSpec, stagingArea: File, log: sbt.Logger)(implicit
     conv: FileConverter
-  ): PluginCompat.ArtifactPath = {
+  ): ArtifactPath = {
     buildPackage(stagingArea, spec, log)
     defaultRpmArtifactPath(stagingArea, spec.meta)
   }

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmHelper.scala
@@ -37,9 +37,7 @@ object RpmHelper {
   private[rpm] def defaultRpmArtifactPath(stagingArea: File, meta: RpmMetadata)(implicit
     conv: FileConverter
   ): ArtifactPath =
-    toArtifactPath(
-      stagingArea / "RPMS" / meta.arch / s"${meta.name}-${meta.version}-${meta.release}.${meta.arch}.rpm"
-    )
+    toArtifactPath(stagingArea / "RPMS" / meta.arch / s"${meta.name}-${meta.version}-${meta.release}.${meta.arch}.rpm")
 
   /**
     * Build the rpm package
@@ -53,9 +51,7 @@ object RpmHelper {
     * @return
     *   The rpm package
     */
-  def buildRpm(spec: RpmSpec, stagingArea: File, log: sbt.Logger)(implicit
-    conv: FileConverter
-  ): ArtifactPath = {
+  def buildRpm(spec: RpmSpec, stagingArea: File, log: sbt.Logger)(implicit conv: FileConverter): ArtifactPath = {
     buildPackage(stagingArea, spec, log)
     defaultRpmArtifactPath(stagingArea, spec.meta)
   }

--- a/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/rpm/RpmPlugin.scala
@@ -10,6 +10,7 @@ import com.typesafe.sbt.packager.SettingsHelper
 import com.typesafe.sbt.packager.Keys.*
 import com.typesafe.sbt.packager.linux.*
 import com.typesafe.sbt.packager.Compat.*
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.validation.*
 import xsbti.FileConverter
 
@@ -187,17 +188,17 @@ object RpmPlugin extends AutoPlugin {
       // `file` points to where buildRpm created the rpm. However we want it to be at `artifactPath`.
       // If `artifactPath` is not the default value then we need to copy the file.
       val path = (Rpm / packageBin / artifactPath).value
-      val defaultPathFile = PluginCompat.artifactPathToFile(defaultPath)
-      val pathFile = PluginCompat.artifactPathToFile(path)
+      val defaultPathFile = artifactPathToFile(defaultPath)
+      val pathFile = artifactPathToFile(path)
       if (pathFile.getCanonicalFile != defaultPathFile.getCanonicalFile)
         IO.copyFile(defaultPathFile, pathFile)
-      PluginCompat.toFileRef(pathFile)
+      toFileRef(pathFile)
     },
     rpmLint := {
       val conv0 = fileConverter.value
       implicit val conv: FileConverter = conv0
       val pkg = (Rpm / packageBin).value
-      val path = PluginCompat.toNioPath(pkg)
+      val path = toNioPath(pkg)
       sys.process.Process(Seq("rpmlint", "-v", path.toAbsolutePath().toString())).!(streams.value.log) match {
         case 0 => ()
         case x => sys.error("Failed to run rpmlint, exit status: " + x)

--- a/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/Keys.scala
@@ -3,24 +3,25 @@ package packager
 package universal
 
 import sbt._
+import sbtcompat.PluginCompat.FileRef
 
 trait UniversalKeys {
   @transient
   val packageZipTarball =
-    taskKey[PluginCompat.FileRef]("Creates a tgz package.")
+    taskKey[FileRef]("Creates a tgz package.")
   @transient
   val packageXzTarball =
-    taskKey[PluginCompat.FileRef]("Creates a txz package.")
+    taskKey[FileRef]("Creates a txz package.")
   @transient
   val packageOsxDmg =
-    taskKey[PluginCompat.FileRef]("Creates a dmg package for macOS (only on macOS).")
+    taskKey[FileRef]("Creates a dmg package for macOS (only on macOS).")
   @transient
   val stage = TaskKey[File](
     "stage",
     "Create a local directory with all the files laid out as they would be in the final distribution."
   )
   @transient
-  val dist = taskKey[PluginCompat.FileRef]("Creates the distribution packages.")
+  val dist = taskKey[FileRef]("Creates the distribution packages.")
   val stagingDirectory = SettingKey[File]("stagingDirectory", "Directory where we stage distributions/releases.")
   val topLevelDirectory = SettingKey[Option[String]]("topLevelDirectory", "Top level dir in compressed output file.")
   val universalArchiveOptions =

--- a/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/universal/UniversalPlugin.scala
@@ -6,6 +6,7 @@ import sbt.Keys.*
 import Archives.*
 import com.typesafe.sbt.SbtNativePackager
 import com.typesafe.sbt.packager.Compat.*
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.Keys.*
 import com.typesafe.sbt.packager.docker.DockerPlugin
 import com.typesafe.sbt.packager.validation._
@@ -112,7 +113,7 @@ object UniversalPlugin extends AutoPlugin {
       UniversalSrc / packageXzTarball / universalArchiveOptions := Seq("-pcvf")
     )
 
-  private[this] def printDist(dist: PluginCompat.FileRef, streams: TaskStreams): PluginCompat.FileRef = {
+  private[this] def printDist(dist: FileRef, streams: TaskStreams): FileRef = {
     streams.log.info("")
     streams.log.info("Your package is ready in " + dist.toString())
     streams.log.info("")
@@ -123,7 +124,7 @@ object UniversalPlugin extends AutoPlugin {
     (File, String, Seq[(File, String)], Option[String], Seq[String]) => File
 
   /** Creates packaging settings for a given package key, configuration + archive type. */
-  private[this] def makePackageSettings(packageKey: TaskKey[PluginCompat.FileRef], config: Configuration)(
+  private[this] def makePackageSettings(packageKey: TaskKey[FileRef], config: Configuration)(
     packager: Packager
   ): Seq[Setting[?]] =
     inConfig(config)(
@@ -134,7 +135,7 @@ object UniversalPlugin extends AutoPlugin {
           val conv0 = fileConverter.value
           implicit val conv: FileConverter = conv0
           val xs = (packageKey / mappings).value
-          val fileMappings = xs.map { case (ref, p) => PluginCompat.toFile(ref) -> p }
+          val fileMappings = xs.map { case (ref, p) => toFile(ref) -> p }
           val file = packager(
             target.value,
             packageName.value,
@@ -142,13 +143,13 @@ object UniversalPlugin extends AutoPlugin {
             topLevelDirectory.value,
             (packageKey / universalArchiveOptions).value
           )
-          PluginCompat.toFileRef(file)
+          toFileRef(file)
         },
         packageKey / validatePackageValidators := {
           val conv0 = fileConverter.value
           implicit val conv: FileConverter = conv0
           val xs = (packageKey / mappings).value
-          val fileMappings = xs.map { case (ref, p) => PluginCompat.toFile(ref) -> p }
+          val fileMappings = xs.map { case (ref, p) => toFile(ref) -> p }
           (config / validatePackageValidators).value ++ Seq(
             nonEmptyMappings(fileMappings),
             filesExist(fileMappings),
@@ -162,10 +163,10 @@ object UniversalPlugin extends AutoPlugin {
     )
 
   /** Finds all sources in a source directory. */
-  private[this] def findSources(sourceDir: File, conv0: FileConverter): Seq[(PluginCompat.FileRef, String)] = {
+  private[this] def findSources(sourceDir: File, conv0: FileConverter): Seq[(FileRef, String)] = {
     implicit val conv: FileConverter = conv0
     ((PathFinder(sourceDir) ** AllPassFilter) --- sourceDir).pair(file => IO.relativize(sourceDir, file)).map {
-      case (f, p) => PluginCompat.toFileRef(f) -> p
+      case (f, p) => toFileRef(f) -> p
     }
   }
 

--- a/src/main/scala/com/typesafe/sbt/packager/windows/WindowsPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/windows/WindowsPlugin.scala
@@ -7,6 +7,7 @@ import com.typesafe.sbt.packager.Keys.{maintainer, packageDescription, packageNa
 import com.typesafe.sbt.packager.universal.UniversalPlugin
 import com.typesafe.sbt.packager.Compat.*
 import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat.*
 import com.typesafe.sbt.packager.SettingsHelper
 
 import com.typesafe.sbt.packager.sourceDateEpoch
@@ -111,7 +112,7 @@ object WindowsPlugin extends AutoPlugin {
         src.getAbsolutePath != dest.getAbsolutePath
       }
       IO.copy(wsxCopyPairs)
-      IO.copy(for ((f, to) <- mappings.value) yield (PluginCompat.toFile(f), target.value / to))
+      IO.copy(for ((f, to) <- mappings.value) yield (toFile(f), target.value / to))
 
       // Now compile WIX
       val candleCmd = findWixExecutable("candle") +:
@@ -141,7 +142,7 @@ object WindowsPlugin extends AutoPlugin {
         case 0        => ()
         case exitCode => sys.error(s"Unable to run build msi. Exited with ${exitCode}")
       }
-      PluginCompat.toFileRef(msi)
+      toFileRef(msi)
     }))
 
   /**
@@ -167,7 +168,7 @@ object WindowsPlugin extends AutoPlugin {
     * @return
     *   windows features
     */
-  def makeWindowsFeatures(name: String, mappings: Seq[(PluginCompat.FileRef, String)])(implicit
+  def makeWindowsFeatures(name: String, mappings: Seq[(FileRef, String)])(implicit
     conv: FileConverter
   ): Seq[WindowsFeature] = {
     // TODO select main script!  Filter Config links!
@@ -175,7 +176,7 @@ object WindowsPlugin extends AutoPlugin {
     val files =
       for {
         (ref, name) <- mappings
-        file = PluginCompat.toFile(ref)
+        file = toFile(ref)
         if !file.isDirectory
       } yield ComponentFile(name, editable = name startsWith "conf")
     val corePackage =
@@ -197,7 +198,7 @@ object WindowsPlugin extends AutoPlugin {
       )
     val configLinks = for {
       (ref, name) <- mappings
-      file = PluginCompat.toFile(ref)
+      file = toFile(ref)
       if !file.isDirectory
       if name startsWith "conf/"
     } yield name.replaceAll("//", "/").stripSuffix("/").stripSuffix("/")

--- a/src/sbt-test/docker/build-command/build.sbt
+++ b/src/sbt-test/docker/build-command/build.sbt
@@ -1,5 +1,5 @@
 import xsbti.FileConverter
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import NativePackagerHelper._
 
 enablePlugins(JavaAppPackaging)

--- a/src/sbt-test/docker/build-command/project/plugins.sbt
+++ b/src/sbt-test/docker/build-command/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/docker/test-layer-groups/build.sbt
+++ b/src/sbt-test/docker/test-layer-groups/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Keys.stagingDirectory
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaAppPackaging)

--- a/src/sbt-test/docker/test-layer-groups/project/plugins.sbt
+++ b/src/sbt-test/docker/test-layer-groups/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/jdkpackager/test-package-mappings/build.sbt
+++ b/src/sbt-test/jdkpackager/test-package-mappings/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 
 import NativePackagerHelper._
 import xsbti.FileConverter

--- a/src/sbt-test/jdkpackager/test-package-mappings/project/plugins.sbt
+++ b/src/sbt-test/jdkpackager/test-package-mappings/project/plugins.sbt
@@ -6,3 +6,4 @@
   else
     addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
 }
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/jlink/test-jlink-minimal/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-minimal/build.sbt
@@ -3,7 +3,7 @@
 import scala.sys.process.Process
 import com.typesafe.sbt.packager.Keys.stagingDirectory
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JlinkPlugin, ClasspathJarPlugin, BashStartScriptPlugin, BatStartScriptPlugin)

--- a/src/sbt-test/jlink/test-jlink-minimal/project/plugins.sbt
+++ b/src/sbt-test/jlink/test-jlink-minimal/project/plugins.sbt
@@ -6,3 +6,4 @@
   else
     addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
 }
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/jlink/test-jlink-misc/build.sbt
+++ b/src/sbt-test/jlink/test-jlink-misc/build.sbt
@@ -3,7 +3,7 @@
 
 import scala.sys.process.Process
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 val runChecks = taskKey[Unit]("Run checks for a specific issue")

--- a/src/sbt-test/jlink/test-jlink-misc/project/plugins.sbt
+++ b/src/sbt-test/jlink/test-jlink-misc/project/plugins.sbt
@@ -6,3 +6,4 @@
   else
     addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
 }
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/config-no-replace/build.sbt
+++ b/src/sbt-test/rpm/config-no-replace/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(RpmPlugin)

--- a/src/sbt-test/rpm/config-no-replace/project/plugins.sbt
+++ b/src/sbt-test/rpm/config-no-replace/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/override-start-script-systemd/build.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemd/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemdPlugin)

--- a/src/sbt-test/rpm/override-start-script-systemd/project/plugins.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemd/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/override-start-script-systemv/build.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemv/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemVPlugin)

--- a/src/sbt-test/rpm/override-start-script-systemv/project/plugins.sbt
+++ b/src/sbt-test/rpm/override-start-script-systemv/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/override-start-script-upstart/build.sbt
+++ b/src/sbt-test/rpm/override-start-script-upstart/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, UpstartPlugin)

--- a/src/sbt-test/rpm/override-start-script-upstart/project/plugins.sbt
+++ b/src/sbt-test/rpm/override-start-script-upstart/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/path-override-rpm/build.sbt
+++ b/src/sbt-test/rpm/path-override-rpm/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemVPlugin)

--- a/src/sbt-test/rpm/path-override-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/path-override-rpm/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/scriptlets-override-rpm/build.sbt
+++ b/src/sbt-test/rpm/scriptlets-override-rpm/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemVPlugin)

--- a/src/sbt-test/rpm/scriptlets-override-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/scriptlets-override-rpm/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/snapshot-override-rpm/build.sbt
+++ b/src/sbt-test/rpm/snapshot-override-rpm/build.sbt
@@ -1,4 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
+import sbtcompat.PluginCompat._
 
 enablePlugins(RpmPlugin)
 

--- a/src/sbt-test/rpm/snapshot-override-rpm/test
+++ b/src/sbt-test/rpm/snapshot-override-rpm/test
@@ -1,3 +1,6 @@
+# Workaround: set target folder to what it was in sbt 1.x because with sbt 2.x and project matrix target is target/out/jvm/scala-3.3.3/
+> set target := baseDirectory.value / "target"
+
 # Run the debian packaging.
 > Rpm/packageBin
 $ exists target/**/rpm/RPMS/noarch/rpm-test-1-SNAPSHOT.noarch.rpm

--- a/src/sbt-test/rpm/snapshot-override-rpm/test
+++ b/src/sbt-test/rpm/snapshot-override-rpm/test
@@ -1,6 +1,3 @@
-# Workaround: set target folder to what it was in sbt 1.x because with sbt 2.x and project matrix target is target/out/jvm/scala-3.3.3/
-> set target := baseDirectory.value / "target"
-
 # Run the debian packaging.
 > Rpm/packageBin
 $ exists target/**/rpm/RPMS/noarch/rpm-test-1-SNAPSHOT.noarch.rpm

--- a/src/sbt-test/rpm/snapshot-rpm/build.sbt
+++ b/src/sbt-test/rpm/snapshot-rpm/build.sbt
@@ -1,4 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
+import sbtcompat.PluginCompat._
 
 enablePlugins(RpmPlugin)
 

--- a/src/sbt-test/rpm/snapshot-rpm/test
+++ b/src/sbt-test/rpm/snapshot-rpm/test
@@ -1,6 +1,3 @@
-# Workaround: set target folder to what it was in sbt 1.x because with sbt 2.x and project matrix target is target/out/jvm/scala-3.3.3/
-> set target := baseDirectory.value / "target"
-
 # Run the debian packaging.
 > Rpm/packageBin
 $ exists target/**/rpm/RPMS/noarch/rpm-test-0.1.0-SNAPSHOT.noarch.rpm

--- a/src/sbt-test/rpm/snapshot-rpm/test
+++ b/src/sbt-test/rpm/snapshot-rpm/test
@@ -1,3 +1,6 @@
+# Workaround: set target folder to what it was in sbt 1.x because with sbt 2.x and project matrix target is target/out/jvm/scala-3.3.3/
+> set target := baseDirectory.value / "target"
+
 # Run the debian packaging.
 > Rpm/packageBin
 $ exists target/**/rpm/RPMS/noarch/rpm-test-0.1.0-SNAPSHOT.noarch.rpm

--- a/src/sbt-test/rpm/systemd-rpm/build.sbt
+++ b/src/sbt-test/rpm/systemd-rpm/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemdPlugin)

--- a/src/sbt-test/rpm/systemd-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/systemd-rpm/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/sysvinit-rpm/build.sbt
+++ b/src/sbt-test/rpm/sysvinit-rpm/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemVPlugin)

--- a/src/sbt-test/rpm/sysvinit-rpm/project/plugins.sbt
+++ b/src/sbt-test/rpm/sysvinit-rpm/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/test-artifactPath/build.sbt
+++ b/src/sbt-test/rpm/test-artifactPath/build.sbt
@@ -1,4 +1,4 @@
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemVPlugin)

--- a/src/sbt-test/rpm/test-artifactPath/project/plugins.sbt
+++ b/src/sbt-test/rpm/test-artifactPath/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/rpm/test-executableScriptName/build.sbt
+++ b/src/sbt-test/rpm/test-executableScriptName/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaServerAppPackaging, SystemVPlugin)

--- a/src/sbt-test/rpm/test-executableScriptName/project/plugins.sbt
+++ b/src/sbt-test/rpm/test-executableScriptName/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/universal/multiproject-classifiers/build.sbt
+++ b/src/sbt-test/universal/multiproject-classifiers/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 lazy val appVersion = "1.0"

--- a/src/sbt-test/universal/multiproject-classifiers/project/plugins.sbt
+++ b/src/sbt-test/universal/multiproject-classifiers/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/universal/staging-custom-main/build.sbt
+++ b/src/sbt-test/universal/staging-custom-main/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaAppPackaging)

--- a/src/sbt-test/universal/staging-custom-main/project/plugins.sbt
+++ b/src/sbt-test/universal/staging-custom-main/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/universal/test-executableScriptName/build.sbt
+++ b/src/sbt-test/universal/test-executableScriptName/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 import xsbti.FileConverter
 
 enablePlugins(JavaAppPackaging)

--- a/src/sbt-test/universal/test-executableScriptName/project/plugins.sbt
+++ b/src/sbt-test/universal/test-executableScriptName/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")

--- a/src/sbt-test/universal/test-mapping-helpers/build.sbt
+++ b/src/sbt-test/universal/test-mapping-helpers/build.sbt
@@ -1,5 +1,5 @@
 import com.typesafe.sbt.packager.Compat._
-import com.typesafe.sbt.packager.PluginCompat
+import sbtcompat.PluginCompat
 
 import com.typesafe.sbt.packager.MappingsHelper._
 import xsbti.FileConverter

--- a/src/sbt-test/universal/test-mapping-helpers/project/plugins.sbt
+++ b/src/sbt-test/universal/test-mapping-helpers/project/plugins.sbt
@@ -1,1 +1,2 @@
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % sys.props("project.version"))
+addSbtPlugin("com.github.sbt" % "sbt2-compat" % "0.1.0")


### PR DESCRIPTION
This PR attempts to shrink the existing compat layer between sbt 1 and 2 by using [sbt2-compat plugin](https://github.com/anatoliykmetyuk/sbt2-compat).

Status: CI is failing due to the sbt2-compat plugin not being published yet.

TODO:

- [x] Publish the compat plugin to Maven
- [x] Update this PR to use the published version (currently uses a local SNAPSHOT)