### PR TITLE
Log docker commands on info instead of debug

### DIFF
--- a/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
+++ b/src/main/scala/com/typesafe/sbt/packager/docker/DockerPlugin.scala
@@ -708,7 +708,7 @@ object DockerPlugin extends AutoPlugin {
     buildkitEnabled: Boolean,
     log: Logger
   ): Unit = {
-    log.debug("Executing Native " + buildCommand.mkString(" "))
+    log.info("Executing Native " + buildCommand.mkString(" "))
     log.debug("Working directory " + context.toString)
 
     val logger = if (buildkitEnabled) publishLocalBuildkitLogger(log) else publishLocalLogger(log)


### PR DESCRIPTION
I had an issue where I was using the wrong key to add a docker flag, I spent a while derping around before I found out the full command was output on `debug`.

It's very minor change, but I thought the docker command might be important enough to make logging it on `info` ok and thus hopefully make such issues more visible.

Thanks